### PR TITLE
chore: use prettier for consistent code formatting #92

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,25 +8,23 @@ module.exports = {
     'plugin:react/jsx-runtime',
     'plugin:react-hooks/recommended',
     'plugin:testing-library/react',
+    'prettier',
   ],
   parser: '@typescript-eslint/parser',
-  plugins: [
-    '@typescript-eslint',
-    'import',
-  ],
+  plugins: ['@typescript-eslint', 'import'],
   rules: {
-    'semi': ['error', 'never'],
+    semi: ['error', 'never'],
     '@typescript-eslint/explicit-member-accessibility': [
       'warn',
       {
-        accessibility: 'no-public'
-      }
+        accessibility: 'no-public',
+      },
     ],
     '@typescript-eslint/no-empty-function': [
       'error',
       {
-        'allow': ['constructors']
-      }
+        allow: ['constructors'],
+      },
     ],
     '@typescript-eslint/no-redeclare': 'off',
     'import/no-default-export': 'error',
@@ -34,11 +32,11 @@ module.exports = {
     'testing-library/no-debugging-utils': [
       'warn',
       {
-        'utilsToCheckFor': {
-          'debug': false,
-        }
-      }
-    ]
+        utilsToCheckFor: {
+          debug: false,
+        },
+      },
+    ],
   },
   root: true,
 }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,24 +1,24 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  reviewers:
-  - tadayosi
-  - phantomjinx
-  - mmelko
-  - joshiraez
-  - jsolovjo
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
-  reviewers:
-  - tadayosi
-  - phantomjinx
-  - mmelko
-  - joshiraez
-  - jsolovjo
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    reviewers:
+      - tadayosi
+      - phantomjinx
+      - mmelko
+      - joshiraez
+      - jsolovjo
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    reviewers:
+      - tadayosi
+      - phantomjinx
+      - mmelko
+      - joshiraez
+      - jsolovjo

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,12 +5,12 @@ on:
     branches:
       - main
     paths-ignore:
-      - "**.md"
+      - '**.md'
   push:
     branches:
       - main
     paths-ignore:
-      - "**.md"
+      - '**.md'
 
 jobs:
   lint:
@@ -37,6 +37,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Install
+        id: install
         run: yarn install
+      - name: Format check
+        id: format-check
+        run: yarn format:check
       - name: Lint
+        id: lint
+        if: steps.install.outcome == 'success'
         run: yarn lint --max-warnings=0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,19 +5,19 @@ on:
     branches:
       - main
     paths-ignore:
-      - "**.md"
+      - '**.md'
   push:
     branches:
       - main
     paths-ignore:
-      - "**.md"
+      - '**.md'
 
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ '14', '16', '18' ]
+        node: ['14', '16', '18']
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+build
+coverage
+dist
+.yarn

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,10 @@
+module.exports = {
+  printWidth: 120,
+  semi: false,
+  singleQuote: true,
+  jsxSingleQuote: true,
+  trailingComma: 'all',
+  bracketSpacing: true,
+  bracketSameLine: false,
+  arrowParens: 'avoid',
+}

--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ You need to have installed the following tools before developing the project.
 
 #### Minimum Version of Yarn is 3.4.1
 
-The default installation version of yarn on many operating systems is *1.22-19* (the classic version). This causes a problem as the development app downloads the `@hawtio/react` package rather than using
-the project directory. As a result, the mandated minimum version has been set to *3.4.1*.
+The default installation version of yarn on many operating systems is _1.22-19_ (the classic version). This causes a problem as the development app downloads the `@hawtio/react` package rather than using
+the project directory. As a result, the mandated minimum version has been set to _3.4.1_.
 
-If `yarn install` is attempted with a version lower than *3.4.1* then an error message is displayed, eg.
+If `yarn install` is attempted with a version lower than _3.4.1_ then an error message is displayed, eg.
+
 > $ /usr/bin/yarn install
 > yarn install v1.22.19
 > [1/5] Validating package.json...
@@ -36,6 +37,7 @@ If `yarn install` is attempted with a version lower than *3.4.1* then an error m
 > error Found incompatible module.
 
 To upgrade such a version to 3.4.1, use yarn's own `set-version` command:
+
 > yarn set version 3.4.1
 
 This will download the 3.4.1 internals to `hawtio-next/.yarn` which are then deferred to by the installed yarn binary.

--- a/app/craco.config.js
+++ b/app/craco.config.js
@@ -6,10 +6,12 @@ module.exports = {
       ignoreWarnings: [
         // For suppressing sourcemap warnings coming from superstruct
         function ignoreSourcemapsloaderWarnings(warning) {
-          return warning.module
-            && warning.module.resource.includes('node_modules')
-            && warning.details
-            && warning.details.includes('source-map-loader')
+          return (
+            warning.module &&
+            warning.module.resource.includes('node_modules') &&
+            warning.details &&
+            warning.details.includes('source-map-loader')
+          )
         },
       ],
     },
@@ -22,17 +24,14 @@ module.exports = {
       coveragePathIgnorePatterns: [
         '<rootDir>/node_modules/',
         '<rootDir>/src/hawtio/test/',
-        '<rootDir>/src/hawtio/.*/ignore/.*'
+        '<rootDir>/src/hawtio/.*/ignore/.*',
       ],
 
-      moduleDirectories: [
-        '<rootDir>/node_modules/',
-        '<rootDir>/src/hawtio/test/'
-      ],
+      moduleDirectories: ['<rootDir>/node_modules/', '<rootDir>/src/hawtio/test/'],
 
       moduleNameMapper: {
         ['@hawtio/(.*)']: '<rootDir>/src/hawtio/$1',
-        'react-markdown': '<rootDir>/node_modules/react-markdown/react-markdown.min.js'
+        'react-markdown': '<rootDir>/node_modules/react-markdown/react-markdown.min.js',
       },
 
       // The path to a module that runs some code to configure or set up the testing framework before each test
@@ -41,33 +40,26 @@ module.exports = {
       testPathIgnorePatterns: [
         '<rootDir>/node_modules/',
         '<rootDir>/src/hawtio/test/',
-        '<rootDir>/src/hawtio/.*/ignore/.*'
+        '<rootDir>/src/hawtio/.*/ignore/.*',
       ],
 
-      transformIgnorePatterns: [
-        'node_modules/(?!@patternfly/react-icons/dist/esm/icons)/'
-      ],
+      transformIgnorePatterns: ['node_modules/(?!@patternfly/react-icons/dist/esm/icons)/'],
 
-      coveragePathIgnorePatterns: [
-        'node_modules/',
-        'src/examples/',
-        'src/index.tsx',
-        'src/reportWebVitals.ts',
-      ],
-    }
+      coveragePathIgnorePatterns: ['node_modules/', 'src/examples/', 'src/index.tsx', 'src/reportWebVitals.ts'],
+    },
   },
   devServer: {
-    setupMiddlewares: (middlewares) => {
+    setupMiddlewares: middlewares => {
       middlewares.push({
         name: 'hawtio-backend',
         path: '/proxy',
         middleware: hawtioBackend({
           // Uncomment it if you want to see debug log for Hawtio backend
           logLevel: 'debug',
-        })
+        }),
       })
 
       return middlewares
-    }
-  }
+    },
+  },
 }

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -1,20 +1,19 @@
 <!DOCTYPE html>
 <html lang="en">
-
-<head>
-  <meta charset="utf-8" />
-  <base href="%PUBLIC_URL%/" />
-  <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="theme-color" content="#000000" />
-  <meta name="description" content="Web site created using create-react-app" />
-  <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-  <!--
+  <head>
+    <meta charset="utf-8" />
+    <base href="%PUBLIC_URL%/" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta name="description" content="Web site created using create-react-app" />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-  <!--
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
@@ -23,12 +22,11 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-  <title>Hawtio.next dev</title>
-</head>
+    <title>Hawtio.next dev</title>
+  </head>
 
-<body>
-  <noscript>You need to enable JavaScript to run this app.</noscript>
-  <div id="root"></div>
-</body>
-
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+  </body>
 </html>

--- a/app/src/examples/example1/Example1.tsx
+++ b/app/src/examples/example1/Example1.tsx
@@ -1,10 +1,11 @@
 import { PageSection, PageSectionVariants, Text, TextContent } from '@patternfly/react-core'
 import React from 'react'
 
-export const Example1: React.FunctionComponent = () =>
+export const Example1: React.FunctionComponent = () => (
   <PageSection variant={PageSectionVariants.light}>
     <TextContent>
-      <Text component="h1">Example 1</Text>
-      <Text component="p">This is an example plugin.</Text>
+      <Text component='h1'>Example 1</Text>
+      <Text component='p'>This is an example plugin.</Text>
     </TextContent>
   </PageSection>
+)

--- a/app/src/examples/example1/index.ts
+++ b/app/src/examples/example1/index.ts
@@ -1,4 +1,3 @@
-
 import { hawtio } from '@hawtio/react'
 import { Example1 } from './Example1'
 
@@ -8,6 +7,6 @@ export const registerExample1 = () => {
     title: 'Example 1',
     path: '/example1',
     component: Example1,
-    isActive: async () => true
+    isActive: async () => true,
   })
 }

--- a/app/src/examples/example2/Example2.tsx
+++ b/app/src/examples/example2/Example2.tsx
@@ -1,10 +1,11 @@
 import { PageSection, PageSectionVariants, Text, TextContent } from '@patternfly/react-core'
 import React from 'react'
 
-export const Example2: React.FunctionComponent = () =>
+export const Example2: React.FunctionComponent = () => (
   <PageSection variant={PageSectionVariants.light}>
     <TextContent>
-      <Text component="h1">Example 2</Text>
-      <Text component="p">This is another example plugin.</Text>
+      <Text component='h1'>Example 2</Text>
+      <Text component='p'>This is another example plugin.</Text>
     </TextContent>
   </PageSection>
+)

--- a/app/src/examples/example2/index.ts
+++ b/app/src/examples/example2/index.ts
@@ -1,4 +1,3 @@
-
 import { hawtio } from '@hawtio/react'
 import { Example2 } from './Example2'
 
@@ -8,6 +7,6 @@ export const registerExample2 = () => {
     title: 'Example 2',
     path: '/example2',
     component: Example2,
-    isActive: async () => true
+    isActive: async () => true,
   })
 }

--- a/app/src/examples/example3/Example3.tsx
+++ b/app/src/examples/example3/Example3.tsx
@@ -1,11 +1,11 @@
 import { PageSection, PageSectionVariants, Text, TextContent } from '@patternfly/react-core'
 import React from 'react'
 
-
-export const Example3: React.FunctionComponent = () =>
+export const Example3: React.FunctionComponent = () => (
   <PageSection variant={PageSectionVariants.light}>
     <TextContent>
-      <Text component="h1">Example 3</Text>
-      <Text component="p">This is yet another example plugin.</Text>
+      <Text component='h1'>Example 3</Text>
+      <Text component='p'>This is yet another example plugin.</Text>
     </TextContent>
   </PageSection>
+)

--- a/app/src/examples/example3/index.ts
+++ b/app/src/examples/example3/index.ts
@@ -7,6 +7,6 @@ export const registerExample3 = () => {
     title: 'Example 3',
     path: '/example3',
     component: Example3,
-    isActive: async () => true
+    isActive: async () => true,
   })
 }

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -1,3 +1,3 @@
 #root {
-  height: 100%
+  height: 100%;
 }

--- a/app/src/index.tsx
+++ b/app/src/index.tsx
@@ -13,13 +13,11 @@ registerPlugins()
 registerExamples()
 hawtio.bootstrap()
 
-const root = ReactDOM.createRoot(
-  document.getElementById('root') as HTMLElement
-)
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 root.render(
   <React.StrictMode>
     <Hawtio />
-  </React.StrictMode>
+  </React.StrictMode>,
 )
 
 // If you want to start measuring performance in your app, pass a function

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -2,11 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "target": "es2015",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -23,7 +19,5 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -35,10 +35,12 @@ Therefore, the migration from legacy Hawtio to Hawtio.next is basically a proces
 
 To give one example, the Attributes feature of the JMX plugin is mapped as follows.
 
+<!-- prettier-ignore-start -->
 | MVC | Legacy Hawtio | Hawtio.next |
 | --- | ------------- | ----------- |
 | Controller & view | [attributes.controller.ts](https://github.com/hawtio/hawtio-integration/blob/main/plugins/jmx/ts/attributes/attributes.controller.ts) <br/> [attributes.html](https://github.com/hawtio/hawtio-integration/blob/main/plugins/jmx/html/attributes/attributes.html) | [Attributes.tsx](https://github.com/hawtio/hawtio-next/blob/main/src/hawtio/plugins/jmx/attributes/Attributes.tsx) |
 | Service | [attributes.service.ts](https://github.com/hawtio/hawtio-integration/blob/main/plugins/jmx/ts/attributes/attributes.service.ts) | [attribute-service.ts](https://github.com/hawtio/hawtio-next/blob/main/src/hawtio/plugins/jmx/attributes/attribute-service.ts) |
+<!-- prettier-ignore-end -->
 
 ### Developing a React component
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "test:packages": "yarn workspace @hawtio/react test",
     "test:app": "yarn workspace app test",
     "lint": "yarn eslint packages/hawtio/src/ app/src/",
-    "lint:fix": "yarn lint --fix"
+    "lint:fix": "yarn lint --fix",
+    "format:check": "yarn prettier --check .",
+    "format:fix": "yarn prettier --write ."
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.50.0",
@@ -31,9 +33,11 @@
     "concurrently": "^7.6.0",
     "cz-conventional-changelog": "3.3.0",
     "eslint": "^8.33.0",
+    "eslint-config-prettier": "^8.6.0",
     "eslint-config-react-app": "^7.0.1",
     "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-react-hooks": "^4.6.0"
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "prettier": "2.8.4"
   },
   "config": {
     "commitizen": {

--- a/packages/hawtio/jest.config.ts
+++ b/packages/hawtio/jest.config.ts
@@ -18,15 +18,9 @@ export default {
   // framework before each test
   setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
 
-  testPathIgnorePatterns: [
-    '<rootDir>/node_modules/',
-  ],
+  testPathIgnorePatterns: ['<rootDir>/node_modules/'],
 
-  transformIgnorePatterns: [
-    'node_modules/(?!@patternfly/react-icons/dist/esm/icons)/',
-  ],
+  transformIgnorePatterns: ['node_modules/(?!@patternfly/react-icons/dist/esm/icons)/'],
 
-  coveragePathIgnorePatterns: [
-    'node_modules/',
-  ],
+  coveragePathIgnorePatterns: ['node_modules/'],
 }

--- a/packages/hawtio/src/Hawtio.test.tsx
+++ b/packages/hawtio/src/Hawtio.test.tsx
@@ -3,9 +3,7 @@ import { Hawtio } from './Hawtio'
 
 describe('Hawtio', () => {
   test('renders page', async () => {
-    render(
-      <Hawtio basepath='/' />
-    )
+    render(<Hawtio basepath='/' />)
     await waitFor(() => {
       const example = screen.queryByText('Hawtio')
       expect(example).toBeInTheDocument()

--- a/packages/hawtio/src/auth/index.ts
+++ b/packages/hawtio/src/auth/index.ts
@@ -1,2 +1,1 @@
 export { DEFAULT_USER, userService } from './user-service'
-

--- a/packages/hawtio/src/auth/user-service.test.ts
+++ b/packages/hawtio/src/auth/user-service.test.ts
@@ -1,7 +1,6 @@
 import { UserService } from './user-service'
 
 describe('userService', () => {
-
   test('default user - login - logout', () => {
     const service = new UserService()
     expect(service.isLogin()).toBe(false)

--- a/packages/hawtio/src/context/HawtioContextProvider.tsx
+++ b/packages/hawtio/src/context/HawtioContextProvider.tsx
@@ -8,9 +8,5 @@ type Props = {
 }
 
 export const HawtioContextProvider: React.FunctionComponent<Props> = ({ children }) => {
-  return (
-    <HawtioContext.Provider value={initialState}>
-      {children}
-    </HawtioContext.Provider>
-  )
+  return <HawtioContext.Provider value={initialState}>{children}</HawtioContext.Provider>
 }

--- a/packages/hawtio/src/core/core.ts
+++ b/packages/hawtio/src/core/core.ts
@@ -29,7 +29,6 @@ type Plugins = {
  * - Plugin loader and discovery mechanism
  */
 class HawtioCore {
-
   /**
    * Hawtio base path.
    */
@@ -68,7 +67,7 @@ class HawtioCore {
    * Adds an angular module to the list of modules to bootstrap.
    */
   addPlugin(plugin: Plugin): HawtioCore {
-    log.info("Add plugin:", plugin.id)
+    log.info('Add plugin:', plugin.id)
     if (this.plugins[plugin.id]) {
       throw new Error(`Plugin "${plugin.id}" already exists`)
     }
@@ -80,7 +79,7 @@ class HawtioCore {
    * Adds a URL for discovering plugins.
    */
   addUrl(url: string): HawtioCore {
-    log.info("Add URL:", url)
+    log.info('Add URL:', url)
     this.urls.push(url)
     return this
   }
@@ -101,7 +100,7 @@ class HawtioCore {
    * It is invoked from Hawtio's bootstrapping.
    */
   private loadPlugins(callback: (plugins: Plugins) => void): void {
-    log.info("Bootstrapping Hawtio...")
+    log.info('Bootstrapping Hawtio...')
 
     // TODO: Load external plugins
 
@@ -126,7 +125,6 @@ class HawtioCore {
     }
     return resolved
   }
-
 }
 
 /**

--- a/packages/hawtio/src/core/event-service.test.ts
+++ b/packages/hawtio/src/core/event-service.test.ts
@@ -10,7 +10,7 @@ describe('EventService', () => {
     eventService.notify({
       type: 'success',
       message: 'Test message',
-      duration: 1000
+      duration: 1000,
     })
     expect.hasAssertions()
   })

--- a/packages/hawtio/src/core/event-service.ts
+++ b/packages/hawtio/src/core/event-service.ts
@@ -3,12 +3,7 @@ import { Logger } from './logging'
 
 const log = Logger.get('hawtio-core-event')
 
-export type NotificationType =
-  | 'default'
-  | 'info'
-  | 'success'
-  | 'warning'
-  | 'danger'
+export type NotificationType = 'default' | 'info' | 'success' | 'warning' | 'danger'
 
 export type Notification = {
   type: NotificationType

--- a/packages/hawtio/src/core/index.ts
+++ b/packages/hawtio/src/core/index.ts
@@ -1,4 +1,3 @@
 export * from './core'
 export * from './event-service'
 export * from './logging'
-

--- a/packages/hawtio/src/core/logging.ts
+++ b/packages/hawtio/src/core/logging.ts
@@ -44,13 +44,13 @@ class LocalStorageHawtioLogger implements HawtioLogger {
   createDefaultHandler: typeof jsLogger.createDefaultHandler = jsLogger.createDefaultHandler
 
   private readonly LOG_LEVEL_MAP: { [name: string]: ILogLevel } = {
-    'TRACE': this.TRACE,
-    'DEBUG': this.DEBUG,
-    'INFO': this.INFO,
-    'TIME': this.TIME,
-    'WARN': this.WARN,
-    'ERROR': this.ERROR,
-    'OFF': this.OFF,
+    TRACE: this.TRACE,
+    DEBUG: this.DEBUG,
+    INFO: this.INFO,
+    TIME: this.TIME,
+    WARN: this.WARN,
+    ERROR: this.ERROR,
+    OFF: this.OFF,
   } as const
 
   get(name: string): ILogger {

--- a/packages/hawtio/src/help/HawtioHelp.tsx
+++ b/packages/hawtio/src/help/HawtioHelp.tsx
@@ -1,4 +1,16 @@
-import { Card, CardBody, Nav, NavItem, NavList, PageGroup, PageNavigation, PageSection, PageSectionVariants, TextContent, Title } from '@patternfly/react-core'
+import {
+  Card,
+  CardBody,
+  Nav,
+  NavItem,
+  NavList,
+  PageGroup,
+  PageNavigation,
+  PageSection,
+  PageSectionVariants,
+  TextContent,
+  Title,
+} from '@patternfly/react-core'
 import React from 'react'
 import Markdown from 'react-markdown'
 import { NavLink, Navigate, Route, Routes, useLocation } from 'react-router-dom'
@@ -12,17 +24,17 @@ export const HawtioHelp: React.FunctionComponent = () => {
   return (
     <React.Fragment>
       <PageSection variant={PageSectionVariants.light}>
-        <Title headingLevel="h1">Help</Title>
+        <Title headingLevel='h1'>Help</Title>
       </PageSection>
       <PageGroup>
         <PageNavigation>
-          <Nav aria-label="Nav" variant="tertiary">
+          <Nav aria-label='Nav' variant='tertiary'>
             <NavList>
-              {helpRegistry.getHelps().map(help =>
+              {helpRegistry.getHelps().map(help => (
                 <NavItem key={help.id} isActive={location.pathname === help.id}>
                   <NavLink to={help.id}>{help.title}</NavLink>
                 </NavItem>
-              )}
+              ))}
             </NavList>
           </Nav>
         </PageNavigation>
@@ -30,15 +42,20 @@ export const HawtioHelp: React.FunctionComponent = () => {
       <PageSection>
         <Card isFullHeight>
           <Routes>
-            {helpRegistry.getHelps().map(help =>
-              <Route key={help.id} path={help.id} element={
-                <CardBody>
-                  <TextContent>
-                    <Markdown>{help.content}</Markdown>
-                  </TextContent>
-                </CardBody>}
-              />)}
-           <Route path='/' element={<Navigate to='home' />} />
+            {helpRegistry.getHelps().map(help => (
+              <Route
+                key={help.id}
+                path={help.id}
+                element={
+                  <CardBody>
+                    <TextContent>
+                      <Markdown>{help.content}</Markdown>
+                    </TextContent>
+                  </CardBody>
+                }
+              />
+            ))}
+            <Route path='/' element={<Navigate to='home' />} />
           </Routes>
         </Card>
       </PageSection>

--- a/packages/hawtio/src/help/help.md
+++ b/packages/hawtio/src/help/help.md
@@ -8,6 +8,6 @@ Browse the available help topics for plugin specific documentation using the hel
 
 ### Further reading
 
-- [Hawtio](https://hawt.io "Hawtio") website
+- [Hawtio](https://hawt.io 'Hawtio') website
 - Help improve Hawtio by [contributing](https://hawt.io/docs/contributing/)
 - Hawtio on [GitHub](https://github.com/hawtio/hawtio)

--- a/packages/hawtio/src/help/registry.test.ts
+++ b/packages/hawtio/src/help/registry.test.ts
@@ -23,8 +23,7 @@ describe('helpRegistry', () => {
     `)
 
     // duplicate help not allowed
-    expect(() => helpRegistry.add('test', 'Test', payload))
-      .toThrowError(/Help 'test' already registered/)
+    expect(() => helpRegistry.add('test', 'Test', payload)).toThrowError(/Help 'test' already registered/)
   })
 
   test('return helps in order', async () => {

--- a/packages/hawtio/src/help/registry.ts
+++ b/packages/hawtio/src/help/registry.ts
@@ -6,7 +6,6 @@ export type Help = {
 }
 
 class HelpRegistry {
-
   private helps: { [id: string]: Help } = {}
 
   add(id: string, title: string, content: string, order = 100) {

--- a/packages/hawtio/src/plugins/camel/Camel.tsx
+++ b/packages/hawtio/src/plugins/camel/Camel.tsx
@@ -1,6 +1,14 @@
 import React from 'react'
 import Split from 'react-split'
-import { EmptyState, EmptyStateIcon, EmptyStateVariant, PageSection, PageSectionVariants, Spinner, Title } from '@patternfly/react-core'
+import {
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  PageSection,
+  PageSectionVariants,
+  Spinner,
+  Title,
+} from '@patternfly/react-core'
 import { CubesIcon } from '@patternfly/react-icons'
 import { CamelTreeView } from './CamelTreeView'
 import { CamelContent } from './CamelContent'
@@ -16,7 +24,7 @@ export const Camel: React.FunctionComponent = () => {
   if (!loaded) {
     return (
       <PageSection>
-        <Spinner isSVG aria-label="Loading Camel Contexts tree" />
+        <Spinner isSVG aria-label='Loading Camel Contexts tree' />
       </PageSection>
     )
   }
@@ -26,7 +34,9 @@ export const Camel: React.FunctionComponent = () => {
       <PageSection variant={PageSectionVariants.light}>
         <EmptyState variant={EmptyStateVariant.full}>
           <EmptyStateIcon icon={CubesIcon} />
-          <Title headingLevel="h1" size="lg">No Camel Contexts found</Title>
+          <Title headingLevel='h1' size='lg'>
+            No Camel Contexts found
+          </Title>
         </EmptyState>
       </PageSection>
     )
@@ -34,19 +44,14 @@ export const Camel: React.FunctionComponent = () => {
 
   return (
     <CamelContext.Provider value={{ tree, node, setNode }}>
-    <Split
-      className="camel-split"
-      sizes={[30, 70]}
-      minSize={200}
-      gutterSize={5}
-    >
-      <div>
-        <CamelTreeView />
-      </div>
-      <div>
-        <CamelContent />
-      </div>
-    </Split>
+      <Split className='camel-split' sizes={[30, 70]} minSize={200} gutterSize={5}>
+        <div>
+          <CamelTreeView />
+        </div>
+        <div>
+          <CamelContent />
+        </div>
+      </Split>
     </CamelContext.Provider>
   )
 }

--- a/packages/hawtio/src/plugins/camel/CamelContent.tsx
+++ b/packages/hawtio/src/plugins/camel/CamelContent.tsx
@@ -1,8 +1,5 @@
 import React from 'react'
 
 export const CamelContent: React.FunctionComponent = () => {
-
-  return (
-    <></>
-  )
+  return <></>
 }

--- a/packages/hawtio/src/plugins/camel/CamelTreeView.tsx
+++ b/packages/hawtio/src/plugins/camel/CamelTreeView.tsx
@@ -1,13 +1,6 @@
 import React, { ChangeEvent, useState, useContext } from 'react'
-import {
-  PluginTreeViewToolbar,
-  MBeanNode,
-  MBeanTree
-} from '@hawtio/plugins/shared'
-import {
-  TreeView,
-  TreeViewDataItem
-} from '@patternfly/react-core'
+import { PluginTreeViewToolbar, MBeanNode, MBeanTree } from '@hawtio/plugins/shared'
+import { TreeView, TreeViewDataItem } from '@patternfly/react-core'
 import { CamelContext } from './context'
 
 export const CamelTreeView: React.FunctionComponent = () => {
@@ -16,8 +9,8 @@ export const CamelTreeView: React.FunctionComponent = () => {
   // TODO consider whether expanded is required here
   //
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [ expanded, setExpanded ] = useState(false)
-  const [ filteredTree, setFilteredTree ] = useState(tree.getTree())
+  const [expanded, setExpanded] = useState(false)
+  const [filteredTree, setFilteredTree] = useState(tree.getTree())
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const onSearch = (event: ChangeEvent<HTMLInputElement>) => {
@@ -28,42 +21,39 @@ export const CamelTreeView: React.FunctionComponent = () => {
     if (input === '') {
       setFilteredTree(tree.getTree())
     } else {
-      setFilteredTree(MBeanTree.createFilteredTree(
-        tree.getTree(),
-        (node: MBeanNode) => node.name.toLowerCase().includes(input.toLowerCase())))
+      setFilteredTree(
+        MBeanTree.createFilteredTree(tree.getTree(), (node: MBeanNode) =>
+          node.name.toLowerCase().includes(input.toLowerCase()),
+        ),
+      )
     }
   }
 
   const onSelect = (event: React.MouseEvent<Element, MouseEvent>, item: TreeViewDataItem) => {
     //TODO
-    console.log("Select TODO")
+    console.log('Select TODO')
     setNode(item as MBeanNode)
   }
 
   const getActiveItems = (): TreeViewDataItem[] => {
     if (!node) {
-      console.log("Getting Active Items: NONE")
+      console.log('Getting Active Items: NONE')
       return []
     } else {
-      console.log("Getting Active Items: " + node.id)
-      return [ node as TreeViewDataItem ]
+      console.log('Getting Active Items: ' + node.id)
+      return [node as TreeViewDataItem]
     }
   }
 
   return (
     <TreeView
-      id="camel-tree-view"
+      id='camel-tree-view'
       data={filteredTree}
       hasGuides={true}
       onSelect={onSelect}
       hasSelectableNodes={true}
       activeItems={getActiveItems()}
-      toolbar={
-        <PluginTreeViewToolbar
-          onSearch={onSearch}
-          onSetExpanded={setExpanded}
-        />
-      }
+      toolbar={<PluginTreeViewToolbar onSearch={onSearch} onSetExpanded={setExpanded} />}
     />
   )
 }

--- a/packages/hawtio/src/plugins/camel/context.ts
+++ b/packages/hawtio/src/plugins/camel/context.ts
@@ -35,8 +35,8 @@ export function useCamelTree() {
         const subTree: MBeanTree = MBeanTree.createMBeanTreeFromNodes(pluginName, [rootNode])
         setTree(subTree)
         if (rootNode && rootNode.children && rootNode.children.length > 0) {
-          const r: TreeViewDataItem = (rootNode as TreeViewDataItem)
-          const c: TreeViewDataItem = (rootNode.children[0] as TreeViewDataItem)
+          const r: TreeViewDataItem = rootNode as TreeViewDataItem
+          const c: TreeViewDataItem = rootNode.children[0] as TreeViewDataItem
           c.defaultExpanded = true
           r.defaultExpanded = true
           setNode(rootNode.children[0])
@@ -45,11 +45,10 @@ export function useCamelTree() {
         // 2. Somewhere in the bootstrapping need to refilter the camel content of the tree
         //    to reshape it as the camel context original - icons too!!!
 
-
         // Jmx.enableTree(this.$scope, this.$location, this.workspace, $(treeElementId), [rootNode])
         // this.updateSelectionFromURL()
       } else {
-        console.log("TODO: reroute back to jmx view")
+        console.log('TODO: reroute back to jmx view')
         setTree(wkspTree)
         // // No camel contexts so redirect to the JMX view and select the first tree node
         // if (tree.children && tree.children.length > 0) {
@@ -72,5 +71,7 @@ type CamelContext = {
 export const CamelContext = createContext<CamelContext>({
   tree: MBeanTree.createEmptyTree(pluginName),
   node: null,
-  setNode: () => { /* no-op */ }
+  setNode: () => {
+    /* no-op */
+  },
 })

--- a/packages/hawtio/src/plugins/camel/icons/CamelIcon.tsx
+++ b/packages/hawtio/src/plugins/camel/icons/CamelIcon.tsx
@@ -2,12 +2,7 @@ import React from 'react'
 import camelSvg from './svg/camel.svg'
 
 const CamelIcon = ({ size = 16 }) => {
-  return (
-    <img src={camelSvg}
-         width={size + 'px'} height={size + 'px'}
-         alt="Camel Icon"
-    />
-  )
+  return <img src={camelSvg} width={size + 'px'} height={size + 'px'} alt='Camel Icon' />
 }
 
 export { CamelIcon }

--- a/packages/hawtio/src/plugins/camel/icons/EndpointFolderIcon.tsx
+++ b/packages/hawtio/src/plugins/camel/icons/EndpointFolderIcon.tsx
@@ -2,12 +2,7 @@ import React from 'react'
 import endpointFolderSvg from './svg/endpoint-folder.svg'
 
 const EndPointFolderIcon = ({ size = 16 }) => {
-  return (
-    <img src={endpointFolderSvg}
-         width={size + 'px'} height={size + 'px'}
-         alt="EndPoint Folder Icon"
-    />
-  )
+  return <img src={endpointFolderSvg} width={size + 'px'} height={size + 'px'} alt='EndPoint Folder Icon' />
 }
 
 export { EndPointFolderIcon }

--- a/packages/hawtio/src/plugins/camel/icons/EndpointIcon.tsx
+++ b/packages/hawtio/src/plugins/camel/icons/EndpointIcon.tsx
@@ -2,12 +2,7 @@ import React from 'react'
 import endpointSvg from './svg/endpoint-node.svg'
 
 const EndPointIcon = ({ size = 16 }) => {
-  return (
-    <img src={endpointSvg}
-         width={size + 'px'} height={size + 'px'}
-         alt="EndPoint Icon"
-    />
-  )
+  return <img src={endpointSvg} width={size + 'px'} height={size + 'px'} alt='EndPoint Icon' />
 }
 
 export { EndPointIcon }

--- a/packages/hawtio/src/plugins/camel/icons/RouteIcon.tsx
+++ b/packages/hawtio/src/plugins/camel/icons/RouteIcon.tsx
@@ -2,12 +2,7 @@ import React from 'react'
 import routeSvg from './svg/camel-route.svg'
 
 const RouteIcon = ({ size = 16 }) => {
-  return (
-    <img src={routeSvg}
-         width={size + 'px'} height={size + 'px'}
-         alt="Route Icon"
-    />
-  )
+  return <img src={routeSvg} width={size + 'px'} height={size + 'px'} alt='Route Icon' />
 }
 
 export { RouteIcon }

--- a/packages/hawtio/src/plugins/camel/tree-processor.ts
+++ b/packages/hawtio/src/plugins/camel/tree-processor.ts
@@ -8,31 +8,31 @@ import { CamelIcon, EndPointFolderIcon, EndPointIcon, RouteIcon } from './icons'
 // Fetch the camel version and add it to the tree
 // to avoid making a blocking call elsewhere
 //
-function retrieveCamelVersion(contextNode: MBeanNode|null) {
-  if (! contextNode) return
+function retrieveCamelVersion(contextNode: MBeanNode | null) {
+  if (!contextNode) return
 
-  if (! contextNode.objectName) {
+  if (!contextNode.objectName) {
     contextNode.addProperty('version', 'Camel Version not available')
     return
   }
 
   jolokiaService.read(contextNode.objectName, 'CamelVersion').then((response: unknown) => {
-    contextNode.addProperty('version', (response as string))
+    contextNode.addProperty('version', response as string)
   })
 }
 
-function adoptChild(parent: MBeanNode|null, child: MBeanNode|null, type: string, childIcon: React.ReactNode) {
-  if (! parent || ! child) return
+function adoptChild(parent: MBeanNode | null, child: MBeanNode | null, type: string, childIcon: React.ReactNode) {
+  if (!parent || !child) return
 
   parent.adopt(child)
   child.setIcons(childIcon)
   child.addProperty('type', type)
 }
 
-function setChildIcon(node: MBeanNode|null, childIcon: React.ReactNode) {
-  if (! node) return
+function setChildIcon(node: MBeanNode | null, childIcon: React.ReactNode) {
+  if (!node) return
 
-  node.getChildren().forEach((child) => {
+  node.getChildren().forEach(child => {
     child.setIcons(childIcon)
   })
 }
@@ -91,11 +91,19 @@ export function processTreeDomain(domainNode: MBeanNode) {
     // context/routes/endpoints/components/dataformats as MBeans
     //
     const mBeansNode = (newCtxNode as MBeanNode).getOrCreate('~MBeans', true)
-    context.getChildren()
-      .filter(child =>
-        !(child.name === 'context' || child.name === 'routes' || child.name === 'endpoints'
-                || child.name === 'components' || child.name === 'dataformats'))
-        .forEach(child => mBeansNode.adopt(child))
+    context
+      .getChildren()
+      .filter(
+        child =>
+          !(
+            child.name === 'context' ||
+            child.name === 'routes' ||
+            child.name === 'endpoints' ||
+            child.name === 'components' ||
+            child.name === 'dataformats'
+          ),
+      )
+      .forEach(child => mBeansNode.adopt(child))
 
     mBeansNode.sort(false)
 

--- a/packages/hawtio/src/plugins/connect/Connect.tsx
+++ b/packages/hawtio/src/plugins/connect/Connect.tsx
@@ -1,4 +1,27 @@
-import { Button, ButtonVariant, DataList, DataListAction, DataListCell, DataListItem, DataListItemCells, DataListItemRow, Dropdown, DropdownItem, DropdownPosition, ExpandableSection, KebabToggle, Modal, ModalVariant, PageSection, PageSectionVariants, Text, TextContent, Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core'
+import {
+  Button,
+  ButtonVariant,
+  DataList,
+  DataListAction,
+  DataListCell,
+  DataListItem,
+  DataListItemCells,
+  DataListItemRow,
+  Dropdown,
+  DropdownItem,
+  DropdownPosition,
+  ExpandableSection,
+  KebabToggle,
+  Modal,
+  ModalVariant,
+  PageSection,
+  PageSectionVariants,
+  Text,
+  TextContent,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
+} from '@patternfly/react-core'
 import { OutlinedQuestionCircleIcon, PluggedIcon, PlusIcon, UnpluggedIcon } from '@patternfly/react-icons'
 import React, { useContext, useEffect, useState } from 'react'
 import { connectService } from './connect-service'
@@ -20,32 +43,42 @@ export const Connect: React.FunctionComponent = () => {
         </Text>
       }
     >
-      <Text component="p">
-        This page allows you to connect to remote processes which <strong>already have a
-          <a href="https://jolokia.org/agent.html" target="_blank" rel="noreferrer">Jolokia agent</a> running inside them</strong>.
-        You will need to know the host name, port and path of the Jolokia agent to be able to connect.
+      <Text component='p'>
+        This page allows you to connect to remote processes which{' '}
+        <strong>
+          already have a
+          <a href='https://jolokia.org/agent.html' target='_blank' rel='noreferrer'>
+            Jolokia agent
+          </a>{' '}
+          running inside them
+        </strong>
+        . You will need to know the host name, port and path of the Jolokia agent to be able to connect.
       </Text>
-      <Text component="p">
+      <Text component='p'>
         If the process you wish to connect to does not have a Jolokia agent inside, please refer to the
-        <a href="http://jolokia.org/agent.html" target="_blank" rel="noreferrer">Jolokia documentation</a> for how to add a JVM,
-        servlet or OSGi based agent inside it.
+        <a href='http://jolokia.org/agent.html' target='_blank' rel='noreferrer'>
+          Jolokia documentation
+        </a>{' '}
+        for how to add a JVM, servlet or OSGi based agent inside it.
       </Text>
-      <Text component="p">
-        If you are using <a href="https://developers.redhat.com/products/fuse/overview/" target="_blank" rel="noreferrer">Red Hat Fuse</a>
-        or <a href="http://activemq.apache.org/" target="_blank" rel="noreferrer">Apache ActiveMQ</a>,
-        then a Jolokia agent is included by default (use context path of Jolokia agent, usually
-        <code>jolokia</code>). Or you can always just deploy hawtio inside the process (which includes the Jolokia agent,
-        use Jolokia servlet mapping inside hawtio context path, usually <code>hawtio/jolokia</code>).
+      <Text component='p'>
+        If you are using{' '}
+        <a href='https://developers.redhat.com/products/fuse/overview/' target='_blank' rel='noreferrer'>
+          Red Hat Fuse
+        </a>
+        or{' '}
+        <a href='http://activemq.apache.org/' target='_blank' rel='noreferrer'>
+          Apache ActiveMQ
+        </a>
+        , then a Jolokia agent is included by default (use context path of Jolokia agent, usually
+        <code>jolokia</code>). Or you can always just deploy hawtio inside the process (which includes the Jolokia
+        agent, use Jolokia servlet mapping inside hawtio context path, usually <code>hawtio/jolokia</code>).
       </Text>
     </ExpandableSection>
   )
 
   const ConnectionList = () => (
-    <DataList
-      id="connection-list"
-      aria-label="connection list"
-      isCompact
-    >
+    <DataList id='connection-list' aria-label='connection list' isCompact>
       {Object.entries(connections).map(([name, connection]) => (
         <ConnectionItem key={name} name={name} connection={connection} />
       ))}
@@ -56,7 +89,7 @@ export const Connect: React.FunctionComponent = () => {
     <ConnectContext.Provider value={{ connections, dispatch }}>
       <PageSection variant={PageSectionVariants.light}>
         <TextContent>
-          <Text component="h1">Connect</Text>
+          <Text component='h1'>Connect</Text>
           <ConnectHint />
         </TextContent>
       </PageSection>
@@ -78,7 +111,7 @@ const ConnectToolbar: React.FunctionComponent = () => {
     scheme: 'http',
     host: '',
     port: 8080,
-    path: '/hawtio/jolokia'
+    path: '/hawtio/jolokia',
   }
 
   const handleAddToggle = () => {
@@ -90,39 +123,31 @@ const ConnectToolbar: React.FunctionComponent = () => {
   }
 
   return (
-    <Toolbar id="connect-toolbar">
+    <Toolbar id='connect-toolbar'>
       <ToolbarContent>
         <ToolbarItem>
-          <Button
-            variant={ButtonVariant.secondary}
-            onClick={handleAddToggle}
-          >
+          <Button variant={ButtonVariant.secondary} onClick={handleAddToggle}>
             <PlusIcon /> Add connection
           </Button>
         </ToolbarItem>
         <ToolbarItem>
           <Dropdown
-            key="connect-toolbar-dropdown"
+            key='connect-toolbar-dropdown'
             isPlain
             isOpen={isDropdownOpen}
             toggle={<KebabToggle onToggle={() => setIsDropdownOpen(!isDropdownOpen)} />}
             dropdownItems={[
-              <DropdownItem key="connect-toolbar-dropdown-import" isDisabled>
+              <DropdownItem key='connect-toolbar-dropdown-import' isDisabled>
                 Import connections
               </DropdownItem>,
-              <DropdownItem key="connect-toolbar-dropdown-export" onClick={exportConnections}>
+              <DropdownItem key='connect-toolbar-dropdown-export' onClick={exportConnections}>
                 Export connections
               </DropdownItem>,
             ]}
           />
         </ToolbarItem>
       </ToolbarContent>
-      <ConnectModal
-        mode="add"
-        isOpen={isAddOpen}
-        onClose={handleAddToggle}
-        input={initialConnection}
-      />
+      <ConnectModal mode='add' isOpen={isAddOpen} onClose={handleAddToggle} input={initialConnection} />
     </Toolbar>
   )
 }
@@ -142,8 +167,7 @@ const ConnectionItem: React.FunctionComponent<ConnectionItemProps> = props => {
 
   useEffect(() => {
     const check = () => {
-      connectService.checkReachable(connection)
-        .then(result => setReachable(result))
+      connectService.checkReachable(connection).then(result => setReachable(result))
     }
     check() // initial fire
     const timer = setInterval(check, 20000)
@@ -179,17 +203,17 @@ const ConnectionItem: React.FunctionComponent<ConnectionItemProps> = props => {
   const ConfirmDeleteModal = () => (
     <Modal
       variant={ModalVariant.small}
-      title="Delete Connection"
-      titleIconVariant="danger"
+      title='Delete Connection'
+      titleIconVariant='danger'
       isOpen={isConfirmDeleteOpen}
       onClose={handleConfirmDeleteToggle}
       actions={[
-        <Button key="delete" variant="danger" onClick={deleteConnection}>
+        <Button key='delete' variant='danger' onClick={deleteConnection}>
           Delete
         </Button>,
-        <Button key="cancel" variant="link" onClick={handleConfirmDeleteToggle}>
+        <Button key='cancel' variant='link' onClick={handleConfirmDeleteToggle}>
           Cancel
-        </Button>
+        </Button>,
       ]}
     >
       You are about to delete the <b>{name}</b> connection.
@@ -202,14 +226,14 @@ const ConnectionItem: React.FunctionComponent<ConnectionItemProps> = props => {
         <DataListItemCells
           dataListCells={[
             <DataListCell key={`connection-cell-icon-${name}`} isIcon>
-              {reachable ? <PluggedIcon color="green" /> : <UnpluggedIcon color="red" />}
+              {reachable ? <PluggedIcon color='green' /> : <UnpluggedIcon color='red' />}
             </DataListCell>,
             <DataListCell key={`connection-cell-name-${name}`}>
               <b>{name}</b>
             </DataListCell>,
             <DataListCell key={`connection-cell-url-${name}`} width={3}>
               {connectService.connectionToUrl(connection)}
-            </DataListCell>
+            </DataListCell>,
           ]}
         />
         <DataListAction
@@ -219,7 +243,7 @@ const ConnectionItem: React.FunctionComponent<ConnectionItemProps> = props => {
         >
           <Button
             key={`connection-action-connect-${name}`}
-            variant="primary"
+            variant='primary'
             onClick={connect}
             isDisabled={!reachable}
             isSmall
@@ -233,16 +257,10 @@ const ConnectionItem: React.FunctionComponent<ConnectionItemProps> = props => {
             isOpen={isDropdownOpen}
             toggle={<KebabToggle onToggle={handleDropdownToggle} />}
             dropdownItems={[
-              <DropdownItem
-                key={`connection-action-edit-${name}`}
-                onClick={handleEditToggle}
-              >
+              <DropdownItem key={`connection-action-edit-${name}`} onClick={handleEditToggle}>
                 Edit
               </DropdownItem>,
-              <DropdownItem
-                key={`connection-action-delete-${name}`}
-                onClick={handleConfirmDeleteToggle}
-              >
+              <DropdownItem key={`connection-action-delete-${name}`} onClick={handleConfirmDeleteToggle}>
                 Delete
               </DropdownItem>,
             ]}
@@ -250,12 +268,7 @@ const ConnectionItem: React.FunctionComponent<ConnectionItemProps> = props => {
           <ConfirmDeleteModal />
         </DataListAction>
       </DataListItemRow>
-      <ConnectModal
-        mode="edit"
-        isOpen={isEditOpen}
-        onClose={handleEditToggle}
-        input={connection}
-      />
+      <ConnectModal mode='edit' isOpen={isEditOpen} onClose={handleEditToggle} input={connection} />
     </DataListItem>
   )
 }

--- a/packages/hawtio/src/plugins/connect/ConnectModal.tsx
+++ b/packages/hawtio/src/plugins/connect/ConnectModal.tsx
@@ -1,5 +1,17 @@
 import { isBlank } from '@hawtio/util/strings'
-import { ActionGroup, Button, ButtonVariant, Form, FormGroup, HelperText, HelperTextItem, Modal, ModalVariant, Switch, TextInput } from '@patternfly/react-core'
+import {
+  ActionGroup,
+  Button,
+  ButtonVariant,
+  Form,
+  FormGroup,
+  HelperText,
+  HelperTextItem,
+  Modal,
+  ModalVariant,
+  Switch,
+  TextInput,
+} from '@patternfly/react-core'
 import { ExclamationCircleIcon } from '@patternfly/react-icons'
 import React, { useContext, useState } from 'react'
 import { ConnectionTestResult, connectService } from './connect-service'
@@ -129,84 +141,81 @@ export const ConnectModal: React.FunctionComponent<ConnectModalProps> = props =>
       isOpen={isOpen}
       onClose={clear}
       actions={[
-        <Button key="save" variant={ButtonVariant.primary} form="connection-form" onClick={save}>
+        <Button key='save' variant={ButtonVariant.primary} form='connection-form' onClick={save}>
           {mode === 'add' ? 'Add' : 'Save'}
         </Button>,
-        <Button key="cancel" variant={ButtonVariant.link} onClick={clear}>
+        <Button key='cancel' variant={ButtonVariant.link} onClick={clear}>
           Cancel
-        </Button>
-      ]}>
-      <Form id="connection-form" isHorizontal>
+        </Button>,
+      ]}
+    >
+      <Form id='connection-form' isHorizontal>
         <FormGroup
-          label="Name"
+          label='Name'
           isRequired
-          fieldId="connection-form-name"
+          fieldId='connection-form-name'
           helperTextInvalid={validations.name.text}
           helperTextInvalidIcon={<ExclamationCircleIcon />}
           validated={validations.name.validated}
         >
           <TextInput
             isRequired
-            id="connection-form-name"
-            name="connection-form-name"
+            id='connection-form-name'
+            name='connection-form-name'
             value={connection.name}
             onChange={name => setConnection({ ...connection, name })}
             validated={validations.name.validated}
           />
         </FormGroup>
-        <FormGroup
-          label="Scheme"
-          isRequired
-          fieldId="connection-form-scheme"
-        >
+        <FormGroup label='Scheme' isRequired fieldId='connection-form-scheme'>
           <Switch
-            id="connection-form-scheme"
-            label="HTTPS"
-            labelOff="HTTP"
+            id='connection-form-scheme'
+            label='HTTPS'
+            labelOff='HTTP'
             isChecked={connection.scheme === 'https'}
             onChange={https => setConnection({ ...connection, scheme: https ? 'https' : 'http' })}
           />
         </FormGroup>
         <FormGroup
-          label="Host"
+          label='Host'
           isRequired
-          fieldId="connection-form-host"
+          fieldId='connection-form-host'
           helperTextInvalid={validations.host.text}
           helperTextInvalidIcon={<ExclamationCircleIcon />}
           validated={validations.host.validated}
         >
           <TextInput
             isRequired
-            id="connection-form-host"
-            name="connection-form-host"
+            id='connection-form-host'
+            name='connection-form-host'
             value={connection.host}
             onChange={host => setConnection({ ...connection, host })}
             validated={validations.host.validated}
           />
         </FormGroup>
         <FormGroup
-          label="Port"
+          label='Port'
           isRequired
-          fieldId="connection-form-port"
+          fieldId='connection-form-port'
           helperTextInvalid={validations.port.text}
           helperTextInvalidIcon={<ExclamationCircleIcon />}
           validated={validations.port.validated}
         >
           <TextInput
             isRequired
-            type="number"
-            id="connection-form-port"
-            name="connection-form-port"
+            type='number'
+            id='connection-form-port'
+            name='connection-form-port'
             value={connection.port}
             onChange={port => setConnection({ ...connection, port: parseInt(port) })}
             validated={validations.port.validated}
           />
         </FormGroup>
-        <FormGroup label="Path" isRequired fieldId="connection-form-path">
+        <FormGroup label='Path' isRequired fieldId='connection-form-path'>
           <TextInput
             isRequired
-            id="connection-form-path"
-            name="connection-form-path"
+            id='connection-form-path'
+            name='connection-form-path'
             value={connection.path}
             onChange={path => setConnection({ ...connection, path })}
           />
@@ -215,15 +224,13 @@ export const ConnectModal: React.FunctionComponent<ConnectModalProps> = props =>
           <Button variant={ButtonVariant.secondary} onClick={test} isSmall>
             Test connection
           </Button>
-          {validations.test ?
+          {validations.test ? (
             <HelperText>
               <HelperTextItem variant={validations.test.ok ? 'success' : 'error'} hasIcon>
                 {validations.test.message}
               </HelperTextItem>
             </HelperText>
-            :
-            null
-          }
+          ) : null}
         </ActionGroup>
       </Form>
     </Modal>

--- a/packages/hawtio/src/plugins/connect/ConnectPreferences.tsx
+++ b/packages/hawtio/src/plugins/connect/ConnectPreferences.tsx
@@ -15,14 +15,11 @@ export const ConnectPreferences: React.FunctionComponent = () => {
   const [maxDepth, setMaxDepth] = useState(DEFAULT_MAX_DEPTH)
   const [maxCollectionSize, setMaxCollectionSize] = useState(DEFAULT_MAX_COLLECTION_SIZE)
 
-  const onUpdateRateChanged = (updateRate: string) =>
-    setUpdateRate(parseInt(updateRate))
+  const onUpdateRateChanged = (updateRate: string) => setUpdateRate(parseInt(updateRate))
 
-  const onMaxDepthChanged = (maxDepth: string) =>
-    setMaxDepth(parseInt(maxDepth))
+  const onMaxDepthChanged = (maxDepth: string) => setMaxDepth(parseInt(maxDepth))
 
-  const onMaxCollectionSizeChanged = (maxCollectionSize: string) =>
-    setMaxCollectionSize(parseInt(maxCollectionSize))
+  const onMaxCollectionSizeChanged = (maxCollectionSize: string) => setMaxCollectionSize(parseInt(maxCollectionSize))
 
   const applyJolokia = () => {
     // TODO: impl
@@ -35,59 +32,40 @@ export const ConnectPreferences: React.FunctionComponent = () => {
   }
 
   const JolokiaForm = () => (
-    <FormSection title="Jolokia" titleElement="h2">
-      <FormGroup
-        label="Update rate"
-        fieldId="jolokia-form-update-rate"
-      >
+    <FormSection title='Jolokia' titleElement='h2'>
+      <FormGroup label='Update rate' fieldId='jolokia-form-update-rate'>
         <TextInput
-          id="jolokia-form-update-rate-input"
-          type="number"
+          id='jolokia-form-update-rate-input'
+          type='number'
           value={updateRate}
           onChange={onUpdateRateChanged}
         />
       </FormGroup>
-      <FormGroup
-        label="Max depth"
-        fieldId="jolokia-form-max-depth"
-      >
-        <TextInput
-          id="jolokia-form-max-depth-input"
-          type="number"
-          value={maxDepth}
-          onChange={onMaxDepthChanged}
-        />
+      <FormGroup label='Max depth' fieldId='jolokia-form-max-depth'>
+        <TextInput id='jolokia-form-max-depth-input' type='number' value={maxDepth} onChange={onMaxDepthChanged} />
       </FormGroup>
-      <FormGroup
-        label="Max collection size"
-        fieldId="jolokia-form-max-collection-size"
-      >
+      <FormGroup label='Max collection size' fieldId='jolokia-form-max-collection-size'>
         <TextInput
-          id="jolokia-form-max-collection-size-input"
-          type="number"
+          id='jolokia-form-max-collection-size-input'
+          type='number'
           value={maxCollectionSize}
           onChange={onMaxCollectionSizeChanged}
         />
       </FormGroup>
-      <FormGroup
-        fieldId="jolokia-form-apply"
-        helperText="Restart Hawtio with the new values in effect."
-      >
-        <Button onClick={applyJolokia}>
-          Apply
-        </Button>
+      <FormGroup fieldId='jolokia-form-apply' helperText='Restart Hawtio with the new values in effect.'>
+        <Button onClick={applyJolokia}>Apply</Button>
       </FormGroup>
     </FormSection>
   )
 
   const ResetForm = () => (
-    <FormSection title="Reset" titleElement="h2">
+    <FormSection title='Reset' titleElement='h2'>
       <FormGroup
-        label="Clear saved connections"
-        fieldId="reset-form-clear"
+        label='Clear saved connections'
+        fieldId='reset-form-clear'
         helperText="Clear all saved connection settings stored in your browser's local storage."
       >
-        <Button variant="danger" onClick={reset}>
+        <Button variant='danger' onClick={reset}>
           Clear
         </Button>
       </FormGroup>

--- a/packages/hawtio/src/plugins/connect/connect-service.ts
+++ b/packages/hawtio/src/plugins/connect/connect-service.ts
@@ -40,7 +40,7 @@ class ConnectService implements IConnectService {
     // Check remote connection from URL query param
     const url = new URL(window.location.href)
     const searchParams = url.searchParams
-    log.debug("Checking search params:", searchParams.toString())
+    log.debug('Checking search params:', searchParams.toString())
     let conn = searchParams.get(PARAM_KEY_CONNECTION)
     if (conn) {
       sessionStorage.setItem(STORAGE_KEY_CURRENT_CONNECTION, JSON.stringify(conn))
@@ -109,8 +109,9 @@ class ConnectService implements IConnectService {
                 default:
                   resolve({ ok: false, message: 'Connection failed' })
               }
-            }
-          })
+            },
+          },
+        )
       } catch (error) {
         log.error(error)
         reject(error)
@@ -136,14 +137,14 @@ class ConnectService implements IConnectService {
         method: 'post',
         mimeType: 'application/json',
         username: connection.username,
-        password: connection.password
+        password: connection.password,
       })
     }
 
     return new Jolokia({
       url: this.getJolokiaUrl(connection),
       method: 'post',
-      mimeType: 'application/json'
+      mimeType: 'application/json',
     })
   }
 
@@ -151,9 +152,9 @@ class ConnectService implements IConnectService {
    * Get the Jolokia URL for the given connection.
    */
   getJolokiaUrl(connection: Connection): string {
-    log.debug("Connect to server with connection:", toString(connection))
+    log.debug('Connect to server with connection:', toString(connection))
     if (connection.jolokiaUrl) {
-      log.debug("Using provided URL:", connection.jolokiaUrl)
+      log.debug('Using provided URL:', connection.jolokiaUrl)
       return connection.jolokiaUrl
     }
 
@@ -163,8 +164,9 @@ class ConnectService implements IConnectService {
       connection.scheme || 'http',
       connection.host || 'localhost',
       String(connection.port || 80),
-      connection.path)
-    log.debug("Using URL:", url)
+      connection.path,
+    )
+    log.debug('Using URL:', url)
     return url
   }
 
@@ -182,7 +184,7 @@ class ConnectService implements IConnectService {
       return response.responseJSON['reason'] === reason
     }
     // Otherwise expect a response header containing a forbidden reason
-    return response.getResponseHeader("Hawtio-Forbidden-Reason") === reason
+    return response.getResponseHeader('Hawtio-Forbidden-Reason') === reason
   }
 
   export(connections: Connections) {

--- a/packages/hawtio/src/plugins/connect/connections.ts
+++ b/packages/hawtio/src/plugins/connect/connections.ts
@@ -22,9 +22,9 @@ export const DELETE = 'DELETE'
 export const RESET = 'RESET'
 
 export type ConnectionsAction =
-  | { type: typeof ADD, connection: Connection }
-  | { type: typeof UPDATE, name: string, connection: Connection }
-  | { type: typeof DELETE, name: string }
+  | { type: typeof ADD; connection: Connection }
+  | { type: typeof UPDATE; name: string; connection: Connection }
+  | { type: typeof DELETE; name: string }
   | { type: typeof RESET }
 
 export function reducer(state: Connections, action: ConnectionsAction): Connections {
@@ -54,9 +54,9 @@ export function reducer(state: Connections, action: ConnectionsAction): Connecti
           // TODO: error handling
           return state
         } else {
-          return Object.fromEntries(Object.entries(state).map(([k, v]) =>
-            k === name ? [connection.name, connection] : [k, v]
-          ))
+          return Object.fromEntries(
+            Object.entries(state).map(([k, v]) => (k === name ? [connection.name, connection] : [k, v])),
+          )
         }
       }
     }

--- a/packages/hawtio/src/plugins/connect/context.ts
+++ b/packages/hawtio/src/plugins/connect/context.ts
@@ -22,5 +22,7 @@ type ConnectContext = {
 
 export const ConnectContext = createContext<ConnectContext>({
   connections: {},
-  dispatch: () => { /* no-op */ }
+  dispatch: () => {
+    /* no-op */
+  },
 })

--- a/packages/hawtio/src/plugins/connect/help.md
+++ b/packages/hawtio/src/plugins/connect/help.md
@@ -2,7 +2,7 @@
 
 The Connect tab allows you to connect to local and remote Jolokia instances so you can examine JVMs.
 
-The "Remote" sub-tab is used to manually add connection details for a Jolokia instance.  You can store connection details and quickly recall the details of a connection and connect.
+The "Remote" sub-tab is used to manually add connection details for a Jolokia instance. You can store connection details and quickly recall the details of a connection and connect.
 
 The use proxy option should often be enabled, as Hawtio is running in your browser; usually due to CORS; you cannot open a different host or port from your browser (due to browse security restrictions); so we have to use a proxy servlet inside the Hawtio web app to proxy all requests for a different jolokia server - so we can communicate with a different jolokia agent.
 

--- a/packages/hawtio/src/plugins/jmx/Jmx.tsx
+++ b/packages/hawtio/src/plugins/jmx/Jmx.tsx
@@ -1,4 +1,12 @@
-import { EmptyState, EmptyStateIcon, EmptyStateVariant, PageSection, PageSectionVariants, Spinner, Title } from '@patternfly/react-core'
+import {
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  PageSection,
+  PageSectionVariants,
+  Spinner,
+  Title,
+} from '@patternfly/react-core'
 import { CubesIcon } from '@patternfly/react-icons'
 import React from 'react'
 import Split from 'react-split'
@@ -13,7 +21,7 @@ export const Jmx: React.FunctionComponent = () => {
   if (!loaded) {
     return (
       <PageSection>
-        <Spinner isSVG aria-label="Loading MBean tree" />
+        <Spinner isSVG aria-label='Loading MBean tree' />
       </PageSection>
     )
   }
@@ -23,7 +31,9 @@ export const Jmx: React.FunctionComponent = () => {
       <PageSection variant={PageSectionVariants.light}>
         <EmptyState variant={EmptyStateVariant.full}>
           <EmptyStateIcon icon={CubesIcon} />
-          <Title headingLevel="h1" size="lg">No MBeans found</Title>
+          <Title headingLevel='h1' size='lg'>
+            No MBeans found
+          </Title>
         </EmptyState>
       </PageSection>
     )
@@ -31,12 +41,7 @@ export const Jmx: React.FunctionComponent = () => {
 
   return (
     <MBeanTreeContext.Provider value={{ tree, node, setNode }}>
-      <Split
-        className="jmx-split"
-        sizes={[30, 70]}
-        minSize={200}
-        gutterSize={5}
-      >
+      <Split className='jmx-split' sizes={[30, 70]} minSize={200} gutterSize={5}>
         <div>
           <JmxTreeView />
         </div>

--- a/packages/hawtio/src/plugins/jmx/JmxContent.tsx
+++ b/packages/hawtio/src/plugins/jmx/JmxContent.tsx
@@ -1,8 +1,23 @@
-import { Card, CardBody, EmptyState, EmptyStateIcon, EmptyStateVariant, Nav, NavItem, NavList, PageGroup, PageNavigation, PageSection, PageSectionVariants, Text, Title } from '@patternfly/react-core'
+import {
+  Card,
+  CardBody,
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  Nav,
+  NavItem,
+  NavList,
+  PageGroup,
+  PageNavigation,
+  PageSection,
+  PageSectionVariants,
+  Text,
+  Title,
+} from '@patternfly/react-core'
 import { CubesIcon, InfoCircleIcon } from '@patternfly/react-icons'
 import { OnRowClick, Table, TableBody, TableHeader, TableProps } from '@patternfly/react-table'
 import React, { useContext } from 'react'
-import { NavLink,Navigate, Route, Routes, useLocation } from 'react-router-dom'
+import { NavLink, Navigate, Route, Routes, useLocation } from 'react-router-dom'
 import { Attributes } from './attributes/Attributes'
 import { Chart } from './chart/Chart'
 import { MBeanTreeContext } from './context'
@@ -17,7 +32,9 @@ export const JmxContent: React.FunctionComponent = () => {
       <PageSection variant={PageSectionVariants.light} isFilled>
         <EmptyState variant={EmptyStateVariant.full}>
           <EmptyStateIcon icon={CubesIcon} />
-          <Title headingLevel="h1" size="lg">Select MBean</Title>
+          <Title headingLevel='h1' size='lg'>
+            Select MBean
+          </Title>
         </EmptyState>
       </PageSection>
     )
@@ -30,46 +47,40 @@ export const JmxContent: React.FunctionComponent = () => {
   ]
 
   const mbeanNav = (
-    <Nav aria-label="MBean Nav" variant="tertiary">
+    <Nav aria-label='MBean Nav' variant='tertiary'>
       <NavList>
-        {navItems.map(nav =>
-          <NavItem key={nav.id} isActive={pathname ===nav.id}>
+        {navItems.map(nav => (
+          <NavItem key={nav.id} isActive={pathname === nav.id}>
             <NavLink to={{ pathname: nav.id, search }}>{nav.title}</NavLink>
           </NavItem>
-        )}
+        ))}
       </NavList>
     </Nav>
   )
 
-  const mbeanRoutes = navItems.map(nav =>
+  const mbeanRoutes = navItems.map(nav => (
     <Route key={nav.id} path={nav.id} element={React.createElement(nav.component)} />
-  )
+  ))
 
   return (
     <React.Fragment>
       <PageGroup>
         <PageSection variant={PageSectionVariants.light}>
-          <Title headingLevel="h1">{node.name}</Title>
-          <Text component="small">{node.objectName}</Text>
+          <Title headingLevel='h1'>{node.name}</Title>
+          <Text component='small'>{node.objectName}</Text>
         </PageSection>
-        {node.objectName &&
-          <PageNavigation>
-            {mbeanNav}
-          </PageNavigation>
-        }
+        {node.objectName && <PageNavigation>{mbeanNav}</PageNavigation>}
       </PageGroup>
       <PageSection>
-        {node.objectName &&
+        {node.objectName && (
           <React.Fragment>
             <Routes>
               {mbeanRoutes}
-              <Route key="root" path="/" element={<Navigate to={"attributes"}/>}/>
+              <Route key='root' path='/' element={<Navigate to={'attributes'} />} />
             </Routes>
           </React.Fragment>
-        }
-        {!node.objectName &&
-          <JmxContentMBeans />
-        }
+        )}
+        {!node.objectName && <JmxContentMBeans />}
       </PageSection>
     </React.Fragment>
   )
@@ -83,14 +94,13 @@ const JmxContentMBeans: React.FunctionComponent = () => {
   }
 
   const columns: TableProps['cells'] = ['MBean', 'Object Name']
-  const rows: TableProps['rows'] = (node.children || [])
-    .map(child => [child.name, child.objectName || '-'])
+  const rows: TableProps['rows'] = (node.children || []).map(child => [child.name, child.objectName || '-'])
 
   if (rows.length === 0) {
     return (
       <Card>
         <CardBody>
-          <Text component="p">
+          <Text component='p'>
             <InfoCircleIcon /> This node has no MBeans.
           </Text>
         </CardBody>
@@ -108,12 +118,7 @@ const JmxContentMBeans: React.FunctionComponent = () => {
 
   return (
     <Card isFullHeight>
-      <Table
-        aria-label="MBeans"
-        variant="compact"
-        cells={columns}
-        rows={rows}
-      >
+      <Table aria-label='MBeans' variant='compact' cells={columns} rows={rows}>
         <TableHeader />
         <TableBody onRowClick={selectChild} />
       </Table>

--- a/packages/hawtio/src/plugins/jmx/JmxTreeView.tsx
+++ b/packages/hawtio/src/plugins/jmx/JmxTreeView.tsx
@@ -20,16 +20,12 @@ export const JmxTreeView: React.FunctionComponent = () => {
 
   return (
     <TreeView
-      id="jmx-tree-view"
+      id='jmx-tree-view'
       data={tree.getTree()}
       hasGuides={true}
       allExpanded={expanded}
       onSelect={onSelect}
-      toolbar={
-        <PluginTreeViewToolbar
-          onSearch={onSearch}
-          onSetExpanded={setExpanded}
-        />}
+      toolbar={<PluginTreeViewToolbar onSearch={onSearch} onSetExpanded={setExpanded} />}
     />
   )
 }

--- a/packages/hawtio/src/plugins/jmx/attributes/AttributeModal.tsx
+++ b/packages/hawtio/src/plugins/jmx/attributes/AttributeModal.tsx
@@ -1,4 +1,13 @@
-import { Button, ClipboardCopy, Form, FormGroup, Modal, ModalVariant, TextArea, TextInput } from '@patternfly/react-core'
+import {
+  Button,
+  ClipboardCopy,
+  Form,
+  FormGroup,
+  Modal,
+  ModalVariant,
+  TextArea,
+  TextInput,
+} from '@patternfly/react-core'
 import React, { useContext, useEffect, useState } from 'react'
 import { MBeanTreeContext } from '../context'
 import { attributeService } from './attribute-service'
@@ -6,7 +15,7 @@ import { attributeService } from './attribute-service'
 export type AttributeModalProps = {
   isOpen: boolean
   onClose: () => void
-  input: { name: string, value: string }
+  input: { name: string; value: string }
 }
 
 export const AttributeModal: React.FunctionComponent<AttributeModalProps> = props => {
@@ -46,62 +55,36 @@ export const AttributeModal: React.FunctionComponent<AttributeModalProps> = prop
       isOpen={isOpen}
       onClose={onClose}
       actions={[
-        <Button key="close" onClick={onClose}>
+        <Button key='close' onClick={onClose}>
           Close
-        </Button>
-      ]}>
-      <Form id="attribute-form" isHorizontal>
-        <FormGroup
-          label="Name"
-          fieldId="attribute-form-name"
-        >
-          <TextInput
-            id="attribute-form-name"
-            name="attribute-form-name"
-            value={name}
-            readOnlyVariant="default"
-          />
+        </Button>,
+      ]}
+    >
+      <Form id='attribute-form' isHorizontal>
+        <FormGroup label='Name' fieldId='attribute-form-name'>
+          <TextInput id='attribute-form-name' name='attribute-form-name' value={name} readOnlyVariant='default' />
         </FormGroup>
-        <FormGroup
-          label="Description"
-          fieldId="attribute-form-description"
-        >
+        <FormGroup label='Description' fieldId='attribute-form-description'>
           <TextArea
-            id="attribute-form-description"
-            name="attribute-form-description"
+            id='attribute-form-description'
+            name='attribute-form-description'
             value={attribute.desc}
-            readOnlyVariant="default"
+            readOnlyVariant='default'
           />
         </FormGroup>
-        <FormGroup
-          label="Type"
-          fieldId="attribute-form-type"
-        >
+        <FormGroup label='Type' fieldId='attribute-form-type'>
           <TextInput
-            id="attribute-form-type"
-            name="attribute-form-type"
+            id='attribute-form-type'
+            name='attribute-form-type'
             value={attribute.type}
-            readOnlyVariant="default"
+            readOnlyVariant='default'
           />
         </FormGroup>
-        <FormGroup
-          label="Jolokia URL"
-          fieldId="attribute-form-jolokia-url"
-        >
-          <ClipboardCopy isReadOnly>
-            {jolokiaUrl}
-          </ClipboardCopy>
+        <FormGroup label='Jolokia URL' fieldId='attribute-form-jolokia-url'>
+          <ClipboardCopy isReadOnly>{jolokiaUrl}</ClipboardCopy>
         </FormGroup>
-        <FormGroup
-          label="Value"
-          fieldId="attribute-form-value"
-        >
-          <TextInput
-            id="attribute-form-value"
-            name="attribute-form-value"
-            value={value}
-            readOnlyVariant="default"
-          />
+        <FormGroup label='Value' fieldId='attribute-form-value'>
+          <TextInput id='attribute-form-value' name='attribute-form-value' value={value} readOnlyVariant='default' />
         </FormGroup>
       </Form>
     </Modal>

--- a/packages/hawtio/src/plugins/jmx/attributes/Attributes.tsx
+++ b/packages/hawtio/src/plugins/jmx/attributes/Attributes.tsx
@@ -38,13 +38,10 @@ export const Attributes: React.FunctionComponent = () => {
     }
 
     const mbean = node.objectName
-    attributeService.register(
-      { type: 'read', mbean },
-      (response: IResponse) => {
-        log.debug('Scheduler - Attributes:', response.value)
-        setAttributes(response.value as AttributeValues)
-      },
-    )
+    attributeService.register({ type: 'read', mbean }, (response: IResponse) => {
+      log.debug('Scheduler - Attributes:', response.value)
+      setAttributes(response.value as AttributeValues)
+    })
 
     return () => attributeService.unregisterAll()
   }, [node])
@@ -57,22 +54,23 @@ export const Attributes: React.FunctionComponent = () => {
     return (
       <Card>
         <CardBody>
-          <Text component="p">Reading attributes...</Text>
+          <Text component='p'>Reading attributes...</Text>
         </CardBody>
       </Card>
     )
-
   }
 
   const columns: TableProps['cells'] = ['Attribute', 'Value']
-  const rows: TableProps['rows'] = Object.entries(attributes)
-    .map(([name, value]) => [name, isObject(value) ? JSON.stringify(value) : String(value)])
+  const rows: TableProps['rows'] = Object.entries(attributes).map(([name, value]) => [
+    name,
+    isObject(value) ? JSON.stringify(value) : String(value),
+  ])
 
   if (rows.length === 0) {
     return (
       <Card>
         <CardBody>
-          <Text component="p">
+          <Text component='p'>
             <InfoCircleIcon /> This MBean has no attributes.
           </Text>
         </CardBody>
@@ -93,20 +91,11 @@ export const Attributes: React.FunctionComponent = () => {
 
   return (
     <Card isFullHeight>
-      <Table
-        aria-label="Attributes"
-        variant="compact"
-        cells={columns}
-        rows={rows}
-      >
+      <Table aria-label='Attributes' variant='compact' cells={columns} rows={rows}>
         <TableHeader />
         <TableBody onRowClick={selectAttribute} />
       </Table>
-      <AttributeModal
-        isOpen={isModalOpen}
-        onClose={handleModalToggle}
-        input={selected}
-      />
+      <AttributeModal isOpen={isModalOpen} onClose={handleModalToggle} input={selected} />
     </Card>
   )
 }

--- a/packages/hawtio/src/plugins/jmx/attributes/attribute-service.ts
+++ b/packages/hawtio/src/plugins/jmx/attributes/attribute-service.ts
@@ -12,12 +12,12 @@ class AttributeService {
 
   async register(request: IRequest, callback: IResponseFn) {
     const handle = await jolokiaService.register(request, callback)
-    log.debug("Register handle:", handle)
+    log.debug('Register handle:', handle)
     this.handles.push(handle)
   }
 
   unregisterAll() {
-    log.debug("Unregister all handles:", this.handles)
+    log.debug('Unregister all handles:', this.handles)
     this.handles.forEach(handle => jolokiaService.unregister(handle))
     this.handles = []
   }

--- a/packages/hawtio/src/plugins/jmx/chart/Chart.tsx
+++ b/packages/hawtio/src/plugins/jmx/chart/Chart.tsx
@@ -1,4 +1,11 @@
-import { EmptyState, EmptyStateIcon, EmptyStateVariant, PageSection, PageSectionVariants, Title } from '@patternfly/react-core'
+import {
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  PageSection,
+  PageSectionVariants,
+  Title,
+} from '@patternfly/react-core'
 import { ClipboardCheckIcon } from '@patternfly/react-icons'
 import { useContext } from 'react'
 import { MBeanTreeContext } from '../context'
@@ -14,7 +21,9 @@ export const Chart: React.FunctionComponent = () => {
     <PageSection variant={PageSectionVariants.light} isFilled>
       <EmptyState variant={EmptyStateVariant.full}>
         <EmptyStateIcon icon={ClipboardCheckIcon} />
-        <Title headingLevel="h1" size="lg">Under construction</Title>
+        <Title headingLevel='h1' size='lg'>
+          Under construction
+        </Title>
       </EmptyState>
     </PageSection>
   )

--- a/packages/hawtio/src/plugins/jmx/context.ts
+++ b/packages/hawtio/src/plugins/jmx/context.ts
@@ -31,5 +31,7 @@ type MBeanTreeContext = {
 export const MBeanTreeContext = createContext<MBeanTreeContext>({
   tree: MBeanTree.createEmptyTree(pluginName),
   node: null,
-  setNode: () => { /* no-op */ }
+  setNode: () => {
+    /* no-op */
+  },
 })

--- a/packages/hawtio/src/plugins/jmx/operations/OperationForm.tsx
+++ b/packages/hawtio/src/plugins/jmx/operations/OperationForm.tsx
@@ -1,4 +1,26 @@
-import { ActionGroup, Button, Checkbox, ClipboardCopy, ClipboardCopyVariant, DataListAction, DataListCell, DataListContent, DataListItem, DataListItemCells, DataListItemRow, DataListToggle, Dropdown, DropdownItem, DropdownPosition, Form, FormGroup, KebabToggle, Text, TextInput, Title } from '@patternfly/react-core'
+import {
+  ActionGroup,
+  Button,
+  Checkbox,
+  ClipboardCopy,
+  ClipboardCopyVariant,
+  DataListAction,
+  DataListCell,
+  DataListContent,
+  DataListItem,
+  DataListItemCells,
+  DataListItemRow,
+  DataListToggle,
+  Dropdown,
+  DropdownItem,
+  DropdownPosition,
+  Form,
+  FormGroup,
+  KebabToggle,
+  Text,
+  TextInput,
+  Title,
+} from '@patternfly/react-core'
 import React, { useContext, useState } from 'react'
 import { MBeanTreeContext } from '../context'
 import { Operation } from './operation'
@@ -46,7 +68,7 @@ export const OperationForm: React.FunctionComponent<OperationFormProps> = props 
         </DataListCell>,
         <DataListCell key={`operation-cell-desc-${name}`} isFilled={false}>
           {operation.description}
-        </DataListCell>
+        </DataListCell>,
       ]}
     />
   )
@@ -64,16 +86,10 @@ export const OperationForm: React.FunctionComponent<OperationFormProps> = props 
         isOpen={isDropdownOpen}
         toggle={<KebabToggle onToggle={handleDropdownToggle} />}
         dropdownItems={[
-          <DropdownItem
-            key={`operation-action-copy-method-name-${name}`}
-            onClick={copyMethodName}
-          >
+          <DropdownItem key={`operation-action-copy-method-name-${name}`} onClick={copyMethodName}>
             Copy method name
           </DropdownItem>,
-          <DropdownItem
-            key={`operation-action-copy-jolokia-url-${name}`}
-            onClick={copyJolokiaURL}
-          >
+          <DropdownItem key={`operation-action-copy-jolokia-url-${name}`} onClick={copyJolokiaURL}>
             Copy Jolokia URL
           </DropdownItem>,
         ]}
@@ -82,26 +98,13 @@ export const OperationForm: React.FunctionComponent<OperationFormProps> = props 
   )
 
   return (
-    <DataListItem
-      key={`operation-${name}`}
-      aria-labelledby={`operation ${name}`}
-      isExpanded={isExpanded}
-    >
+    <DataListItem key={`operation-${name}`} aria-labelledby={`operation ${name}`} isExpanded={isExpanded}>
       <DataListItemRow>
-        <DataListToggle
-          onClick={handleToggle}
-          isExpanded={isExpanded}
-          id="ex-toggle1"
-          aria-controls="ex-expand1"
-        />
+        <DataListToggle onClick={handleToggle} isExpanded={isExpanded} id='ex-toggle1' aria-controls='ex-expand1' />
         <OperationCells />
         <OperationActions />
       </DataListItemRow>
-      <OperationFormContents
-        {...props}
-        objectName={objectName}
-        isExpanded={isExpanded}
-      />
+      <OperationFormContents {...props} objectName={objectName} isExpanded={isExpanded} />
     </DataListItem>
   )
 }
@@ -158,9 +161,7 @@ const OperationFormContents: React.FunctionComponent<OperationFormContentsProps>
     if (!result) {
       return false
     }
-    return result.startsWith('<!DOCTYPE html>')
-      || /^<table[^>]*>/.test(result)
-      || /^<ul[^>]*>/.test(result)
+    return result.startsWith('<!DOCTYPE html>') || /^<table[^>]*>/.test(result) || /^<ul[^>]*>/.test(result)
   }
 
   const argFormInput = (javaType: string, index: number) => {
@@ -174,9 +175,9 @@ const OperationFormContents: React.FunctionComponent<OperationFormContentsProps>
       case 'long':
       case 'java.lang.Integer':
       case 'java.lang.Long':
-        return <TextInput id={id} type="number" value={Number(value)} onChange={updateArgValues(index)} />
+        return <TextInput id={id} type='number' value={Number(value)} onChange={updateArgValues(index)} />
       default:
-        return <TextInput id={id} type="text" value={String(value)} onChange={updateArgValues(index)} />
+        return <TextInput id={id} type='text' value={String(value)} onChange={updateArgValues(index)} />
     }
   }
 
@@ -193,23 +194,22 @@ const OperationFormContents: React.FunctionComponent<OperationFormContentsProps>
 
   const OperationExecuteForm = () => (
     <Form isHorizontal={operation.args.length > 0}>
-      {(operation.args.length === 0) &&
-        <Text component="p">
-          This JMX operation requires no arguments.
-          Click the <code>Execute</code> button to invoke the operation.
+      {operation.args.length === 0 && (
+        <Text component='p'>
+          This JMX operation requires no arguments. Click the <code>Execute</code> button to invoke the operation.
         </Text>
-      }
-      {(operation.args.length > 0) &&
-        <Text component="p">
-          This JMX operation requires some parameters.
-          Fill in the fields below and click the <code>Execute</code> button to invoke the operation.
+      )}
+      {operation.args.length > 0 && (
+        <Text component='p'>
+          This JMX operation requires some parameters. Fill in the fields below and click the <code>Execute</code>{' '}
+          button to invoke the operation.
         </Text>
-      }
+      )}
       {argForms}
       <ActionGroup>
         <Button
           key={`operation-action-execute-${name}`}
-          variant="primary"
+          variant='primary'
           onClick={execute}
           isSmall
           isDisabled={isExecuting}
@@ -222,7 +222,7 @@ const OperationFormContents: React.FunctionComponent<OperationFormContentsProps>
 
   const OperationExecuteResult = () => (
     <React.Fragment>
-      <Title headingLevel="h4">Result</Title>
+      <Title headingLevel='h4'>Result</Title>
       {/*
         TODO: Known issue - "Warning: findDOMNode is deprecated in StrictMode."
         https://github.com/patternfly/patternfly-react/issues/8368
@@ -233,7 +233,7 @@ const OperationFormContents: React.FunctionComponent<OperationFormContentsProps>
         isCode
         isReadOnly
         //removeFindDomNode
-        className={isFailed ? "jmx-operation-error" : ""}
+        className={isFailed ? 'jmx-operation-error' : ''}
       >
         {result}
       </ClipboardCopy>
@@ -242,22 +242,14 @@ const OperationFormContents: React.FunctionComponent<OperationFormContentsProps>
 
   return (
     <React.Fragment>
-      <DataListContent
-        id={`operation-execute-${name}`}
-        aria-label={`operation execute ${name}`}
-        isHidden={!isExpanded}
-      >
+      <DataListContent id={`operation-execute-${name}`} aria-label={`operation execute ${name}`} isHidden={!isExpanded}>
         <OperationExecuteForm />
       </DataListContent>
-      {result &&
-        <DataListContent
-          id={`operation-result-${name}`}
-          aria-label={`operation result ${name}`}
-          isHidden={!isExpanded}
-        >
+      {result && (
+        <DataListContent id={`operation-result-${name}`} aria-label={`operation result ${name}`} isHidden={!isExpanded}>
           <OperationExecuteResult />
         </DataListContent>
-      }
+      )}
     </React.Fragment>
   )
 }

--- a/packages/hawtio/src/plugins/jmx/operations/Operations.css
+++ b/packages/hawtio/src/plugins/jmx/operations/Operations.css
@@ -1,3 +1,3 @@
 #jmx-operation-list .pf-c-data-list__item-content {
-  display: grid
+  display: grid;
 }

--- a/packages/hawtio/src/plugins/jmx/operations/Operations.tsx
+++ b/packages/hawtio/src/plugins/jmx/operations/Operations.tsx
@@ -21,7 +21,7 @@ export const Operations: React.FunctionComponent = () => {
     return (
       <Card>
         <CardBody>
-          <Text component="p">
+          <Text component='p'>
             <InfoCircleIcon /> This MBean has no JMX operations.
           </Text>
         </CardBody>
@@ -32,11 +32,7 @@ export const Operations: React.FunctionComponent = () => {
   const operations = createOperations(objectName, mbean.op)
 
   const OperationList = () => (
-    <DataList
-      id="jmx-operation-list"
-      aria-label="operation list"
-      isCompact
-    >
+    <DataList id='jmx-operation-list' aria-label='operation list' isCompact>
       {operations.map(op => (
         <OperationForm key={op.name} name={op.name} operation={op} />
       ))}
@@ -46,7 +42,7 @@ export const Operations: React.FunctionComponent = () => {
   return (
     <Card isFullHeight>
       <CardBody>
-        <Text component="p">
+        <Text component='p'>
           This MBean supports the following JMX operations. Expand an item in the list to invoke that operation.
         </Text>
       </CardBody>

--- a/packages/hawtio/src/plugins/jmx/operations/operation-service.ts
+++ b/packages/hawtio/src/plugins/jmx/operations/operation-service.ts
@@ -2,7 +2,6 @@ import { jolokiaService } from '@hawtio/plugins/connect/jolokia-service'
 import { log } from '../globals'
 
 class OperationService {
-
   async execute(mbean: string, operation: string, args: unknown[]): Promise<string> {
     log.debug('Execute:', mbean, '-', operation, '-', args)
     const response = await jolokiaService.execute(mbean, operation, args)

--- a/packages/hawtio/src/plugins/jmx/operations/operation.ts
+++ b/packages/hawtio/src/plugins/jmx/operations/operation.ts
@@ -7,14 +7,13 @@ type OperationMap = { [name: string]: Operation }
 export function createOperations(objectName: string, jmxOperations: IJmxOperations): Operation[] {
   const operations: Operation[] = []
   const operationMap: OperationMap = {}
-  Object.entries(jmxOperations)
-    .forEach(([name, op]) => {
-      if (Array.isArray(op)) {
-        op.forEach(op => addOperation(operations, operationMap, name, op))
-      } else {
-        addOperation(operations, operationMap, name, op)
-      }
-    })
+  Object.entries(jmxOperations).forEach(([name, op]) => {
+    if (Array.isArray(op)) {
+      op.forEach(op => addOperation(operations, operationMap, name, op))
+    } else {
+      addOperation(operations, operationMap, name, op)
+    }
+  })
   operations.sort((a, b) => stringSorter(a.readableName, b.readableName))
   if (!isEmpty(operationMap)) {
     fetchPermissions(operationMap, objectName)
@@ -23,13 +22,12 @@ export function createOperations(objectName: string, jmxOperations: IJmxOperatio
   return operations
 }
 
-function addOperation(
-  operations: Operation[], operationMap: OperationMap, name: string, op: IJmxOperation,
-): void {
+function addOperation(operations: Operation[], operationMap: OperationMap, name: string, op: IJmxOperation): void {
   const operation = new Operation(
     name,
     op.args.map(arg => new OperationArgument(arg.name, arg.type, arg.desc)),
-    op.desc)
+    op.desc,
+  )
   operations.push(operation)
   operationMap[operation.name] = operation
 }
@@ -44,33 +42,25 @@ export class Operation {
   readonly readableName: string
   canInvoke: boolean
 
-  constructor(
-    method: string,
-    readonly args: OperationArgument[],
-    readonly description: string,
-  ) {
+  constructor(method: string, readonly args: OperationArgument[], readonly description: string) {
     this.name = this.buildName(method)
     this.readableName = this.buildReadableName(method)
     this.canInvoke = true
   }
 
   private buildName(method: string): string {
-    return method + "(" + this.args.map(arg => arg.type).join() + ")"
+    return method + '(' + this.args.map(arg => arg.type).join() + ')'
   }
 
   private buildReadableName(method: string): string {
-    return method + "(" + this.args.map(arg => arg.readableType).join(', ') + ")"
+    return method + '(' + this.args.map(arg => arg.readableType).join(', ') + ')'
   }
 }
 
 export class OperationArgument {
   readonly readableType: string
 
-  constructor(
-    readonly name: string,
-    readonly type: string,
-    readonly desc: string,
-  ) {
+  constructor(readonly name: string, readonly type: string, readonly desc: string) {
     this.readableType = this.buildReadableType()
   }
 

--- a/packages/hawtio/src/plugins/shared/components/PluginTreeViewToolbar.tsx
+++ b/packages/hawtio/src/plugins/shared/components/PluginTreeViewToolbar.tsx
@@ -6,13 +6,13 @@ import {
   ToolbarGroup,
   ToolbarItem,
   Tooltip,
-  TreeViewSearch
+  TreeViewSearch,
 } from '@patternfly/react-core'
 import { MinusIcon, PlusIcon } from '@patternfly/react-icons'
 
 interface ToolbarProps {
-  onSearch: (event: ChangeEvent<HTMLInputElement>) => void,
-  onSetExpanded: (newExpanded: boolean) => void,
+  onSearch: (event: ChangeEvent<HTMLInputElement>) => void
+  onSetExpanded: (newExpanded: boolean) => void
 }
 
 export const PluginTreeViewToolbar: React.FunctionComponent<ToolbarProps> = (props: ToolbarProps) => {
@@ -36,25 +36,18 @@ export const PluginTreeViewToolbar: React.FunctionComponent<ToolbarProps> = (pro
   return (
     <Toolbar style={{ padding: 0 }}>
       <ToolbarContent style={{ padding: 0 }}>
-        <ToolbarGroup variant="filter-group">
-          <ToolbarItem variant="search-filter" widths={{ default: '100%' }}>
+        <ToolbarGroup variant='filter-group'>
+          <ToolbarItem variant='search-filter' widths={{ default: '100%' }}>
             <TreeViewSearch
               onSearch={onSearch}
-              id="input-search"
-              name="search-input"
-              aria-label="Search input example"
+              id='input-search'
+              name='search-input'
+              aria-label='Search input example'
             />
           </ToolbarItem>
-          <ToolbarItem variant="expand-all">
-            <Tooltip
-              content={expanded ? 'Collapse all' : 'Expand all'}
-              removeFindDomNode
-            >
-              <Button
-                variant="plain"
-                aria-label="Expand Collapse"
-                onClick={toggleExpanded}
-              >
+          <ToolbarItem variant='expand-all'>
+            <Tooltip content={expanded ? 'Collapse all' : 'Expand all'} removeFindDomNode>
+              <Button variant='plain' aria-label='Expand Collapse' onClick={toggleExpanded}>
                 {expanded ? <MinusIcon /> : <PlusIcon />}
               </Button>
             </Tooltip>

--- a/packages/hawtio/src/plugins/shared/tree/node.ts
+++ b/packages/hawtio/src/plugins/shared/tree/node.ts
@@ -29,9 +29,9 @@ export class MBeanNode implements TreeViewDataItem {
   // and getting the same logger for all nodes belonging to the same tree
   //
   private static getLogger(owner: string): ILogger {
-    const logId =`${owner}-node`
-    let log: ILogger|undefined = nodeLoggers.get(logId)
-    if (! log) {
+    const logId = `${owner}-node`
+    let log: ILogger | undefined = nodeLoggers.get(logId)
+    if (!log) {
       log = Logger.get(logId)
       nodeLoggers.set(logId, log)
     }
@@ -54,13 +54,13 @@ export class MBeanNode implements TreeViewDataItem {
   }
 
   populateMBean(propList: string, mbean: IJmxMBean) {
-    this.log.debug("  JMX tree mbean:", propList)
+    this.log.debug('  JMX tree mbean:', propList)
     const props = new PropertyList(this, propList)
     this.createMBeanNode(props.getPaths(), props, mbean)
   }
 
   private createMBeanNode(paths: string[], props: PropertyList, mbean: IJmxMBean) {
-    this.log.debug("    JMX tree property:", paths[0])
+    this.log.debug('    JMX tree property:', paths[0])
     if (paths.length === 1) {
       // final mbean node
       const mbeanNode = this.create(paths[0], false)
@@ -70,7 +70,7 @@ export class MBeanNode implements TreeViewDataItem {
 
     const path = paths.shift()
     if (path === undefined) {
-      throw new Error("path should not be empty")
+      throw new Error('path should not be empty')
     }
     const child = this.getOrCreate(path, true)
     child.createMBeanNode(paths, props, mbean)
@@ -86,7 +86,7 @@ export class MBeanNode implements TreeViewDataItem {
   }
 
   getIndex(index: number): MBeanNode | null {
-    return this.children ? this.children[index]: null
+    return this.children ? this.children[index] : null
   }
 
   getChildren(): MBeanNode[] {
@@ -138,7 +138,7 @@ export class MBeanNode implements TreeViewDataItem {
   }
 
   sort(recursive: boolean) {
-    if (! this.children) return
+    if (!this.children) return
 
     this.children?.sort((a, b) => stringSorter(a.name, b.name))
     if (recursive) {
@@ -153,7 +153,7 @@ export class MBeanNode implements TreeViewDataItem {
 
     let answer: MBeanNode | null = null
     if (this.children) {
-      this.children.forEach((child) => {
+      this.children.forEach(child => {
         if (!answer) {
           answer = child.findDescendant(filter)
         }
@@ -165,7 +165,7 @@ export class MBeanNode implements TreeViewDataItem {
   filterClone(filter: (node: MBeanNode) => boolean): MBeanNode | null {
     const copyChildren: MBeanNode[] = []
     if (this.children) {
-      this.children.forEach((child) => {
+      this.children.forEach(child => {
         const childCopy = child.filterClone(filter)
         if (childCopy) {
           copyChildren.push(childCopy)
@@ -208,11 +208,14 @@ export class MBeanNode implements TreeViewDataItem {
 class PropertyList {
   private domain: MBeanNode
   private propList: string
-  private paths: { key: string, value: string }[] = []
+  private paths: { key: string; value: string }[] = []
   typeName?: string
   serviceName?: string
 
-  private readonly propRegex = new RegExp('(([^=,]+)=(\\\\"[^"]+\\\\"|\\\\\'[^\']+\\\\\'|"[^"]+"|\'[^\']+\'|[^,]+))|([^=,]+)', 'g')
+  private readonly propRegex = new RegExp(
+    '(([^=,]+)=(\\\\"[^"]+\\\\"|\\\\\'[^\']+\\\\\'|"[^"]+"|\'[^\']+\'|[^,]+))|([^=,]+)',
+    'g',
+  )
 
   constructor(domain: MBeanNode, propList: string) {
     this.domain = domain
@@ -306,7 +309,7 @@ export function reorderObjects(objs: object[], key: string, order: string[]) {
     return
   }
 
-  const objKey = key as keyof typeof objs[0]
+  const objKey = key as keyof (typeof objs)[0]
   order.reverse().forEach(value => {
     const index = objs.findIndex(o => o[objKey] === value)
     if (index >= 0) {
@@ -324,7 +327,7 @@ export function checkReorderNeeded(objs: object[], key: string, order: string[])
     return false
   }
 
-  const objKey = key as keyof typeof objs[0]
+  const objKey = key as keyof (typeof objs)[0]
   if (objs.length < order.length) {
     return objs.some((o, i) => o[objKey] !== order[i])
   }

--- a/packages/hawtio/src/plugins/shared/tree/registry.test.ts
+++ b/packages/hawtio/src/plugins/shared/tree/registry.test.ts
@@ -7,13 +7,12 @@ describe('treeProcessorRegistry', () => {
   })
 
   test('add a domain processor', async () => {
-
     expect(treeProcessorRegistry).not.toBeNull()
     expect(treeProcessorRegistry.getDomains()).toEqual([])
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const testProcessor = (domainNode: MBeanNode) => {
-      console.log("Nothing to do")
+      console.log('Nothing to do')
     }
 
     treeProcessorRegistry.add('test', testProcessor)
@@ -23,7 +22,7 @@ describe('treeProcessorRegistry', () => {
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const testProcessor2 = (domainNode: MBeanNode) => {
-      console.log("Nothing to do")
+      console.log('Nothing to do')
     }
 
     // Add additional processor to same domain

--- a/packages/hawtio/src/plugins/shared/tree/registry.ts
+++ b/packages/hawtio/src/plugins/shared/tree/registry.ts
@@ -1,6 +1,6 @@
 import { MBeanNode } from './node'
 
-export type TreeProcessorFunction = (domainNode: MBeanNode) => void;
+export type TreeProcessorFunction = (domainNode: MBeanNode) => void
 
 export type Domain = {
   id: string
@@ -8,26 +8,25 @@ export type Domain = {
 }
 
 class TreeProcessorRegistry {
-
   private domains: { [id: string]: Domain } = {}
 
   add(domain: string, processor: TreeProcessorFunction) {
     if (this.domains[domain]) {
       this.domains[domain].processors.push(processor)
     } else {
-      this.domains[domain] = { id: domain, processors: [processor]}
+      this.domains[domain] = { id: domain, processors: [processor] }
     }
   }
 
   getProcessors(domain: string): TreeProcessorFunction[] {
-    if (! this.domains[domain] || ! this.domains[domain].processors) return []
+    if (!this.domains[domain] || !this.domains[domain].processors) return []
     return this.domains[domain].processors
   }
 
   getDomains(): Domain[] {
     const allDomains: Domain[] = []
     for (const id in this.domains) {
-      allDomains.push({id: id, processors: this.domains[id].processors})
+      allDomains.push({ id: id, processors: this.domains[id].processors })
     }
     return allDomains
   }

--- a/packages/hawtio/src/plugins/shared/tree/tree.ts
+++ b/packages/hawtio/src/plugins/shared/tree/tree.ts
@@ -7,7 +7,6 @@ import { MBeanNode } from './node'
 import { treeProcessorRegistry, TreeProcessorFunction } from './registry'
 
 export class MBeanTree {
-
   private id: string
   private log: ILogger
 
@@ -58,7 +57,7 @@ export class MBeanTree {
   }
 
   private populateDomain(name: string, domain: IJmxDomain) {
-    this.log.debug("JMX tree domain:", name)
+    this.log.debug('JMX tree domain:', name)
     const domainNode = this.getOrCreateNode(name)
     Object.entries(domain).forEach(([propList, mbean]) => {
       domainNode.populateMBean(propList, mbean)
@@ -97,7 +96,7 @@ export class MBeanTree {
       return node.name === name
     })
 
-    return (node) ? node : null
+    return node ? node : null
   }
 
   isEmpty(): boolean {
@@ -113,7 +112,7 @@ export class MBeanTree {
    */
   findDescendant(filter: (node: MBeanNode) => boolean): MBeanNode | null {
     let answer: MBeanNode | null = null
-    this.tree.forEach((child) => {
+    this.tree.forEach(child => {
       if (!answer) {
         answer = child.findDescendant(filter)
       }

--- a/packages/hawtio/src/plugins/shared/workspace.test.ts
+++ b/packages/hawtio/src/plugins/shared/workspace.test.ts
@@ -4,9 +4,7 @@ import { workspace } from './workspace'
 jest.mock('@hawtio/plugins/connect/jolokia-service')
 
 describe('workspace', () => {
-
   test('getting the tree', async () => {
-
     const tree: MBeanTree = await workspace.getTree()
     expect(tree.isEmpty()).toBeFalsy()
     expect(tree.get('java.util.logging')).toBeDefined()
@@ -28,8 +26,14 @@ describe('workspace', () => {
   })
 
   test('tree contains domain with properties', async () => {
-    await expect(workspace.treeContainsDomainAndProperties('quartz', { id: 'quartz', name: 'quartz' })).resolves.toBeTruthy()
-    await expect(workspace.treeContainsDomainAndProperties('quartz', { id: 'QuartzScheduler', name: 'QuartzScheduler' })).resolves.toBeTruthy()
-    await expect(workspace.treeContainsDomainAndProperties('quartz', { id: 'SomeRandomChild', name: 'NoThisChildIsNotHere' })).resolves.toBeFalsy()
+    await expect(
+      workspace.treeContainsDomainAndProperties('quartz', { id: 'quartz', name: 'quartz' }),
+    ).resolves.toBeTruthy()
+    await expect(
+      workspace.treeContainsDomainAndProperties('quartz', { id: 'QuartzScheduler', name: 'QuartzScheduler' }),
+    ).resolves.toBeTruthy()
+    await expect(
+      workspace.treeContainsDomainAndProperties('quartz', { id: 'SomeRandomChild', name: 'NoThisChildIsNotHere' }),
+    ).resolves.toBeFalsy()
   })
 })

--- a/packages/hawtio/src/plugins/shared/workspace.ts
+++ b/packages/hawtio/src/plugins/shared/workspace.ts
@@ -24,17 +24,17 @@ class Workspace {
     const options: ISimpleOptions = {
       ignoreErrors: true,
       error: (response: IErrorResponse) => {
-        log.debug("Error fetching JMX tree:", response)
+        log.debug('Error fetching JMX tree:', response)
       },
       ajaxError: (xhr: JQueryXHR) => {
-        log.debug("Error fetching JMX tree:", xhr)
-      }
+        log.debug('Error fetching JMX tree:', xhr)
+      },
     }
     const value = await jolokiaService.list(options)
 
     // TODO: this.jolokiaStatus.xhr = null
     const domains = this.unwindResponseWithRBACCache(value)
-    log.debug("JMX tree loaded:", domains)
+    log.debug('JMX tree loaded:', domains)
     return MBeanTree.createMBeanTreeFromDomains('workspace', domains)
   }
 
@@ -76,9 +76,9 @@ class Workspace {
     if (!node) return false
 
     for (const [k, v] of Object.entries(properties)) {
-      switch(k) {
+      switch (k) {
         case 'id':
-          if (! node.id.startsWith(v as string) && node.id !== v) return false
+          if (!node.id.startsWith(v as string) && node.id !== v) return false
           break
         case 'name':
           if (node.name !== v) return false
@@ -92,7 +92,10 @@ class Workspace {
     return true
   }
 
-  async treeContainsDomainAndProperties(domainName: string, properties?: Record<string, unknown> | null): Promise<boolean> {
+  async treeContainsDomainAndProperties(
+    domainName: string,
+    properties?: Record<string, unknown> | null,
+  ): Promise<boolean> {
     const tree = await this.tree
     if (!tree) {
       return false
@@ -104,7 +107,7 @@ class Workspace {
     }
 
     if (properties) {
-      let domainAndChildren:MBeanNode[] = [domain]
+      let domainAndChildren: MBeanNode[] = [domain]
       domainAndChildren = domainAndChildren.concat(domain.children || [])
       const checkProperties = (node: MBeanNode) => {
         if (!this.matchesProperties(node, properties)) {

--- a/packages/hawtio/src/preferences/HawtioPreferences.tsx
+++ b/packages/hawtio/src/preferences/HawtioPreferences.tsx
@@ -1,8 +1,17 @@
-
 import { helpRegistry } from '@hawtio/help/registry'
-import { Card, Nav, NavItem, NavList, PageGroup, PageNavigation, PageSection, PageSectionVariants, Title } from '@patternfly/react-core'
+import {
+  Card,
+  Nav,
+  NavItem,
+  NavList,
+  PageGroup,
+  PageNavigation,
+  PageSection,
+  PageSectionVariants,
+  Title,
+} from '@patternfly/react-core'
 import React from 'react'
-import { NavLink,Navigate, Route, Routes, useLocation } from 'react-router-dom'
+import { NavLink, Navigate, Route, Routes, useLocation } from 'react-router-dom'
 import help from './help.md'
 import { HomePreferences } from './HomePreferences'
 import { LogsPreferences } from './LogsPreferences'
@@ -17,17 +26,17 @@ export const HawtioPreferences: React.FunctionComponent = () => {
   return (
     <React.Fragment>
       <PageSection variant={PageSectionVariants.light}>
-        <Title headingLevel="h1">Preferences</Title>
+        <Title headingLevel='h1'>Preferences</Title>
       </PageSection>
       <PageGroup>
         <PageNavigation>
-          <Nav aria-label="Nav" variant="tertiary">
+          <Nav aria-label='Nav' variant='tertiary'>
             <NavList>
-              {preferencesRegistry.getPreferences().map(prefs =>
+              {preferencesRegistry.getPreferences().map(prefs => (
                 <NavItem key={prefs.id} isActive={location.pathname === prefs.id}>
                   <NavLink to={prefs.id}>{prefs.title}</NavLink>
                 </NavItem>
-              )}
+              ))}
             </NavList>
           </Nav>
         </PageNavigation>
@@ -36,14 +45,11 @@ export const HawtioPreferences: React.FunctionComponent = () => {
         <Card isFullHeight>
           <Routes>
             {preferencesRegistry.getPreferences().map(prefs => (
-              <Route
-                key={prefs.id}
-                path={prefs.id}
-                element={React.createElement(prefs.component)} />
+              <Route key={prefs.id} path={prefs.id} element={React.createElement(prefs.component)} />
             ))}
-            <Route path="/" element={<Navigate to={'home'}/>}/>
+            <Route path='/' element={<Navigate to={'home'} />} />
           </Routes>
-        </Card >
+        </Card>
       </PageSection>
     </React.Fragment>
   )

--- a/packages/hawtio/src/preferences/HomePreferences.tsx
+++ b/packages/hawtio/src/preferences/HomePreferences.tsx
@@ -11,12 +11,10 @@ export const HomePreferences: React.FunctionComponent = () => {
   }
 
   const UIForm = () => (
-    <FormGroup
-      label="Default vertical nav state"
-      fieldId="ui-form-vertical-nav-switch">
+    <FormGroup label='Default vertical nav state' fieldId='ui-form-vertical-nav-switch'>
       <Switch
-        label="Show vertical navigation"
-        labelOff="Hide vertical navigation"
+        label='Show vertical navigation'
+        labelOff='Hide vertical navigation'
         isChecked={defaultVerticalNavState}
         onChange={setDefaultVerticalNavState}
       />
@@ -25,11 +23,11 @@ export const HomePreferences: React.FunctionComponent = () => {
 
   const ResetForm = () => (
     <FormGroup
-      label="Reset settings"
-      fieldId="reset-form-reset"
+      label='Reset settings'
+      fieldId='reset-form-reset'
       helperText="Clear all custom settings stored in your browser's local storage and reset to defaults."
     >
-      <Button variant="danger" onClick={reset}>
+      <Button variant='danger' onClick={reset}>
         Reset
       </Button>
     </FormGroup>
@@ -38,10 +36,10 @@ export const HomePreferences: React.FunctionComponent = () => {
   return (
     <CardBody>
       <Form isHorizontal>
-        <FormSection title="UI" titleElement="h2">
+        <FormSection title='UI' titleElement='h2'>
           <UIForm />
         </FormSection>
-        <FormSection title="Reset" titleElement="h2">
+        <FormSection title='Reset' titleElement='h2'>
           <ResetForm />
         </FormSection>
       </Form>

--- a/packages/hawtio/src/preferences/LogsPreferences.tsx
+++ b/packages/hawtio/src/preferences/LogsPreferences.tsx
@@ -1,5 +1,27 @@
 import { ChildLogger, Logger } from '@hawtio/core'
-import { Button, CardBody, DataList, DataListAction, DataListCell, DataListItem, DataListItemCells, DataListItemRow, Dropdown, DropdownItem, DropdownToggle, Form, FormGroup, FormSection, FormSelect, FormSelectOption, Select, SelectOption, Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core'
+import {
+  Button,
+  CardBody,
+  DataList,
+  DataListAction,
+  DataListCell,
+  DataListItem,
+  DataListItemCells,
+  DataListItemRow,
+  Dropdown,
+  DropdownItem,
+  DropdownToggle,
+  Form,
+  FormGroup,
+  FormSection,
+  FormSelect,
+  FormSelectOption,
+  Select,
+  SelectOption,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
+} from '@patternfly/react-core'
 import { PlusIcon, TrashIcon } from '@patternfly/react-icons'
 import React, { useContext, useState } from 'react'
 import { LogsContext, useChildLoggers } from './context'
@@ -8,11 +30,7 @@ export const LogsPreferences: React.FunctionComponent = () => {
   const { childLoggers, availableChildLoggers, reloadChildLoggers } = useChildLoggers()
 
   const ChildLoggerList = () => (
-    <DataList
-      id="logs-child-logger-list"
-      aria-label="logs child logger list"
-      isCompact
-    >
+    <DataList id='logs-child-logger-list' aria-label='logs child logger list' isCompact>
       {childLoggers.map(childLogger => (
         <ChildLoggerItem key={childLogger.name} logger={childLogger} />
       ))}
@@ -23,10 +41,10 @@ export const LogsPreferences: React.FunctionComponent = () => {
     <LogsContext.Provider value={{ childLoggers, availableChildLoggers, reloadChildLoggers }}>
       <CardBody>
         <Form isHorizontal>
-          <FormSection title="Global log settings" titleElement="h2">
+          <FormSection title='Global log settings' titleElement='h2'>
             <GlobalForms />
           </FormSection>
-          <FormSection title="Child loggers" titleElement="h2">
+          <FormSection title='Child loggers' titleElement='h2'>
             <ChildLoggerToolbar />
             <ChildLoggerList />
           </FormSection>
@@ -36,13 +54,7 @@ export const LogsPreferences: React.FunctionComponent = () => {
   )
 }
 
-const LOG_LEVEL_OPTIONS = [
-  'OFF',
-  'ERROR',
-  'WARN',
-  'INFO',
-  'DEBUG',
-] as const
+const LOG_LEVEL_OPTIONS = ['OFF', 'ERROR', 'WARN', 'INFO', 'DEBUG'] as const
 
 const GlobalForms: React.FunctionComponent = () => {
   const [logLevel, setLogLevel] = useState(Logger.getLevel().name)
@@ -54,18 +66,11 @@ const GlobalForms: React.FunctionComponent = () => {
 
   return (
     <React.Fragment>
-      <FormGroup
-        label="Log level"
-        fieldId="logs-global-form-log-level"
-      >
-        <FormSelect
-          id="logs-global-form-log-level-select"
-          value={logLevel}
-          onChange={handleLogLevelChange}
-        >
-          {LOG_LEVEL_OPTIONS.map((level, index) =>
+      <FormGroup label='Log level' fieldId='logs-global-form-log-level'>
+        <FormSelect id='logs-global-form-log-level-select' value={logLevel} onChange={handleLogLevelChange}>
+          {LOG_LEVEL_OPTIONS.map((level, index) => (
             <FormSelectOption key={index} label={level} value={level} />
-          )}
+          ))}
         </FormSelect>
       </FormGroup>
     </React.Fragment>
@@ -85,22 +90,22 @@ const ChildLoggerToolbar: React.FunctionComponent = () => {
     reloadChildLoggers()
   }
 
-  const availableChildLoggerItems = availableChildLoggers.map(logger =>
+  const availableChildLoggerItems = availableChildLoggers.map(logger => (
     <DropdownItem key={logger.name} onClick={addChildLogger(logger)}>
       {logger.name}
     </DropdownItem>
-  )
+  ))
 
   return (
-    <Toolbar id="connect-toolbar">
+    <Toolbar id='connect-toolbar'>
       <ToolbarContent>
         <ToolbarItem>
           <Dropdown
             onSelect={handleAddToggle}
             toggle={
               <DropdownToggle
-                id="logs-child-logger-toolbar-dropdown-toggle"
-                toggleVariant="secondary"
+                id='logs-child-logger-toolbar-dropdown-toggle'
+                toggleVariant='secondary'
                 onToggle={handleAddToggle}
               >
                 <PlusIcon /> Add
@@ -151,17 +156,17 @@ const ChildLoggerItem: React.FunctionComponent<ChildLoggerItemProps> = props => 
             </DataListCell>,
             <DataListCell key={`logs-child-logger-log-level-${name}`}>
               <Select
-                id="logs-child-logger-actions-log-level"
+                id='logs-child-logger-actions-log-level'
                 onToggle={onLogLevelToggle}
                 onSelect={(event, value) => onLogLevelSelect(String(value))}
                 selections={logger.filterLevel.name}
                 isOpen={isSelectOpen}
               >
-                {LOG_LEVEL_OPTIONS.map((level, index) =>
+                {LOG_LEVEL_OPTIONS.map((level, index) => (
                   <SelectOption key={index} value={level} />
-                )}
+                ))}
               </Select>
-            </DataListCell>
+            </DataListCell>,
           ]}
         />
         <DataListAction
@@ -169,7 +174,7 @@ const ChildLoggerItem: React.FunctionComponent<ChildLoggerItemProps> = props => 
           aria-label={`logs child logger actions ${name}`}
           aria-labelledby={`${name} logs-child-logger-actions-${name}`}
         >
-          <Button variant="secondary" onClick={deleteChildLogger}>
+          <Button variant='secondary' onClick={deleteChildLogger}>
             <TrashIcon />
           </Button>
         </DataListAction>

--- a/packages/hawtio/src/preferences/context.ts
+++ b/packages/hawtio/src/preferences/context.ts
@@ -25,5 +25,7 @@ type LogsContext = {
 export const LogsContext = createContext<LogsContext>({
   childLoggers: [],
   availableChildLoggers: [],
-  reloadChildLoggers: () => { /* no-op */ },
+  reloadChildLoggers: () => {
+    /* no-op */
+  },
 })

--- a/packages/hawtio/src/preferences/registry.test.tsx
+++ b/packages/hawtio/src/preferences/registry.test.tsx
@@ -14,8 +14,9 @@ describe('preferencesRegistry', () => {
     expect(preferencesRegistry.getPreferences()[0].component).not.toBeNull()
 
     // duplicate preferences not allowed
-    expect(() => preferencesRegistry.add('test', 'Test', () => <React.Fragment />))
-      .toThrowError(/Preferences 'test' already registered/)
+    expect(() => preferencesRegistry.add('test', 'Test', () => <React.Fragment />)).toThrowError(
+      /Preferences 'test' already registered/,
+    )
   })
 
   test('return preferences in order', () => {

--- a/packages/hawtio/src/preferences/registry.ts
+++ b/packages/hawtio/src/preferences/registry.ts
@@ -9,7 +9,6 @@ export type Preferences = {
 }
 
 class PreferencesRegistry {
-
   private preferences: { [id: string]: Preferences } = {}
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/hawtio/src/test/support.ts
+++ b/packages/hawtio/src/test/support.ts
@@ -1,4 +1,3 @@
-
 export function mockFetch(payload: string) {
   const mockedFetch = jest.fn(() => Promise.resolve(new Response(payload)))
   global.fetch = mockedFetch

--- a/packages/hawtio/src/ui/about/HawtioAbout.tsx
+++ b/packages/hawtio/src/ui/about/HawtioAbout.tsx
@@ -12,19 +12,19 @@ export const HawtioAbout: React.FunctionComponent<HawtioAboutProps> = props => {
     <AboutModal
       isOpen={props.isOpen}
       onClose={props.onClose}
-      trademark="&copy; Hawtio project"
+      trademark='&copy; Hawtio project'
       brandImageSrc={imgLogo}
-      brandImageAlt="Hawtio Management Console"
-      productName="Hawtio Management Console"
+      brandImageAlt='Hawtio Management Console'
+      productName='Hawtio Management Console'
     >
       <TextContent>
-        <TextList component="dl">
-          <TextListItem component="dt">Hawtio.next</TextListItem>
-          <TextListItem component="dd">PACKAGE_VERSION_PLACEHOLDER</TextListItem>
-          <TextListItem component="dt">ABC</TextListItem>
-          <TextListItem component="dd">a.b.c</TextListItem>
-          <TextListItem component="dt">XYZ</TextListItem>
-          <TextListItem component="dd">x.y.z</TextListItem>
+        <TextList component='dl'>
+          <TextListItem component='dt'>Hawtio.next</TextListItem>
+          <TextListItem component='dd'>PACKAGE_VERSION_PLACEHOLDER</TextListItem>
+          <TextListItem component='dt'>ABC</TextListItem>
+          <TextListItem component='dd'>a.b.c</TextListItem>
+          <TextListItem component='dt'>XYZ</TextListItem>
+          <TextListItem component='dd'>x.y.z</TextListItem>
         </TextList>
       </TextContent>
     </AboutModal>

--- a/packages/hawtio/src/ui/notification/HawtioNotification.tsx
+++ b/packages/hawtio/src/ui/notification/HawtioNotification.tsx
@@ -55,11 +55,7 @@ export const HawtioNotification: React.FunctionComponent = () => {
   }
 
   return (
-    <AlertGroup
-      isToast
-      isLiveRegion
-      onOverflowClick={onOverflowClick}
-      overflowMessage={overflowMessage}>
+    <AlertGroup isToast isLiveRegion onOverflowClick={onOverflowClick} overflowMessage={overflowMessage}>
       {alerts.slice(0, maxDisplayed).map(({ key, variant, title }) => (
         <Alert
           variant={variant}

--- a/packages/hawtio/src/ui/page/HawtioBackground.tsx
+++ b/packages/hawtio/src/ui/page/HawtioBackground.tsx
@@ -11,8 +11,7 @@ const images: BackgroundImageSrcMap = {
   xs2x: backgroundImageSrcXs2x,
   sm: backgroundImageSrcSm,
   sm2x: backgroundImageSrcSm2x,
-  lg: backgroundImageSrcLg
+  lg: backgroundImageSrcLg,
 }
 
-export const HawtioBackground: React.FunctionComponent = () =>
-  <BackgroundImage src={images} />
+export const HawtioBackground: React.FunctionComponent = () => <BackgroundImage src={images} />

--- a/packages/hawtio/src/ui/page/HawtioHeader.tsx
+++ b/packages/hawtio/src/ui/page/HawtioHeader.tsx
@@ -1,7 +1,23 @@
 import imgLogo from '@hawtio/img/hawtio-logo.svg'
 import imgAvatar from '@hawtio/img/img_avatar.svg'
 import { HawtioAbout } from '@hawtio/ui/about/HawtioAbout'
-import { Avatar, Brand, Dropdown, DropdownItem, DropdownToggle, Masthead, MastheadBrand, MastheadContent, MastheadMain, MastheadToggle, PageToggleButton, Toolbar, ToolbarContent, ToolbarGroup, ToolbarItem } from '@patternfly/react-core'
+import {
+  Avatar,
+  Brand,
+  Dropdown,
+  DropdownItem,
+  DropdownToggle,
+  Masthead,
+  MastheadBrand,
+  MastheadContent,
+  MastheadMain,
+  MastheadToggle,
+  PageToggleButton,
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
+} from '@patternfly/react-core'
 import { BarsIcon, HelpIcon } from '@patternfly/react-icons'
 import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
@@ -19,29 +35,25 @@ export const HawtioHeader: React.FunctionComponent = () => {
   const onAboutToggle = () => setAboutOpen(!aboutOpen)
 
   const helpItems = [
-    <DropdownItem key="help" component={
-      <Link to='/help'>Help</Link>
-    } />,
-    <DropdownItem key="about" onClick={onAboutToggle}>About</DropdownItem>
+    <DropdownItem key='help' component={<Link to='/help'>Help</Link>} />,
+    <DropdownItem key='about' onClick={onAboutToggle}>
+      About
+    </DropdownItem>,
   ]
 
   const userItems = [
-    <DropdownItem key="preferences" component={
-      <Link to='/preferences'>Preferences</Link>
-    } />,
-    <DropdownItem key="logout" component={
-      <Link to='/logout'>Log out</Link>
-    } />
+    <DropdownItem key='preferences' component={<Link to='/preferences'>Preferences</Link>} />,
+    <DropdownItem key='logout' component={<Link to='/logout'>Log out</Link>} />,
   ]
 
   const headerToolbar = (
-    <Toolbar id="hawtio-header-toolbar">
+    <Toolbar id='hawtio-header-toolbar'>
       <ToolbarContent>
         <ToolbarGroup>
           <ToolbarItem>
             <Dropdown
               isPlain
-              position="right"
+              position='right'
               onSelect={onHelpSelect}
               toggle={
                 <DropdownToggle toggleIndicator={null} onToggle={setHelpOpen}>
@@ -57,14 +69,14 @@ export const HawtioHeader: React.FunctionComponent = () => {
           <ToolbarItem>
             <Dropdown
               isPlain
-              position="right"
+              position='right'
               onSelect={onUserSelect}
               isOpen={userOpen}
               toggle={
                 <DropdownToggle
-                  id="hawtio-header-user-dropdown-toggle"
+                  id='hawtio-header-user-dropdown-toggle'
                   onToggle={setUserOpen}
-                  icon={<Avatar src={imgAvatar} alt="user" />}
+                  icon={<Avatar src={imgAvatar} alt='user' />}
                 >
                   Hawtio User
                 </DropdownToggle>
@@ -77,26 +89,24 @@ export const HawtioHeader: React.FunctionComponent = () => {
     </Toolbar>
   )
 
-  const hawtioLogo = <Brand src={imgLogo} alt="Hawtio Management Console" />
+  const hawtioLogo = <Brand src={imgLogo} alt='Hawtio Management Console' />
 
   return (
     <React.Fragment>
       <Masthead display={{ default: 'inline' }}>
         <MastheadToggle>
           <PageToggleButton
-            variant="plain"
-            aria-label="Global navigation"
+            variant='plain'
+            aria-label='Global navigation'
             isNavOpen={navOpen}
             onNavToggle={onNavToggle}
-            id="vertical-nav-toggle"
+            id='vertical-nav-toggle'
           >
             <BarsIcon />
           </PageToggleButton>
         </MastheadToggle>
         <MastheadMain>
-          <MastheadBrand component={props => <Link to="/" {...props} />}>
-            {hawtioLogo}
-          </MastheadBrand>
+          <MastheadBrand component={props => <Link to='/' {...props} />}>{hawtioLogo}</MastheadBrand>
         </MastheadMain>
         <MastheadContent>{headerToolbar}</MastheadContent>
       </Masthead>

--- a/packages/hawtio/src/ui/page/HawtioPage.tsx
+++ b/packages/hawtio/src/ui/page/HawtioPage.tsx
@@ -1,6 +1,15 @@
 import { HawtioHelp } from '@hawtio/help/HawtioHelp'
 import { HawtioPreferences } from '@hawtio/preferences/HawtioPreferences'
-import { EmptyState, EmptyStateIcon, EmptyStateVariant, Page, PageSection, PageSectionVariants, Spinner, Title } from '@patternfly/react-core'
+import {
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  Page,
+  PageSection,
+  PageSectionVariants,
+  Spinner,
+  Title,
+} from '@patternfly/react-core'
 import { CubesIcon } from '@patternfly/react-icons'
 import React from 'react'
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom'
@@ -18,7 +27,7 @@ export const HawtioPage: React.FunctionComponent = () => {
     return (
       <Page>
         <PageSection>
-          <Spinner isSVG aria-label="Loading Hawtio" />
+          <Spinner isSVG aria-label='Loading Hawtio' />
         </PageSection>
       </Page>
     )
@@ -28,7 +37,9 @@ export const HawtioPage: React.FunctionComponent = () => {
     <PageSection variant={PageSectionVariants.light}>
       <EmptyState variant={EmptyStateVariant.full}>
         <EmptyStateIcon icon={CubesIcon} />
-        <Title headingLevel="h1" size="lg">Hawtio</Title>
+        <Title headingLevel='h1' size='lg'>
+          Hawtio
+        </Title>
       </EmptyState>
     </PageSection>
   )
@@ -44,25 +55,18 @@ export const HawtioPage: React.FunctionComponent = () => {
   return (
     <PageContext.Provider value={{ plugins, loaded }}>
       <HawtioBackground />
-      <Page
-        header={<HawtioHeader />}
-        sidebar={<HawtioSidebar />}
-        isManagedSidebar
-      >
+      <Page header={<HawtioHeader />} sidebar={<HawtioSidebar />} isManagedSidebar>
         <Routes>
           {/* plugins */}
           {plugins.map(plugin => (
-            <Route
-              key={plugin.id}
-              path={`${plugin.path}/*`}
-              element={React.createElement(plugin.component)}/>
+            <Route key={plugin.id} path={`${plugin.path}/*`} element={React.createElement(plugin.component)} />
           ))}
           <Route key='help' path='help/*' element={<HawtioHelp />} />
           <Route key='preferences' path='preferences/*' element={<HawtioPreferences />} />
 
           <Route index key='root' path='/' element={defaultPage} />
         </Routes>
-      <HawtioNotification />
+        <HawtioNotification />
       </Page>
     </PageContext.Provider>
   )

--- a/packages/hawtio/src/ui/page/HawtioSidebar.tsx
+++ b/packages/hawtio/src/ui/page/HawtioSidebar.tsx
@@ -12,7 +12,7 @@ export const HawtioSidebar: React.FunctionComponent = () => {
   }
 
   const pageNav = (
-    <Nav theme="dark">
+    <Nav theme='dark'>
       <NavList>
         {plugins.map(plugin => (
           <NavItem key={plugin.id} isActive={plugin.path === pathname}>
@@ -23,5 +23,5 @@ export const HawtioSidebar: React.FunctionComponent = () => {
     </Nav>
   )
 
-  return <PageSidebar nav={pageNav} theme="dark" />
+  return <PageSidebar nav={pageNav} theme='dark' />
 }

--- a/packages/hawtio/src/util/cookies.ts
+++ b/packages/hawtio/src/util/cookies.ts
@@ -3,8 +3,6 @@ export function getCookie(name: string): string | null {
     return null
   }
   const cookies = document.cookie.split(';')
-  const cookie = cookies
-    .map(cookie => cookie.split('='))
-    .find(cookie => cookie.length > 1 && cookie[0] === name)
+  const cookie = cookies.map(cookie => cookie.split('=')).find(cookie => cookie.length > 1 && cookie[0] === name)
   return cookie ? cookie[1] : null
 }

--- a/packages/hawtio/src/util/jolokia.ts
+++ b/packages/hawtio/src/util/jolokia.ts
@@ -1,5 +1,19 @@
 import { Logger } from '@hawtio/core'
-import { IErrorResponse, IErrorResponseFn, IListOptions, IListResponseFn, IOptions, IOptionsBase, IResponseFn, ISearchOptions, ISearchResponseFn, ISimpleOptions, ISimpleResponseFn, IVersionOptions, IVersionResponseFn } from 'jolokia.js'
+import {
+  IErrorResponse,
+  IErrorResponseFn,
+  IListOptions,
+  IListResponseFn,
+  IOptions,
+  IOptionsBase,
+  IResponseFn,
+  ISearchOptions,
+  ISearchResponseFn,
+  ISimpleOptions,
+  ISimpleResponseFn,
+  IVersionOptions,
+  IVersionResponseFn,
+} from 'jolokia.js'
 
 const log = Logger.get('hawtio-util')
 
@@ -32,16 +46,13 @@ export function onVersionSuccess(successFn: IVersionResponseFn, options: IVersio
 }
 
 export function onGenericSuccess<R, O extends IOptionsBase>(successFn: R, options?: O): O {
-  return onGenericSuccessAndError(
-    successFn,
-    defaultErrorHandler(options),
-    options)
+  return onGenericSuccessAndError(successFn, defaultErrorHandler(options), options)
 }
 
 export function onGenericSuccessAndError<R, O extends IOptionsBase>(
   successFn: R,
   errorFn: IErrorResponseFn,
-  options?: O
+  options?: O,
 ): O {
   const defaultOptions: IOptionsBase = {
     method: 'POST',
@@ -91,8 +102,7 @@ function isIgnorableException(response: IErrorResponse): boolean {
     'IllegalArgumentException: No operation',
   ]
   const test = (e: string) => ignorables.some(i => e.indexOf(i) >= 0)
-  return (response.stacktrace != null && test(response.stacktrace))
-    || (response.error != null && test(response.error))
+  return (response.stacktrace != null && test(response.stacktrace)) || (response.error != null && test(response.error))
 }
 
 /**
@@ -121,17 +131,14 @@ export function escapeMBeanPath(mbean: string): string {
  * @param mbean the MBean
  */
 function applyJolokiaEscapeRules(mbean: string): string {
-  return mbean
-    .replace(/!/g, '!!')
-    .replace(/\//g, '!/')
-    .replace(/"/g, '!"')
+  return mbean.replace(/!/g, '!!').replace(/\//g, '!/').replace(/"/g, '!"')
 }
 
 /**
  * Escapes only tags ('<' and '>') as opposed to typical URL encodings.
  *
  * @param text string to be escaped
-*/
+ */
 export function escapeTags(text: string): string {
   let escaped = text.replace('<', '&lt;')
   escaped = escaped.replace('>', '&gt;')
@@ -142,7 +149,7 @@ export function escapeTags(text: string): string {
  * Escapes dots ('.') to '-'.
  *
  * @param text string to be escaped
-*/
+ */
 export function escapeDots(text: string): string {
   return text.replace(/\./g, '-')
 }

--- a/packages/hawtio/src/util/objects.test.ts
+++ b/packages/hawtio/src/util/objects.test.ts
@@ -8,7 +8,9 @@ describe('objects', () => {
     expect(isObject(false)).toBe(false)
     const obj = { a: 'x', b: 'y', c: 'z' }
     expect(isObject(obj)).toBe(true)
-    const fn = () => { /* no-op */ }
+    const fn = () => {
+      /* no-op */
+    }
     expect(isObject(fn)).toBe(true)
   })
 })

--- a/packages/hawtio/src/util/strings.test.ts
+++ b/packages/hawtio/src/util/strings.test.ts
@@ -8,7 +8,7 @@ describe('strings', () => {
     expect(toString(obj)).toEqual('{ a: x, b: y, c: z }')
   })
 
-  test("trimQuotes()", () => {
+  test('trimQuotes()', () => {
     // it should only trim enclosing quotes
     expect(trimQuotes('"0.0.0.0"')).toBe('0.0.0.0')
     expect(trimQuotes("'0.0.0.0'")).toBe('0.0.0.0')

--- a/packages/hawtio/src/util/strings.ts
+++ b/packages/hawtio/src/util/strings.ts
@@ -21,8 +21,8 @@ export function isBlank(str: string): boolean {
 }
 
 /**
-* Simple toString that obscures any field called 'password'.
-*/
+ * Simple toString that obscures any field called 'password'.
+ */
 export function toString(obj: unknown): string {
   if (!obj) {
     return '{}'
@@ -47,7 +47,10 @@ export function obfuscate(str: string): string {
   if (typeof str !== 'string') {
     return ''
   }
-  return str.split('').map(() => '*').join('')
+  return str
+    .split('')
+    .map(() => '*')
+    .join('')
 }
 
 /**
@@ -82,7 +85,11 @@ export function trimQuotes(text: string): string {
 }
 
 export function stringSorter(a: string, b: string): number {
-  if (a < b) { return -1 }
-  if (a > b) { return 1 }
+  if (a < b) {
+    return -1
+  }
+  if (a > b) {
+    return 1
+  }
   return 0
 }

--- a/packages/hawtio/tsconfig.json
+++ b/packages/hawtio/tsconfig.json
@@ -2,16 +2,10 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@hawtio/*": [
-        "src/*"
-      ]
+      "@hawtio/*": ["src/*"]
     },
     "target": "es2015",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -28,10 +22,6 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": [
-    "src"
-  ],
-  "exclude": [
-    "src/hawtio/**/ignore/**"
-  ],
+  "include": ["src"],
+  "exclude": ["src/hawtio/**/ignore/**"]
 }

--- a/packages/hawtio/tsup.config.ts
+++ b/packages/hawtio/tsup.config.ts
@@ -7,6 +7,6 @@ export default defineConfig({
   loader: {
     '.svg': 'dataurl',
     '.jpg': 'dataurl',
-    '.md': 'text'
+    '.md': 'text',
   },
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1975,9 +1975,11 @@ __metadata:
     concurrently: ^7.6.0
     cz-conventional-changelog: 3.3.0
     eslint: ^8.33.0
+    eslint-config-prettier: ^8.6.0
     eslint-config-react-app: ^7.0.1
     eslint-plugin-import: ^2.26.0
     eslint-plugin-react-hooks: ^4.6.0
+    prettier: 2.8.4
   languageName: unknown
   linkType: soft
 
@@ -6904,6 +6906,17 @@ __metadata:
     escodegen: bin/escodegen.js
     esgenerate: bin/esgenerate.js
   checksum: 5aa6b2966fafe0545e4e77936300cc94ad57cfe4dc4ebff9950492eaba83eef634503f12d7e3cbd644ecc1bab388ad0e92b06fd32222c9281a75d1cf02ec6cef
+  languageName: node
+  linkType: hard
+
+"eslint-config-prettier@npm:^8.6.0":
+  version: 8.6.0
+  resolution: "eslint-config-prettier@npm:8.6.0"
+  peerDependencies:
+    eslint: ">=7.0.0"
+  bin:
+    eslint-config-prettier: bin/cli.js
+  checksum: ff0d0dfc839a556355422293428637e8d35693de58dabf8638bf0b6529131a109d0b2ade77521aa6e54573bb842d7d9d322e465dd73dd61c7590fa3834c3fa81
   languageName: node
   linkType: hard
 
@@ -12778,6 +12791,15 @@ __metadata:
   version: 1.1.2
   resolution: "prelude-ls@npm:1.1.2"
   checksum: c4867c87488e4a0c233e158e4d0d5565b609b105d75e4c05dc760840475f06b731332eb93cc8c9cecb840aa8ec323ca3c9a56ad7820ad2e63f0261dadcb154e4
+  languageName: node
+  linkType: hard
+
+"prettier@npm:2.8.4":
+  version: 2.8.4
+  resolution: "prettier@npm:2.8.4"
+  bin:
+    prettier: bin-prettier.js
+  checksum: c173064bf3df57b6d93d19aa98753b9b9dd7657212e33b41ada8e2e9f9884066bb9ca0b4005b89b3ab137efffdf8fbe0b462785aba20364798ff4303aadda57e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
fix #92

From this commit, we use Prettier to format most of the project code in order to keep the same formatting rules across different IDEs such as VS Code and WebStorm the team use.

- You can run format check with `yarn format:check` and fix with `yarn format:fix`
- Format check is also integrated into the `Lint` CI workflow
- Please follow https://prettier.io/docs/en/editors.html to integrate Prettier settings with your editor. I recommend enabling auto formatting upon save files.

The Prettier rules I apply as the default:
```
module.exports = {
  printWidth: 120,
  semi: false,
  singleQuote: true,
  jsxSingleQuote: true,
  trailingComma: 'all',
  bracketSpacing: true,
  bracketSameLine: false,
  arrowParens: 'avoid',
}
```