### PR TITLE
(#11): Small changes to jest configuration

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -8,12 +8,32 @@ module.exports = {
     },
   },
   jest: {
-    configure: config => {
-      config.moduleNameMapper['@hawtio/(.*)'] = '<rootDir>/src/hawtio/$1'
-      config.transformIgnorePatterns = [
+    configure: {
+      // Automatically clear mock calls and instances between every test
+      clearMocks: true,
+
+      moduleDirectories: [
+        "<rootDir>/node_modules/",
+        "<rootDir>/src/hawtio/test/"
+      ],
+
+      moduleNameMapper: {
+        ['@hawtio/(.*)']: '<rootDir>/src/hawtio/$1',
+        'react-markdown': '<rootDir>/node_modules/react-markdown/react-markdown.min.js'
+      },
+
+      // The path to a module that runs some code to configure or set up the testing framework before each test
+      setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
+
+      testPathIgnorePatterns: [
+        "<rootDir>/node_modules/",
+        "<rootDir>/src/hawtio/test/"
+      ],
+
+      transformIgnorePatterns: [
         "node_modules/(?!@patternfly/react-icons/dist/esm/icons)/"
-      ]
-      return config
+      ],
+
     }
   },
   devServer: {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "craco start",
     "build": "craco build",
     "test": "craco test",
+    "test:coverage": "yarn run test --coverage src/**/*.ts",
     "lint": "yarn eslint src/",
     "deploy": "yarn build && cp build/index.html build/200.html && surge build/ hawtio-next.surge.sh"
   },

--- a/src/hawtio/help/registry.test.ts
+++ b/src/hawtio/help/registry.test.ts
@@ -1,14 +1,25 @@
-import { jest } from '@jest/globals'
 import { helpRegistry } from './registry'
+import * as support from '@hawtio/test/support'
+
+let realFetch: typeof global.fetch;
 
 describe('helpRegistry', () => {
-  beforeEach(() => helpRegistry.reset())
+  beforeEach(() => {
+    helpRegistry.reset();
+    realFetch = global.fetch;
+  })
+
+  afterEach(() => {
+    global.fetch = realFetch;
+  })
 
   test('add a help', async () => {
-    global.fetch = jest.fn(() => Promise.resolve(new Response(`
+
+    const payload = `
       # Help Test
       Test help content.
-    `)))
+    `;
+    support.mockFetch(payload)
 
     expect(helpRegistry).not.toBeNull()
     expect(helpRegistry.getHelps()).toEqual([])
@@ -27,7 +38,7 @@ describe('helpRegistry', () => {
   })
 
   test('return helps in order', async () => {
-    global.fetch = jest.fn(() => Promise.resolve(new Response('')))
+    support.mockFetch('')
 
     expect(helpRegistry).not.toBeNull()
     expect(helpRegistry.getHelps()).toEqual([])

--- a/src/hawtio/test/support.ts
+++ b/src/hawtio/test/support.ts
@@ -1,0 +1,5 @@
+
+export function mockFetch(payload: string) {
+  const mockedFetch = jest.fn(() => Promise.resolve(new Response(payload)))
+  global.fetch = mockedFetch;
+}


### PR DESCRIPTION
* craco.config.js
 * Removes need for config parameter
 * Adds src/hawtio/test module to directories
 * Adds moduleNameMapper for react-markdown which was throwing an error on use of "export" token"

* package.json
 * Adds script for test coverage

* **/.ts
 * Adds support module for testing. Include any functions required by number of tests
 * Moves the mocking of global.fetch to its own function and adds handling for replacing with any default after tests are completed