### PR TITLE
#55 Home preferences, saving to local storage

### DIFF
--- a/packages/hawtio/src/preferences/HomePreferences.tsx
+++ b/packages/hawtio/src/preferences/HomePreferences.tsx
@@ -1,13 +1,49 @@
 import { Button, CardBody, Form, FormGroup, FormSection, Switch } from '@patternfly/react-core'
 import React, { useState } from 'react'
+import { string } from 'superstruct'
 import { log } from './globals'
 
+type LocalStorageFieldData<T> = {
+  localStorageKey: string,
+  defaultValue: T,
+  updateFunction: React.Dispatch<React.SetStateAction<T>>
+}
+
 export const HomePreferences: React.FunctionComponent = () => {
-  const [defaultVerticalNavState, setDefaultVerticalNavState] = useState(true)
+
+  const LOCAL_STORAGE_VERTICAL_NAVIGATION = "local_storage_vertical_navigation"
+  const DEFAULT_VALUE_VERTICAL_NAVIGATION = true;
+  
+  const VERTICAL_NAVIGATION_INITIAL_VALUE : boolean = 
+    localStorage.getItem(LOCAL_STORAGE_VERTICAL_NAVIGATION) !== null
+    ? localStorage.getItem(LOCAL_STORAGE_VERTICAL_NAVIGATION) === "true"
+    : DEFAULT_VALUE_VERTICAL_NAVIGATION;
+
+  const [defaultVerticalNavState, setDefaultVerticalNavState] = useState(VERTICAL_NAVIGATION_INITIAL_VALUE)
+
+  const VERTICAL_NAVIGATION_FIELD_PARAMETERS : LocalStorageFieldData<boolean> = {
+    localStorageKey: LOCAL_STORAGE_VERTICAL_NAVIGATION,
+    defaultValue: true,
+    updateFunction: setDefaultVerticalNavState
+  }
+
+  const FIELDS_TO_RESET = [VERTICAL_NAVIGATION_FIELD_PARAMETERS]
 
   const reset = () => {
-    // TODO: impl
-    log.info('TODO - Reset settings')
+    FIELDS_TO_RESET.forEach(
+      field => {
+        localStorage.removeItem(field.localStorageKey)
+        field.updateFunction(field.defaultValue)
+      }
+    )
+  }
+
+  const savingToLocalStorage = <T,>(keyToSave : string, updateFunction : React.Dispatch<React.SetStateAction<T>>) 
+    : React.Dispatch<React.SetStateAction<T>> => {
+    return (value) => {
+      localStorage.setItem(keyToSave, String(value))
+      return updateFunction(value)
+    };
   }
 
   const UIForm = () => (
@@ -16,7 +52,7 @@ export const HomePreferences: React.FunctionComponent = () => {
         label='Show vertical navigation'
         labelOff='Hide vertical navigation'
         isChecked={defaultVerticalNavState}
-        onChange={setDefaultVerticalNavState}
+        onChange={savingToLocalStorage(LOCAL_STORAGE_VERTICAL_NAVIGATION, setDefaultVerticalNavState)}
       />
     </FormGroup>
   )


### PR DESCRIPTION
Fixes #55 

Quick ticket, although I'm not sure if we are to implement the actual behaviour of the preference in this ticket as well.

Not so elegant solution, as I'd like to be able to have a list/dictionary configuring all the fields and their defaults, local storage keys and update functions, but I need to compute the initial value before retrieving the function, and I need the function before I can build the dictionary. So in the end I went with a simpler solution just adding all the data to an array

The array is used by the reset function to make sure everything goes back into place.

Even though this is a rather small preferences page, I'll be using a similar pattern in #28 

Gif showing it in action

![Preferences](https://user-images.githubusercontent.com/17336236/221568174-3f5ca28a-9b70-42c7-b38c-8375597198b9.gif)


