### PR TITLE
feat(#145): Provides TypeConverters view

### DIFF
--- a/packages/hawtio/src/plugins/camel/CamelContent.tsx
+++ b/packages/hawtio/src/plugins/camel/CamelContent.tsx
@@ -20,6 +20,7 @@ import { CamelContext } from './context'
 import { Attributes, Operations, Chart, JmxContentMBeans, MBeanNode } from '@hawtiosrc/plugins/shared'
 import { Contexts } from './contexts'
 import { Exchanges } from './exchanges'
+import { TypeConverters } from './type-converters'
 import * as ccs from './camel-content-service'
 
 export const CamelContent: React.FunctionComponent = () => {
@@ -68,6 +69,12 @@ export const CamelContent: React.FunctionComponent = () => {
       title: 'Exchanges',
       component: Exchanges,
       isApplicable: (node: MBeanNode) => ccs.hasExchange(node),
+    },
+    {
+      id: 'type-converters',
+      title: 'Type Converters',
+      component: TypeConverters,
+      isApplicable: (node: MBeanNode) => ccs.hasTypeConverter(node),
     },
   ]
 

--- a/packages/hawtio/src/plugins/camel/camel-content-service.ts
+++ b/packages/hawtio/src/plugins/camel/camel-content-service.ts
@@ -146,6 +146,41 @@ export function hasExchange(node: MBeanNode): boolean {
   )
 }
 
+export function findTypeConverter(node: MBeanNode): MBeanNode | null {
+  if (!node) return null
+
+  const ctxNode = findContext(node)
+  if (!ctxNode) return null
+
+  const result = ctxNode.navigate(mbeansType, 'services')
+  if (!result || !result.children) return null
+
+  const typeConvertor = result.getChildren().find(m => m.name.endsWith('TypeConverter'))
+  return !typeConvertor ? null : typeConvertor
+}
+
+export function canListTypeConverters(node: MBeanNode): boolean {
+  const tc = findTypeConverter(node)
+  if (!tc) return false
+
+  return workspace.hasInvokeRights(tc as MBeanNode, 'listTypeConverters')
+}
+
+export function hasTypeConverter(node: MBeanNode): boolean {
+  return (
+    node &&
+    !isRouteNode(node) &&
+    !isRouteXmlNode(node) &&
+    !isEndpointsFolder(node) &&
+    !isEndpointNode(node) &&
+    !isComponentsFolder(node) &&
+    !isComponentNode(node) &&
+    (isContext(node) || isRoutesFolder(node)) &&
+    isCamelVersionEQGT_2_13(node) &&
+    canListTypeConverters(node)
+  )
+}
+
 /**
  * Fetch the camel version and add it to the tree to avoid making a blocking call
  * elsewhere.

--- a/packages/hawtio/src/plugins/camel/contexts/Contexts.tsx
+++ b/packages/hawtio/src/plugins/camel/contexts/Contexts.tsx
@@ -17,14 +17,14 @@ import { Table, TableBody, TableHeader, TableProps, wrappable } from '@patternfl
 import { IResponse } from 'jolokia.js'
 import { AttributeValues } from '@hawtiosrc/plugins/connect/jolokia-service'
 import React, { useEffect, useState, useContext } from 'react'
-import { PluginNodeSelectionContext } from '@hawtiosrc/plugins'
+import { CamelContext } from '@hawtiosrc/plugins/camel/context'
 import { log } from '../globals'
 import { contextsService, ContextAttributes } from './contexts-service'
 import { eventService } from '@hawtiosrc/core'
 import { workspace } from '@hawtiosrc/plugins/shared'
 
 export const Contexts: React.FunctionComponent = () => {
-  const { selectedNode } = useContext(PluginNodeSelectionContext)
+  const { selectedNode } = useContext(CamelContext)
   const [isReading, setIsReading] = useState(true)
 
   const emptyCtxs: ContextAttributes[] = []

--- a/packages/hawtio/src/plugins/camel/type-converters/TypeConverters.css
+++ b/packages/hawtio/src/plugins/camel/type-converters/TypeConverters.css
@@ -1,0 +1,3 @@
+.camel-type-converters-statistics {
+  margin-left: 3em !important;
+}

--- a/packages/hawtio/src/plugins/camel/type-converters/TypeConverters.tsx
+++ b/packages/hawtio/src/plugins/camel/type-converters/TypeConverters.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { Card, CardTitle, CardBody } from '@patternfly/react-core'
+import { TypeConvertersStatistics } from './TypeConvertersStatistics'
+import './TypeConverters.css'
+
+export const TypeConverters: React.FunctionComponent = () => {
+  return (
+    <Card isFullHeight>
+      <CardTitle>Type Converters</CardTitle>
+      <CardBody>
+        <TypeConvertersStatistics></TypeConvertersStatistics>
+      </CardBody>
+    </Card>
+  )
+}

--- a/packages/hawtio/src/plugins/camel/type-converters/TypeConvertersStatistics.test.tsx
+++ b/packages/hawtio/src/plugins/camel/type-converters/TypeConvertersStatistics.test.tsx
@@ -1,0 +1,249 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MBeanNode, MBeanTree } from '@hawtiosrc/plugins/shared/tree'
+import { workspace } from '@hawtiosrc/plugins/shared/workspace'
+import { CamelContext } from '../context'
+import { jmxDomain } from '../globals'
+import { camelTreeProcessor } from '@hawtiosrc/plugins/camel/tree-processor'
+import { jolokiaService } from '@hawtiosrc/plugins/connect'
+import { TypeConvertersStatistics } from './TypeConvertersStatistics'
+import { TypeConvertersStats } from './type-converters-service'
+import fs from 'fs'
+import path from 'path'
+
+const routesXmlPath = path.resolve(__dirname, '..', 'testdata', 'camel-sample-app-routes.xml')
+const sampleRoutesXml = fs.readFileSync(routesXmlPath, { encoding: 'utf8', flag: 'r' })
+
+/**
+ * Mock the routes xml to provide a full tree
+ */
+jest.mock('@hawtiosrc/plugins/connect/jolokia-service')
+jolokiaService.execute = jest.fn(async (mbean: string, operation: string, args?: unknown[]): Promise<unknown> => {
+  if (
+    mbean === 'org.apache.camel:context=SampleCamel,type=context,name="SampleCamel"' &&
+    operation === 'dumpRoutesAsXml()'
+  ) {
+    return sampleRoutesXml
+  }
+
+  return ''
+})
+
+let testStats: TypeConvertersStats = new TypeConvertersStats()
+let canDisplayTypeConvertersStatistics = false
+
+/**
+ * This has to be outside of the describe and test blocks.
+ * Otherwise, it is ignored & the real function is used
+ */
+jest.mock('./type-converters-service', () => {
+  const originalModule = jest.requireActual('./type-converters-service')
+  return {
+    ...originalModule,
+    getStatisticsEnablement: jest.fn(async (node: MBeanNode | null) => {
+      return Promise.resolve(canDisplayTypeConvertersStatistics)
+    }),
+    setStatisticsEnablement: jest.fn(async (node: MBeanNode, state: boolean): Promise<unknown> => {
+      canDisplayTypeConvertersStatistics = state
+      return Promise.resolve(true)
+    }),
+    getStatistics: jest.fn(async (node: MBeanNode | null): Promise<TypeConvertersStats> => {
+      return Promise.resolve(testStats)
+    }),
+  }
+})
+
+describe('TypeConvertersStatistics', () => {
+  let tree: MBeanTree
+
+  beforeAll(async () => {
+    tree = await workspace.getTree()
+    camelTreeProcessor(tree)
+  })
+
+  beforeEach(async () => {
+    canDisplayTypeConvertersStatistics = false // reset for each test
+    testStats = new TypeConvertersStats()
+  })
+
+  test('default values', async () => {
+    // canDisplayTypeConvertersStatistics = false
+    render(<TypeConvertersStatistics />)
+
+    await screen.findByTestId('no-stats-available')
+
+    expect(screen.getByTestId('no-stats-available')).toHaveTextContent('No statistics available.')
+  })
+
+  test('selected node provided statistics disabled', async () => {
+    const domainNode: MBeanNode = tree.get(jmxDomain) as MBeanNode
+    expect(domainNode).not.toBeNull()
+    const contextsNode: MBeanNode = domainNode.getIndex(0) as MBeanNode
+    expect(contextsNode).not.toBeNull()
+    const contextNode: MBeanNode = contextsNode.getIndex(0) as MBeanNode
+    expect(contextNode).not.toBeNull()
+
+    const selectedNode = contextNode
+    const setSelectedNode = () =>
+      void (
+        {
+          /* no op */
+        }
+      )
+    render(
+      <CamelContext.Provider value={{ tree, selectedNode, setSelectedNode }}>
+        <TypeConvertersStatistics />
+      </CamelContext.Provider>,
+    )
+
+    await screen.findByTestId('stats-view-list')
+
+    const statsView = await screen.findByTestId('stats-view-list')
+    expect(statsView).toBeInTheDocument()
+    expect(screen.getByTestId('attemptCounter')).toHaveTextContent('-')
+    expect(screen.getByTestId('hitCounter')).toHaveTextContent('-')
+    expect(screen.getByTestId('missesCounter')).toHaveTextContent('-')
+    expect(screen.getByTestId('failedCounter')).toHaveTextContent('-')
+  })
+
+  test('selected node provided statistics enabled', async () => {
+    canDisplayTypeConvertersStatistics = true
+
+    const domainNode: MBeanNode = tree.get(jmxDomain) as MBeanNode
+    expect(domainNode).not.toBeNull()
+    const contextsNode: MBeanNode = domainNode.getIndex(0) as MBeanNode
+    expect(contextsNode).not.toBeNull()
+    const contextNode: MBeanNode = contextsNode.getIndex(0) as MBeanNode
+    expect(contextNode).not.toBeNull()
+
+    const selectedNode = contextNode
+    const setSelectedNode = () =>
+      void (
+        {
+          /* no op */
+        }
+      )
+    render(
+      <CamelContext.Provider value={{ tree, selectedNode, setSelectedNode }}>
+        <TypeConvertersStatistics />
+      </CamelContext.Provider>,
+    )
+
+    await screen.findByTestId('stats-view-list')
+
+    const statsView = await screen.findByTestId('stats-view-list')
+    expect(statsView).toBeInTheDocument()
+    expect(screen.getByTestId('attemptCounter')).toHaveTextContent('0')
+    expect(screen.getByTestId('hitCounter')).toHaveTextContent('0')
+    expect(screen.getByTestId('missesCounter')).toHaveTextContent('0')
+    expect(screen.getByTestId('failedCounter')).toHaveTextContent('0')
+  })
+
+  test('selected node provided statistics enabled with stats', async () => {
+    canDisplayTypeConvertersStatistics = true
+    testStats = {
+      attemptCounter: 5,
+      hitCounter: 4,
+      missCounter: 3,
+      failedCounter: 2,
+    }
+
+    const domainNode: MBeanNode = tree.get(jmxDomain) as MBeanNode
+    expect(domainNode).not.toBeNull()
+    const contextsNode: MBeanNode = domainNode.getIndex(0) as MBeanNode
+    expect(contextsNode).not.toBeNull()
+    const contextNode: MBeanNode = contextsNode.getIndex(0) as MBeanNode
+    expect(contextNode).not.toBeNull()
+
+    const selectedNode = contextNode
+    const setSelectedNode = () =>
+      void (
+        {
+          /* no op */
+        }
+      )
+    render(
+      <CamelContext.Provider value={{ tree, selectedNode, setSelectedNode }}>
+        <TypeConvertersStatistics />
+      </CamelContext.Provider>,
+    )
+
+    await screen.findByTestId('stats-view-list')
+
+    const statsView = await screen.findByTestId('stats-view-list')
+    expect(statsView).toBeInTheDocument()
+
+    await waitFor(() =>
+      expect(screen.getByTestId('attemptCounter')).toHaveTextContent(String(testStats.attemptCounter)),
+    )
+    await waitFor(() => expect(screen.getByTestId('hitCounter')).toHaveTextContent(String(testStats.hitCounter)))
+    await waitFor(() => expect(screen.getByTestId('missesCounter')).toHaveTextContent(String(testStats.missCounter)))
+    await waitFor(() => expect(screen.getByTestId('failedCounter')).toHaveTextContent(String(testStats.failedCounter)))
+  })
+
+  test('selected node provided statistics first disabled then enabled', async () => {
+    testStats = {
+      attemptCounter: 5,
+      hitCounter: 4,
+      missCounter: 3,
+      failedCounter: 2,
+    }
+
+    const domainNode: MBeanNode = tree.get(jmxDomain) as MBeanNode
+    expect(domainNode).not.toBeNull()
+    const contextsNode: MBeanNode = domainNode.getIndex(0) as MBeanNode
+    expect(contextsNode).not.toBeNull()
+    const contextNode: MBeanNode = contextsNode.getIndex(0) as MBeanNode
+    expect(contextNode).not.toBeNull()
+
+    const selectedNode = contextNode
+    const setSelectedNode = () =>
+      void (
+        {
+          /* no op */
+        }
+      )
+
+    const ConverterStats = (
+      <CamelContext.Provider value={{ tree, selectedNode, setSelectedNode }}>
+        <TypeConvertersStatistics />
+      </CamelContext.Provider>
+    )
+
+    const { rerender } = render(ConverterStats)
+
+    await screen.findByTestId('stats-view-list')
+
+    let statsView = await screen.findByTestId('stats-view-list')
+    expect(statsView).toBeInTheDocument()
+
+    /*
+     * The statistics are disabled so expect '-'
+     */
+    await waitFor(() => expect(screen.getByTestId('attemptCounter')).toHaveTextContent('-'))
+    await waitFor(() => expect(screen.getByTestId('hitCounter')).toHaveTextContent('-'))
+    await waitFor(() => expect(screen.getByTestId('missesCounter')).toHaveTextContent('-'))
+    await waitFor(() => expect(screen.getByTestId('failedCounter')).toHaveTextContent('-'))
+
+    /*
+     * Enable the statistics
+     */
+    const enableButton = screen.getByRole('button', { name: /Enable Statistics/i })
+    expect(enableButton).toBeInTheDocument()
+
+    /* Click the unblock button */
+    fireEvent.click(enableButton)
+
+    /* Re-render the page */
+    rerender(ConverterStats)
+
+    statsView = await screen.findByTestId('stats-view-list')
+    expect(statsView).toBeInTheDocument()
+
+    await waitFor(() =>
+      expect(screen.getByTestId('attemptCounter')).toHaveTextContent(String(testStats.attemptCounter)),
+    )
+    await waitFor(() => expect(screen.getByTestId('hitCounter')).toHaveTextContent(String(testStats.hitCounter)))
+    await waitFor(() => expect(screen.getByTestId('missesCounter')).toHaveTextContent(String(testStats.missCounter)))
+    await waitFor(() => expect(screen.getByTestId('failedCounter')).toHaveTextContent(String(testStats.failedCounter)))
+  })
+})

--- a/packages/hawtio/src/plugins/camel/type-converters/TypeConvertersStatistics.tsx
+++ b/packages/hawtio/src/plugins/camel/type-converters/TypeConvertersStatistics.tsx
@@ -1,0 +1,172 @@
+import React, { useContext, useEffect, useState } from 'react'
+import {
+  Button,
+  DescriptionList,
+  DescriptionListTerm,
+  DescriptionListGroup,
+  DescriptionListDescription,
+  Text,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
+} from '@patternfly/react-core'
+import { RedoIcon, TrendUpIcon } from '@patternfly/react-icons'
+import { CamelContext } from '@hawtiosrc/plugins/camel/context'
+import { MBeanNode } from '@hawtiosrc/plugins/shared/tree'
+import { eventService } from '@hawtiosrc/core'
+import * as tcs from './type-converters-service'
+
+const enableButtonLabelValue = 'Enable Statistics'
+const disableButtonLabelValue = 'Disable Statistics'
+
+export const TypeConvertersStatistics: React.FunctionComponent = () => {
+  const { selectedNode } = useContext(CamelContext)
+  const [isReading, setIsReading] = useState(true)
+  const [statistics, setStatistics] = useState<tcs.TypeConvertersStats>(new tcs.TypeConvertersStats())
+  const [statisticsEnabled, setStatisticsEnabled] = useState(false)
+
+  const onModeStatisticsClicked = () => {
+    tcs.setStatisticsEnablement(selectedNode as MBeanNode, !statisticsEnabled).then(_ => {
+      setStatisticsEnabled(!statisticsEnabled)
+    })
+  }
+
+  const onResetStatisticsClicked = () => {
+    setStatistics(new tcs.TypeConvertersStats())
+    tcs.resetStatistics(selectedNode as MBeanNode)
+  }
+
+  const modeStatisticsValue = (value: number): string => {
+    return statisticsEnabled ? `${value}` : '-'
+  }
+
+  /**
+   * Runs on load to determine if statistics are enabled
+   * and set the flag accordingly
+   */
+  useEffect(() => {
+    setIsReading(true)
+
+    const checkEnabled = async () => {
+      const enabled = await tcs.getStatisticsEnablement(selectedNode)
+      setStatisticsEnabled(enabled)
+      setIsReading(false)
+    }
+
+    checkEnabled()
+  }, [selectedNode])
+
+  /**
+   * Executes on change of statisticsEnabled flag in that
+   * statistics are only fetched when that flag is true
+   * Importantly, the timeout is not executed in the background
+   * if statistic collection is disabled
+   */
+  useEffect(() => {
+    if (!statisticsEnabled) return
+
+    let timeoutHandle: NodeJS.Timeout
+    const readStats = async () => {
+      try {
+        if (statisticsEnabled) {
+          const stats = await tcs.getStatistics(selectedNode)
+          setStatistics(stats)
+        }
+
+        timeoutHandle = setTimeout(readStats, 10000)
+      } catch (error) {
+        eventService.notify({
+          type: 'warning',
+          message: error as string,
+        })
+      }
+    }
+    readStats()
+
+    return () => {
+      clearTimeout(timeoutHandle)
+    }
+  }, [selectedNode, statisticsEnabled])
+
+  if (!selectedNode) {
+    return (
+      <React.Fragment>
+        <Text data-testid='no-stats-available' component='p'>
+          No statistics available.
+        </Text>
+      </React.Fragment>
+    )
+  }
+
+  if (isReading) {
+    return (
+      <React.Fragment>
+        <Text data-testid='loading' component='p'>
+          Loading ...
+        </Text>
+      </React.Fragment>
+    )
+  }
+
+  return (
+    <React.Fragment>
+      <Toolbar data-testid='stats-view-toolbar' id='toolbar-items'>
+        <ToolbarContent>
+          <ToolbarItem>
+            <Button
+              variant='secondary'
+              isSmall={true}
+              icon={React.createElement(TrendUpIcon)}
+              onClick={onModeStatisticsClicked}
+            >
+              {statisticsEnabled ? disableButtonLabelValue : enableButtonLabelValue}
+            </Button>
+          </ToolbarItem>
+          <ToolbarItem>
+            <Button
+              variant='secondary'
+              isSmall={true}
+              isDisabled={!statisticsEnabled}
+              icon={React.createElement(RedoIcon)}
+              onClick={onResetStatisticsClicked}
+            >
+              Reset Statistics
+            </Button>
+          </ToolbarItem>
+          <ToolbarItem variant='separator' />
+        </ToolbarContent>
+      </Toolbar>
+      <DescriptionList
+        isHorizontal
+        isCompact
+        className='camel-type-converters-statistics'
+        data-testid='stats-view-list'
+      >
+        <DescriptionListGroup>
+          <DescriptionListTerm>Attempts</DescriptionListTerm>
+          <DescriptionListDescription data-testid='attemptCounter'>
+            {modeStatisticsValue(statistics.attemptCounter)}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Hits</DescriptionListTerm>
+          <DescriptionListDescription data-testid='hitCounter'>
+            {modeStatisticsValue(statistics.hitCounter)}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Misses</DescriptionListTerm>
+          <DescriptionListDescription data-testid='missesCounter'>
+            {modeStatisticsValue(statistics.missCounter)}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Failures</DescriptionListTerm>
+          <DescriptionListDescription data-testid='failedCounter'>
+            {modeStatisticsValue(statistics.failedCounter)}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+      </DescriptionList>
+    </React.Fragment>
+  )
+}

--- a/packages/hawtio/src/plugins/camel/type-converters/index.ts
+++ b/packages/hawtio/src/plugins/camel/type-converters/index.ts
@@ -1,0 +1,1 @@
+export { TypeConverters } from './TypeConverters'

--- a/packages/hawtio/src/plugins/camel/type-converters/type-converters-service.test.tsx
+++ b/packages/hawtio/src/plugins/camel/type-converters/type-converters-service.test.tsx
@@ -1,0 +1,117 @@
+import { MBeanNode, MBeanTree, workspace } from '@hawtiosrc/plugins/shared'
+import { jmxDomain } from '../globals'
+import { camelTreeProcessor } from '@hawtiosrc/plugins/camel/tree-processor'
+import { jolokiaService } from '@hawtiosrc/plugins/connect'
+import * as tcs from './type-converters-service'
+import fs from 'fs'
+import path from 'path'
+import { AttributeValues } from '@hawtiosrc/plugins/connect/jolokia-service'
+
+const routesXmlPath = path.resolve(__dirname, '..', 'testdata', 'camel-sample-app-routes.xml')
+const sampleRoutesXml = fs.readFileSync(routesXmlPath, { encoding: 'utf8', flag: 'r' })
+
+const testStats: tcs.TypeConvertersStats = {
+  attemptCounter: 5,
+  hitCounter: 4,
+  missCounter: 3,
+  failedCounter: 2,
+}
+
+let canDisplayTypeConvertersStatistics = false
+
+/**
+ * Mock the routes xml to provide a full tree
+ */
+jest.mock('@hawtiosrc/plugins/connect/jolokia-service')
+jolokiaService.execute = jest.fn(async (mbean: string, operation: string, args?: unknown[]): Promise<unknown> => {
+  if (
+    mbean === 'org.apache.camel:context=SampleCamel,type=context,name="SampleCamel"' &&
+    operation === 'dumpRoutesAsXml()'
+  ) {
+    return sampleRoutesXml
+  }
+
+  return ''
+})
+
+jolokiaService.readAttributes = jest.fn(async (mbean: string): Promise<AttributeValues> => {
+  if (mbean.endsWith('DefaultTypeConverter')) {
+    const av: AttributeValues = {
+      AttemptCounter: testStats.attemptCounter,
+      HitCounter: testStats.hitCounter,
+      MissCounter: testStats.missCounter,
+      FailedCounter: testStats.failedCounter,
+    }
+    return av
+  }
+
+  return {}
+})
+
+jolokiaService.readAttribute = jest.fn(async (mbean: string, attr: string): Promise<unknown> => {
+  if (attr === 'StatisticsEnabled') {
+    return canDisplayTypeConvertersStatistics
+  }
+
+  return false
+})
+
+jolokiaService.writeAttribute = jest.fn(async (mbean: string, attr: string, value: unknown): Promise<unknown> => {
+  if (attr === 'StatisticsEnabled') {
+    canDisplayTypeConvertersStatistics = value as boolean
+  }
+
+  return true
+})
+
+describe('type-converters-service', () => {
+  let tree: MBeanTree
+
+  beforeAll(async () => {
+    tree = await workspace.getTree()
+    camelTreeProcessor(tree)
+  })
+
+  beforeEach(async () => {
+    canDisplayTypeConvertersStatistics = false
+    // xchgs = [] // reset xchgs to empty
+  })
+
+  test('getStatisticsEnablement', async () => {
+    canDisplayTypeConvertersStatistics = true
+
+    const domainNode: MBeanNode = tree.get(jmxDomain) as MBeanNode
+    expect(domainNode).not.toBeNull()
+    const contextsNode: MBeanNode = domainNode.getIndex(0) as MBeanNode
+    expect(contextsNode).not.toBeNull()
+    const contextNode: MBeanNode = contextsNode.getIndex(0) as MBeanNode
+    expect(contextNode).not.toBeNull()
+
+    const state = await tcs.getStatisticsEnablement(contextNode)
+    expect(state).toBeTruthy()
+  })
+
+  test('setStatisticsEnablement', async () => {
+    const domainNode: MBeanNode = tree.get(jmxDomain) as MBeanNode
+    expect(domainNode).not.toBeNull()
+    const contextsNode: MBeanNode = domainNode.getIndex(0) as MBeanNode
+    expect(contextsNode).not.toBeNull()
+    const contextNode: MBeanNode = contextsNode.getIndex(0) as MBeanNode
+    expect(contextNode).not.toBeNull()
+
+    await tcs.setStatisticsEnablement(contextNode, true)
+    expect(canDisplayTypeConvertersStatistics).toBeTruthy()
+  })
+
+  test('getStatistics', async () => {
+    const domainNode: MBeanNode = tree.get(jmxDomain) as MBeanNode
+    expect(domainNode).not.toBeNull()
+    const contextsNode: MBeanNode = domainNode.getIndex(0) as MBeanNode
+    expect(contextsNode).not.toBeNull()
+    const contextNode: MBeanNode = contextsNode.getIndex(0) as MBeanNode
+    expect(contextNode).not.toBeNull()
+
+    const stats = await tcs.getStatistics(contextNode)
+    expect(stats).toEqual(testStats)
+  })
+})

--- a/packages/hawtio/src/plugins/camel/type-converters/type-converters-service.ts
+++ b/packages/hawtio/src/plugins/camel/type-converters/type-converters-service.ts
@@ -1,0 +1,91 @@
+import { jolokiaService } from '@hawtiosrc/plugins/connect'
+import { MBeanNode } from '@hawtiosrc/plugins/shared/tree'
+import { findContext } from '@hawtiosrc/plugins/camel/camel-content-service'
+import { mbeansType } from '../globals'
+
+export class TypeConvertersStats {
+  attemptCounter: number
+  hitCounter: number
+  missCounter: number
+  failedCounter: number
+
+  constructor() {
+    this.attemptCounter = 0
+    this.hitCounter = 0
+    this.missCounter = 0
+    this.failedCounter = 0
+  }
+}
+
+export class TypeConverter {
+  constructor(public from: string, public to: string) {
+    this.from = from
+    this.to = to
+  }
+}
+
+function getTypeConverterObjectName(node: MBeanNode): string | null {
+  const ctxNode = findContext(node)
+  if (!ctxNode) return null
+
+  const service = ctxNode.navigate(mbeansType, 'services', '*TypeConverter') as MBeanNode
+  if (!service) return null
+
+  return service.objectName as string
+}
+
+/**
+ * Get the TypeConverter 'StatisticsEnabled' attribute
+ * @param node the node selected
+ */
+export async function getStatisticsEnablement(node: MBeanNode | null): Promise<boolean> {
+  if (!node) return false
+
+  const serviceName = getTypeConverterObjectName(node)
+  if (!serviceName) return Promise.reject()
+
+  const response = await jolokiaService.readAttribute(serviceName, 'StatisticsEnabled')
+  return response as boolean
+}
+
+/**
+ * Set the TypeConverter 'StatisticsEnabled' attribute
+ * @param node the node selected
+ * @param state the state of the attribute
+ */
+export async function setStatisticsEnablement(node: MBeanNode, state: boolean): Promise<unknown> {
+  const serviceName = getTypeConverterObjectName(node)
+  if (!serviceName) return Promise.reject()
+
+  return jolokiaService.writeAttribute(serviceName, 'StatisticsEnabled', state)
+}
+
+/**
+ * Reset the TypeConverters counters
+ * @param node the node selected
+ */
+export async function resetStatistics(node: MBeanNode): Promise<unknown> {
+  const serviceName = getTypeConverterObjectName(node)
+  if (!serviceName) return false
+
+  return await jolokiaService.execute(serviceName, 'resetTypeConversionCounters')
+}
+
+/**
+ * Get the TypeConverters statistics
+ * @param node the node selected
+ */
+export async function getStatistics(node: MBeanNode | null): Promise<TypeConvertersStats> {
+  const stats = new TypeConvertersStats()
+  if (!node) return stats
+
+  const serviceName = getTypeConverterObjectName(node)
+  if (!serviceName) return stats
+
+  const response = await jolokiaService.readAttributes(serviceName)
+  stats.attemptCounter = response['AttemptCounter'] as number
+  stats.hitCounter = response['HitCounter'] as number
+  stats.missCounter = response['MissCounter'] as number
+  stats.failedCounter = response['FailedCounter'] as number
+  return stats
+}

--- a/packages/hawtio/src/plugins/connect/jolokia-service.ts
+++ b/packages/hawtio/src/plugins/connect/jolokia-service.ts
@@ -362,6 +362,16 @@ class JolokiaService implements IJolokiaService {
     })
   }
 
+  async writeAttribute(mbean: string, attribute: string, value: unknown): Promise<unknown> {
+    const jolokia = await this.jolokia
+    return new Promise(resolve => {
+      jolokia.request(
+        { type: 'write', mbean, attribute, value },
+        onSuccess(response => resolve(response.value as unknown)),
+      )
+    })
+  }
+
   async execute(mbean: string, operation: string, args: unknown[] = []): Promise<unknown> {
     const jolokia = await this.jolokia
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
* jolokia-service
 * View that requires a writeAttribute function so implemented in same style as the 'read' function

* Contexts
 * Narrows the context to use the CamelContext rather than the more general plugin context. Allows for fewer imports when running jest unit tests