### PR TITLE
feat: React router migration

### DIFF
--- a/packages/hawtio/package.json
+++ b/packages/hawtio/package.json
@@ -47,7 +47,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^8.0.5",
-    "react-router-dom": "^5.3.4",
+    "react-router-dom": "^6.8.0",
     "react-split": "^2.0.14",
     "superstruct": "^1.0.3",
     "typescript": "^4.9.5"

--- a/packages/hawtio/src/help/HawtioHelp.tsx
+++ b/packages/hawtio/src/help/HawtioHelp.tsx
@@ -1,7 +1,7 @@
 import { Card, CardBody, Nav, NavItem, NavList, PageGroup, PageNavigation, PageSection, PageSectionVariants, TextContent, Title } from '@patternfly/react-core'
 import React from 'react'
 import Markdown from 'react-markdown'
-import { NavLink, Redirect, Route, Switch, useLocation } from 'react-router-dom'
+import { NavLink, Navigate, Route, Routes, useLocation } from 'react-router-dom'
 import help from './help.md'
 import { helpRegistry } from './registry'
 
@@ -9,7 +9,6 @@ helpRegistry.add('home', 'Home', help, 1)
 
 export const HawtioHelp: React.FunctionComponent = () => {
   const location = useLocation()
-  const path = (id: string) => `/help/${id}`
   return (
     <React.Fragment>
       <PageSection variant={PageSectionVariants.light}>
@@ -20,8 +19,8 @@ export const HawtioHelp: React.FunctionComponent = () => {
           <Nav aria-label="Nav" variant="tertiary">
             <NavList>
               {helpRegistry.getHelps().map(help =>
-                <NavItem key={help.id} isActive={location.pathname === path(help.id)}>
-                  <NavLink to={path(help.id)}>{help.title}</NavLink>
+                <NavItem key={help.id} isActive={location.pathname === help.id}>
+                  <NavLink to={help.id}>{help.title}</NavLink>
                 </NavItem>
               )}
             </NavList>
@@ -30,19 +29,18 @@ export const HawtioHelp: React.FunctionComponent = () => {
       </PageGroup>
       <PageSection>
         <Card isFullHeight>
-          <Switch>
+          <Routes>
             {helpRegistry.getHelps().map(help =>
-              <Route key={help.id} path={path(help.id)}>
+              <Route key={help.id} path={help.id} element={
                 <CardBody>
                   <TextContent>
                     <Markdown>{help.content}</Markdown>
                   </TextContent>
-                </CardBody>
-              </Route>
-            )}
-            <Redirect exact from='/help' to={path('home')} />
-          </Switch>
-        </Card >
+                </CardBody>}
+              />)}
+           <Route path='/' element={<Navigate to='home' />} />
+          </Routes>
+        </Card>
       </PageSection>
     </React.Fragment>
   )

--- a/packages/hawtio/src/plugins/connect/index.ts
+++ b/packages/hawtio/src/plugins/connect/index.ts
@@ -10,7 +10,7 @@ export const connect = () => {
   hawtio.addPlugin({
     id: 'connect',
     title: 'Connect',
-    path: '/connect',
+    path: 'connect',
     component: Connect,
     isActive,
   })

--- a/packages/hawtio/src/plugins/jmx/JmxContent.tsx
+++ b/packages/hawtio/src/plugins/jmx/JmxContent.tsx
@@ -2,7 +2,7 @@ import { Card, CardBody, EmptyState, EmptyStateIcon, EmptyStateVariant, Nav, Nav
 import { CubesIcon, InfoCircleIcon } from '@patternfly/react-icons'
 import { OnRowClick, Table, TableBody, TableHeader, TableProps } from '@patternfly/react-table'
 import React, { useContext } from 'react'
-import { NavLink, Route, useLocation } from 'react-router-dom'
+import { NavLink,Navigate, Route, Routes, useLocation } from 'react-router-dom'
 import { Attributes } from './attributes/Attributes'
 import { Chart } from './chart/Chart'
 import { MBeanTreeContext } from './context'
@@ -23,8 +23,6 @@ export const JmxContent: React.FunctionComponent = () => {
     )
   }
 
-  const path = (id: string) => `/jmx/${id}`
-
   const navItems = [
     { id: 'attributes', title: 'Attributes', component: Attributes },
     { id: 'operations', title: 'Operations', component: Operations },
@@ -35,8 +33,8 @@ export const JmxContent: React.FunctionComponent = () => {
     <Nav aria-label="MBean Nav" variant="tertiary">
       <NavList>
         {navItems.map(nav =>
-          <NavItem key={nav.id} isActive={pathname === path(nav.id)}>
-            <NavLink to={{ pathname: path(nav.id), search }}>{nav.title}</NavLink>
+          <NavItem key={nav.id} isActive={pathname ===nav.id}>
+            <NavLink to={{ pathname: nav.id, search }}>{nav.title}</NavLink>
           </NavItem>
         )}
       </NavList>
@@ -44,7 +42,7 @@ export const JmxContent: React.FunctionComponent = () => {
   )
 
   const mbeanRoutes = navItems.map(nav =>
-    <Route key={nav.id} path={path(nav.id)} component={nav.component} />
+    <Route key={nav.id} path={nav.id} element={React.createElement(nav.component)} />
   )
 
   return (
@@ -63,8 +61,10 @@ export const JmxContent: React.FunctionComponent = () => {
       <PageSection>
         {node.objectName &&
           <React.Fragment>
-            {mbeanRoutes}
-            <Route key='root' exact path='/jmx' component={Attributes} />
+            <Routes>
+              {mbeanRoutes}
+              <Route key="root" path="/" element={<Navigate to={"attributes"}/>}/>
+            </Routes>
           </React.Fragment>
         }
         {!node.objectName &&

--- a/packages/hawtio/src/plugins/jmx/index.ts
+++ b/packages/hawtio/src/plugins/jmx/index.ts
@@ -8,7 +8,7 @@ export const jmx = () => {
   hawtio.addPlugin({
     id: 'jmx',
     title: 'JMX',
-    path: '/jmx',
+    path: 'jmx',
     component: Jmx,
     isActive: async () => workspace.hasMBeans(),
   })

--- a/packages/hawtio/src/preferences/HawtioPreferences.tsx
+++ b/packages/hawtio/src/preferences/HawtioPreferences.tsx
@@ -2,7 +2,7 @@
 import { helpRegistry } from '@hawtio/help/registry'
 import { Card, Nav, NavItem, NavList, PageGroup, PageNavigation, PageSection, PageSectionVariants, Title } from '@patternfly/react-core'
 import React from 'react'
-import { NavLink, Redirect, Route, Switch, useLocation } from 'react-router-dom'
+import { NavLink,Navigate, Route, Routes, useLocation } from 'react-router-dom'
 import help from './help.md'
 import { HomePreferences } from './HomePreferences'
 import { LogsPreferences } from './LogsPreferences'
@@ -14,7 +14,6 @@ preferencesRegistry.add('logs', 'Logs', LogsPreferences, 2)
 
 export const HawtioPreferences: React.FunctionComponent = () => {
   const location = useLocation()
-  const path = (id: string) => `/preferences/${id}`
   return (
     <React.Fragment>
       <PageSection variant={PageSectionVariants.light}>
@@ -25,8 +24,8 @@ export const HawtioPreferences: React.FunctionComponent = () => {
           <Nav aria-label="Nav" variant="tertiary">
             <NavList>
               {preferencesRegistry.getPreferences().map(prefs =>
-                <NavItem key={prefs.id} isActive={location.pathname === path(prefs.id)}>
-                  <NavLink to={path(prefs.id)}>{prefs.title}</NavLink>
+                <NavItem key={prefs.id} isActive={location.pathname === prefs.id}>
+                  <NavLink to={prefs.id}>{prefs.title}</NavLink>
                 </NavItem>
               )}
             </NavList>
@@ -35,15 +34,15 @@ export const HawtioPreferences: React.FunctionComponent = () => {
       </PageGroup>
       <PageSection>
         <Card isFullHeight>
-          <Switch>
+          <Routes>
             {preferencesRegistry.getPreferences().map(prefs => (
               <Route
                 key={prefs.id}
-                path={path(prefs.id)}
-                component={prefs.component} />
+                path={prefs.id}
+                element={React.createElement(prefs.component)} />
             ))}
-            <Redirect exact from='/preferences' to={path('home')} />
-          </Switch>
+            <Route path="/" element={<Navigate to={'home'}/>}/>
+          </Routes>
         </Card >
       </PageSection>
     </React.Fragment>

--- a/packages/hawtio/src/ui/page/HawtioPage.tsx
+++ b/packages/hawtio/src/ui/page/HawtioPage.tsx
@@ -3,7 +3,7 @@ import { HawtioPreferences } from '@hawtio/preferences/HawtioPreferences'
 import { EmptyState, EmptyStateIcon, EmptyStateVariant, Page, PageSection, PageSectionVariants, Spinner, Title } from '@patternfly/react-core'
 import { CubesIcon } from '@patternfly/react-icons'
 import React from 'react'
-import { Redirect, Route, Switch, useLocation } from 'react-router-dom'
+import { Navigate, Route, Routes, useLocation } from 'react-router-dom'
 import { HawtioNotification } from '../notification/HawtioNotification'
 import { PageContext, usePlugins } from './context'
 import { HawtioBackground } from './HawtioBackground'
@@ -36,7 +36,7 @@ export const HawtioPage: React.FunctionComponent = () => {
   const defaultPlugin = plugins[0] || null
   let defaultPage
   if (defaultPlugin) {
-    defaultPage = <Redirect to={{ pathname: defaultPlugin.path, search }} />
+    defaultPage = <Navigate to={{ pathname: defaultPlugin.path, search }} />
   } else {
     defaultPage = <HawtioHome />
   }
@@ -49,26 +49,20 @@ export const HawtioPage: React.FunctionComponent = () => {
         sidebar={<HawtioSidebar />}
         isManagedSidebar
       >
-        <Switch>
+        <Routes>
           {/* plugins */}
           {plugins.map(plugin => (
             <Route
               key={plugin.id}
-              path={plugin.path}
-              component={plugin.component}
-            />
+              path={`${plugin.path}/*`}
+              element={React.createElement(plugin.component)}/>
           ))}
-          <Route key='help' path='/help'>
-            <HawtioHelp />
-          </Route>
-          <Route key='preferences' path='/preferences'>
-            <HawtioPreferences />
-          </Route>
-          <Route key='root' path='/' >
-            {defaultPage}
-          </Route>
-        </Switch>
-        <HawtioNotification />
+          <Route key='help' path='help/*' element={<HawtioHelp />} />
+          <Route key='preferences' path='preferences/*' element={<HawtioPreferences />} />
+
+          <Route index key='root' path='/' element={defaultPage} />
+        </Routes>
+      <HawtioNotification />
       </Page>
     </PageContext.Provider>
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -1451,7 +1451,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
   version: 7.20.13
   resolution: "@babel/runtime@npm:7.20.13"
   dependencies:
@@ -2006,7 +2006,7 @@ __metadata:
     react: ^18.2.0
     react-dom: ^18.2.0
     react-markdown: ^8.0.5
-    react-router-dom: ^5.3.4
+    react-router-dom: ^6.8.0
     react-split: ^2.0.14
     superstruct: ^1.0.3
     ts-jest: ^29.0.5
@@ -2775,6 +2775,13 @@ __metadata:
     webpack-plugin-serve:
       optional: true
   checksum: c45beded9c56fbbdc7213a2c36131ace5db360ed704d462cc39d6678f980173a91c9a3f691e6bd3a026f25486644cd0027e8a12a0a4eced8e8b886a0472e7d34
+  languageName: node
+  linkType: hard
+
+"@remix-run/router@npm:1.3.1":
+  version: 1.3.1
+  resolution: "@remix-run/router@npm:1.3.1"
+  checksum: c91cba100b13fbb83cdaf43ca66b0d9fc1ab9dfe0bc58ac80ff2a4889488bf518a111267c790350eac8c7f764cc7809402430de15bdf70282d0bd60acf06d9de
   languageName: node
   linkType: hard
 
@@ -8174,29 +8181,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"history@npm:^4.9.0":
-  version: 4.10.1
-  resolution: "history@npm:4.10.1"
-  dependencies:
-    "@babel/runtime": ^7.1.2
-    loose-envify: ^1.2.0
-    resolve-pathname: ^3.0.0
-    tiny-invariant: ^1.0.2
-    tiny-warning: ^1.0.0
-    value-equal: ^1.0.1
-  checksum: addd84bc4683929bae4400419b5af132ff4e4e9b311a0d4e224579ea8e184a6b80d7f72c55927e4fa117f69076a9e47ce082d8d0b422f1a9ddac7991490ca1d0
-  languageName: node
-  linkType: hard
-
-"hoist-non-react-statics@npm:^3.1.0":
-  version: 3.3.2
-  resolution: "hoist-non-react-statics@npm:3.3.2"
-  dependencies:
-    react-is: ^16.7.0
-  checksum: b1538270429b13901ee586aa44f4cc3ecd8831c061d06cb8322e50ea17b3f5ce4d0e2e66394761e6c8e152cd8c34fb3b4b690116c6ce2bd45b18c746516cb9e8
-  languageName: node
-  linkType: hard
-
 "homedir-polyfill@npm:^1.0.1":
   version: 1.0.3
   resolution: "homedir-polyfill@npm:1.0.3"
@@ -8984,13 +8968,6 @@ __metadata:
   dependencies:
     is-docker: ^2.0.0
   checksum: 20849846ae414997d290b75e16868e5261e86ff5047f104027026fd61d8b5a9b0b3ade16239f35e1a067b3c7cc02f70183cb661010ed16f4b6c7c93dad1b19d8
-  languageName: node
-  linkType: hard
-
-"isarray@npm:0.0.1":
-  version: 0.0.1
-  resolution: "isarray@npm:0.0.1"
-  checksum: 49191f1425681df4a18c2f0f93db3adb85573bcdd6a4482539d98eac9e705d8961317b01175627e860516a2fc45f8f9302db26e5a380a97a520e272e2a40a8d4
   languageName: node
   linkType: hard
 
@@ -10599,7 +10576,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loose-envify@npm:^1.0.0, loose-envify@npm:^1.1.0, loose-envify@npm:^1.2.0, loose-envify@npm:^1.3.1, loose-envify@npm:^1.4.0":
+"loose-envify@npm:^1.0.0, loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
@@ -11875,15 +11852,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:^1.7.0":
-  version: 1.8.0
-  resolution: "path-to-regexp@npm:1.8.0"
-  dependencies:
-    isarray: 0.0.1
-  checksum: 709f6f083c0552514ef4780cb2e7e4cf49b0cc89a97439f2b7cc69a608982b7690fb5d1720a7473a59806508fc2dae0be751ba49f495ecf89fd8fbc62abccbcd
-  languageName: node
-  linkType: hard
-
 "path-type@npm:^4.0.0":
   version: 4.0.0
   resolution: "path-type@npm:4.0.0"
@@ -13121,7 +13089,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^16.13.1, react-is@npm:^16.3.2, react-is@npm:^16.6.0, react-is@npm:^16.7.0":
+"react-is@npm:^16.13.1, react-is@npm:^16.3.2":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: f7a19ac3496de32ca9ae12aa030f00f14a3d45374f1ceca0af707c831b2a6098ef0d6bdae51bd437b0a306d7f01d4677fcc8de7c0d331eb47ad0f46130e53c5f
@@ -13175,39 +13143,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:^5.3.4":
-  version: 5.3.4
-  resolution: "react-router-dom@npm:5.3.4"
+"react-router-dom@npm:^6.8.0":
+  version: 6.8.0
+  resolution: "react-router-dom@npm:6.8.0"
   dependencies:
-    "@babel/runtime": ^7.12.13
-    history: ^4.9.0
-    loose-envify: ^1.3.1
-    prop-types: ^15.6.2
-    react-router: 5.3.4
-    tiny-invariant: ^1.0.2
-    tiny-warning: ^1.0.0
+    "@remix-run/router": 1.3.1
+    react-router: 6.8.0
   peerDependencies:
-    react: ">=15"
-  checksum: b86a6f2f5222f041e38adf4e4b32c7643d6735a1a915ef25855b2db285fd059d72ba8d62e5bcd5d822b8ef9520a80453209e55077f5a90d0f72e908979b8f535
+    react: ">=16.8"
+    react-dom: ">=16.8"
+  checksum: a10419023267014bdad20f50b5be04dffda49ebeb06c52ce9567795769dc0dc9b4e2fa61b52b5d70b61df4d17f85bae8f9c7e94c73d25d16974e46fd47765ced
   languageName: node
   linkType: hard
 
-"react-router@npm:5.3.4":
-  version: 5.3.4
-  resolution: "react-router@npm:5.3.4"
+"react-router@npm:6.8.0":
+  version: 6.8.0
+  resolution: "react-router@npm:6.8.0"
   dependencies:
-    "@babel/runtime": ^7.12.13
-    history: ^4.9.0
-    hoist-non-react-statics: ^3.1.0
-    loose-envify: ^1.3.1
-    path-to-regexp: ^1.7.0
-    prop-types: ^15.6.2
-    react-is: ^16.6.0
-    tiny-invariant: ^1.0.2
-    tiny-warning: ^1.0.0
+    "@remix-run/router": 1.3.1
   peerDependencies:
-    react: ">=15"
-  checksum: 892d4e274a23bf4f39abc2efca54472fb646d3aed4b584020cf49654d2f50d09a2bacebe7c92b4ec7cb8925077376dfcd0664bad6442a73604397cefec9f01f9
+    react: ">=16.8"
+  checksum: 6e258c47f6cbbd0b0c7c9fd7bbaf7cd5cd60472935512fbe97c91e4bbd9b1717f0dee231f5d7206bedfbccdbc21ab77eaf336ba971ea5d8c6b1277045a7b958a
   languageName: node
   linkType: hard
 
@@ -13554,13 +13510,6 @@ __metadata:
   dependencies:
     global-dirs: ^0.1.1
   checksum: c4e11d33e84bde7516b824503ffbe4b6cce863d5ce485680fd3db997b7c64da1df98321b1fd0703b58be8bc9bc83bc96bd83043f96194386b45eb47229efb6b6
-  languageName: node
-  linkType: hard
-
-"resolve-pathname@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "resolve-pathname@npm:3.0.0"
-  checksum: 6147241ba42c423dbe83cb067a2b4af4f60908c3af57e1ea567729cc71416c089737fe2a73e9e79e7a60f00f66c91e4b45ad0d37cd4be2d43fec44963ef14368
   languageName: node
   linkType: hard
 
@@ -14851,20 +14800,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tiny-invariant@npm:^1.0.2":
-  version: 1.2.0
-  resolution: "tiny-invariant@npm:1.2.0"
-  checksum: e09a718a7c4a499ba592cdac61f015d87427a0867ca07f50c11fd9b623f90cdba18937b515d4a5e4f43dac92370498d7bdaee0d0e7a377a61095e02c4a92eade
-  languageName: node
-  linkType: hard
-
-"tiny-warning@npm:^1.0.0":
-  version: 1.0.3
-  resolution: "tiny-warning@npm:1.0.3"
-  checksum: da62c4acac565902f0624b123eed6dd3509bc9a8d30c06e017104bedcf5d35810da8ff72864400ad19c5c7806fc0a8323c68baf3e326af7cb7d969f846100d71
-  languageName: node
-  linkType: hard
-
 "tippy.js@npm:5.1.2":
   version: 5.1.2
   resolution: "tippy.js@npm:5.1.2"
@@ -15526,13 +15461,6 @@ __metadata:
     "@types/istanbul-lib-coverage": ^2.0.1
     convert-source-map: ^1.6.0
   checksum: a49c34bf0a3af0c11041a3952a2600913904a983bd1bc87148b5c033bc5c1d02d5a13620fcdbfa2c60bc582a2e2970185780f0c844b4c3a220abf405f8af6311
-  languageName: node
-  linkType: hard
-
-"value-equal@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "value-equal@npm:1.0.1"
-  checksum: bb7ae1facc76b5cf8071aeb6c13d284d023fdb370478d10a5d64508e0e6e53bb459c4bbe34258df29d82e6f561f874f0105eba38de0e61fe9edd0bdce07a77a2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This is a WIP PR. I've currently migrated and refactored all (I hope) routes in all plugins except camel.

Thinks to do: 
- migrate camel plugin,
- configure local dev environment to auto redirect to [host]/hawtio, this was removed in router v6
@tadayosi  please check if applicable so far