### PR TITLE
chore: mandate the minimum version of yarn to use for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,22 @@ You need to have installed the following tools before developing the project.
 - [Node.js >= 16](https://nodejs.org/en/)
 - [Yarn v3](https://yarnpkg.com/getting-started/install)
 
+#### Minimum Version of Yarn is 3.3.1
+The default installation version of yarn on many operating systems is *1.22-19* (the classic version). This causes a problem as the development app downloads the `@hawtio/react` package rather than using
+the project directory. As a result, the mandated minimum version has been set to *3.3.1*.
+
+If `yarn install` is attempted with a version lower than *3.3.1* then an error message is displayed, eg.
+> $ /usr/bin/yarn install
+> yarn install v1.22.19
+> [1/5] Validating package.json...
+> error @hawtio/next-root@0.0.0: The engine "yarn" is incompatible with this module. Expected version ">=3.3.1". Got "1.22.19"
+> error Found incompatible module.
+
+To upgrade such a version to 3.3.1, use yarn's own `set-version` command:
+> yarn set version 3.3.1
+
+This will download the 3.3.1 internals to `hawtio-next/.yarn` which are then deferred to by the installed yarn binary.
+
 ### Developing
 
 After checking out the project, run the following command to set up the project dependencies.

--- a/app/package.json
+++ b/app/package.json
@@ -31,5 +31,8 @@
       "last 1 safari version"
     ]
   },
-  "packageManager": "yarn@3.3.1"
+  "packageManager": "yarn@3.3.1",
+  "engines": {
+    "yarn": ">=3.3.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
       "path": "cz-conventional-changelog"
     }
   },
-  "packageManager": "yarn@3.3.1"
+  "packageManager": "yarn@3.3.1",
+  "engines": {
+    "yarn": ">=3.3.1"
+  }
 }


### PR DESCRIPTION
* Default installed versions of yarn (1.22-19) do not understand to use the local package directory. They prefer to install published package from npm. This causes issues if the development is futher forward than the published @hawtio/react package.

* package.json
 * Mandate a minimum version of yarn 3.3.1. If lower than this is installed then yarn will display an error message.

* README.md
 * Provides information in the event that the installed version of yarn does not meet the minimum.