### PR TITLE
Search on JMX tree (Fixes #24 and #72)

### DIFF
--- a/packages/hawtio/src/plugins/jmx/JmxTreeView.tsx
+++ b/packages/hawtio/src/plugins/jmx/JmxTreeView.tsx
@@ -8,16 +8,15 @@ import './JmxTreeView.css'
 export const JmxTreeView: React.FunctionComponent = () => {
   const { tree, node, setNode } = useContext(MBeanTreeContext)
   const [expanded, setExpanded] = useState(false)
-  const [filteredTree, updateTree] = useState(tree.getTree())
+  const [filteredTree, setFilteredTree] = useState(tree.getTree())
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const onSearch = (event: ChangeEvent<HTMLInputElement>) => {
-    if (!event.target.value) updateTree(tree.getTree())
+    if (!event.target.value) setFilteredTree(tree.getTree())
 
     const treeElements = lookupSearchInTree(event.target.value, tree.getTree())
 
-    if (treeElements.length === 0) updateTree(tree.getTree())
-    else updateTree(treeElements)
+    if (treeElements.length === 0) setFilteredTree(tree.getTree())
+    else setFilteredTree(treeElements)
   }
 
   const onSelect = (event: React.MouseEvent<Element, MouseEvent>, item: TreeViewDataItem) => {
@@ -25,11 +24,11 @@ export const JmxTreeView: React.FunctionComponent = () => {
   }
 
   const lookupSearchInTree = (search: string, tree?: MBeanNode[]): MBeanNode[] => {
-    if (tree?.length === 0) return []
+    if (!tree || tree?.length === 0) return []
 
     let results: MBeanNode[] = []
 
-    for (const parentNode of tree || []) {
+    for (const parentNode of tree) {
       if (parentNode.name.toLowerCase().includes(search.toLowerCase())) {
         results = results.concat(parentNode)
       } else {

--- a/packages/hawtio/src/plugins/jmx/JmxTreeView.tsx
+++ b/packages/hawtio/src/plugins/jmx/JmxTreeView.tsx
@@ -1,7 +1,7 @@
 import { TreeView, TreeViewDataItem } from '@patternfly/react-core'
 import React, { ChangeEvent, useContext, useState } from 'react'
-import { PluginTreeViewToolbar } from '@hawtio/plugins/shared'
-import { MBeanNode } from '@hawtio/plugins/shared'
+import { PluginTreeViewToolbar } from '@hawtiosrc/plugins/shared'
+import { MBeanNode } from '@hawtiosrc/plugins/shared'
 import { MBeanTreeContext } from './context'
 import './JmxTreeView.css'
 

--- a/packages/hawtio/src/plugins/jmx/JmxTreeView.tsx
+++ b/packages/hawtio/src/plugins/jmx/JmxTreeView.tsx
@@ -6,45 +6,45 @@ import { MBeanTreeContext } from './context'
 import './JmxTreeView.css'
 
 export const JmxTreeView: React.FunctionComponent = () => {
-  const { tree, node, setNode } = useContext(MBeanTreeContext);
-  const [expanded, setExpanded] = useState(false);
-  const [filteredTree, updateTree] = useState(tree.getTree());
+  const { tree, node, setNode } = useContext(MBeanTreeContext)
+  const [expanded, setExpanded] = useState(false)
+  const [filteredTree, updateTree] = useState(tree.getTree())
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const onSearch = (event: ChangeEvent<HTMLInputElement>) => {
-    if(!event.target.value) updateTree(tree.getTree());
-    
-    const treeElements = lookupSearchInTree(event.target.value, tree.getTree());
+    if (!event.target.value) updateTree(tree.getTree())
+
+    const treeElements = lookupSearchInTree(event.target.value, tree.getTree())
 
     if (treeElements.length == 0) updateTree(tree.getTree())
-    else updateTree(treeElements);
+    else updateTree(treeElements)
   }
 
   const onSelect = (event: React.MouseEvent<Element, MouseEvent>, item: TreeViewDataItem) => {
     setNode(item as MBeanNode)
   }
 
-  const lookupSearchInTree = (search: string, tree?: MBeanNode[]) : MBeanNode[] => {
-    if (tree?.length == 0) return [];
-    
-    let results : MBeanNode[] = [];
+  const lookupSearchInTree = (search: string, tree?: MBeanNode[]): MBeanNode[] => {
+    if (tree?.length == 0) return []
+
+    let results: MBeanNode[] = []
 
     for (let parentNode of tree || []) {
-      if(parentNode.name.toLowerCase().includes(search.toLowerCase())) {
-        results = results.concat(parentNode);
+      if (parentNode.name.toLowerCase().includes(search.toLowerCase())) {
+        results = results.concat(parentNode)
       } else {
-        const resultsInSubtree = lookupSearchInTree(search, parentNode.children);
+        const resultsInSubtree = lookupSearchInTree(search, parentNode.children)
 
         if (resultsInSubtree.length != 0) {
-          const parentNodeCloned = Object.assign({}, parentNode); 
-          parentNodeCloned.children = resultsInSubtree;
+          const parentNodeCloned = Object.assign({}, parentNode)
+          parentNodeCloned.children = resultsInSubtree
 
-          results = results.concat(parentNodeCloned);
+          results = results.concat(parentNodeCloned)
         }
       }
     }
 
-    return results;
+    return results
   }
 
   return (
@@ -53,7 +53,7 @@ export const JmxTreeView: React.FunctionComponent = () => {
       data={filteredTree}
       hasGuides={true}
       hasSelectableNodes={true}
-      activeItems={node ? [node] : [] }
+      activeItems={node ? [node] : []}
       allExpanded={expanded}
       onSelect={onSelect}
       toolbar={<PluginTreeViewToolbar onSearch={onSearch} onSetExpanded={setExpanded} />}

--- a/packages/hawtio/src/plugins/jmx/JmxTreeView.tsx
+++ b/packages/hawtio/src/plugins/jmx/JmxTreeView.tsx
@@ -6,23 +6,54 @@ import { MBeanTreeContext } from './context'
 import './JmxTreeView.css'
 
 export const JmxTreeView: React.FunctionComponent = () => {
-  const { tree, setNode } = useContext(MBeanTreeContext)
-  const [expanded, setExpanded] = useState(false)
+  const { tree, node, setNode } = useContext(MBeanTreeContext);
+  const [expanded, setExpanded] = useState(false);
+  const [filteredTree, updateTree] = useState(tree.getTree());
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const onSearch = (event: ChangeEvent<HTMLInputElement>) => {
-    // TODO
+    if(!event.target.value) updateTree(tree.getTree());
+    
+    const treeElements = lookupSearchInTree(event.target.value, tree.getTree());
+
+    if (treeElements.length == 0) updateTree(tree.getTree())
+    else updateTree(treeElements);
   }
 
   const onSelect = (event: React.MouseEvent<Element, MouseEvent>, item: TreeViewDataItem) => {
     setNode(item as MBeanNode)
   }
 
+  const lookupSearchInTree = (search: string, tree?: MBeanNode[]) : MBeanNode[] => {
+    if (tree?.length == 0) return [];
+    
+    let results : MBeanNode[] = [];
+
+    for (let parentNode of tree || []) {
+      if(parentNode.name.toLowerCase().includes(search.toLowerCase())) {
+        results = results.concat(parentNode);
+      } else {
+        const resultsInSubtree = lookupSearchInTree(search, parentNode.children);
+
+        if (resultsInSubtree.length != 0) {
+          const parentNodeCloned = Object.assign({}, parentNode); 
+          parentNodeCloned.children = resultsInSubtree;
+
+          results = results.concat(parentNodeCloned);
+        }
+      }
+    }
+
+    return results;
+  }
+
   return (
     <TreeView
       id='jmx-tree-view'
-      data={tree.getTree()}
+      data={filteredTree}
       hasGuides={true}
+      hasSelectableNodes={true}
+      activeItems={node ? [node] : [] }
       allExpanded={expanded}
       onSelect={onSelect}
       toolbar={<PluginTreeViewToolbar onSearch={onSearch} onSetExpanded={setExpanded} />}

--- a/packages/hawtio/src/plugins/jmx/JmxTreeView.tsx
+++ b/packages/hawtio/src/plugins/jmx/JmxTreeView.tsx
@@ -1,7 +1,7 @@
 import { TreeView, TreeViewDataItem } from '@patternfly/react-core'
 import React, { ChangeEvent, useContext, useState } from 'react'
-import { PluginTreeViewToolbar } from '@hawtiosrc/plugins/shared'
-import { MBeanNode } from '@hawtiosrc/plugins/shared'
+import { PluginTreeViewToolbar } from '@hawtio/plugins/shared'
+import { MBeanNode } from '@hawtio/plugins/shared'
 import { MBeanTreeContext } from './context'
 import './JmxTreeView.css'
 

--- a/packages/hawtio/src/plugins/jmx/JmxTreeView.tsx
+++ b/packages/hawtio/src/plugins/jmx/JmxTreeView.tsx
@@ -16,7 +16,7 @@ export const JmxTreeView: React.FunctionComponent = () => {
 
     const treeElements = lookupSearchInTree(event.target.value, tree.getTree())
 
-    if (treeElements.length == 0) updateTree(tree.getTree())
+    if (treeElements.length === 0) updateTree(tree.getTree())
     else updateTree(treeElements)
   }
 
@@ -25,17 +25,17 @@ export const JmxTreeView: React.FunctionComponent = () => {
   }
 
   const lookupSearchInTree = (search: string, tree?: MBeanNode[]): MBeanNode[] => {
-    if (tree?.length == 0) return []
+    if (tree?.length === 0) return []
 
     let results: MBeanNode[] = []
 
-    for (let parentNode of tree || []) {
+    for (const parentNode of tree || []) {
       if (parentNode.name.toLowerCase().includes(search.toLowerCase())) {
         results = results.concat(parentNode)
       } else {
         const resultsInSubtree = lookupSearchInTree(search, parentNode.children)
 
-        if (resultsInSubtree.length != 0) {
+        if (resultsInSubtree.length !== 0) {
           const parentNodeCloned = Object.assign({}, parentNode)
           parentNodeCloned.children = resultsInSubtree
 


### PR DESCRIPTION
Search on JMX tree and highlight of selected node.

Tree search functionality is as follows:

- If parent node is a hit bring the parent node completely.
- If parent node is not a hit but any subnodes are hits, return the parent with only the subnodes that are hits. (Subnodes follow the same rule as above).
- If there are no hits in parent or subnodes, it's not shown.

![jmxsearch](https://user-images.githubusercontent.com/17336236/221526492-7bdb10bc-b5dc-4204-af6b-1b9c0f09d72d.gif)

@phantomjinx  I saw that you did one search functionality and put it in the class JMBeanTree. Would you like me to update it? Right now yours wont retrieve children nodes on parent hits.

|-> Will be setting up a PR in the future refactoring this code to the general case for both JMX and Camel

Also another gif showing the highlight in action 

![highlighting](https://user-images.githubusercontent.com/17336236/221547201-be89168b-f019-45a2-b656-37143cc588dd.gif)


Fixed the issue with the broken yarn build with @tadayosi [suggestion](https://github.com/hawtio/hawtio-next/pull/119#issuecomment-1446097088). Using yarn build:all or yarn build:camel-model does the trick :)
