### PR TITLE
feat(#41): Camel preferences

### DIFF
--- a/packages/hawtio/src/plugins/camel/CamelPreferences.tsx
+++ b/packages/hawtio/src/plugins/camel/CamelPreferences.tsx
@@ -14,7 +14,7 @@ const CamelPreferencesForm: React.FunctionComponent = () => {
   const [camelPreferences, setCamelPreferences] = useState(camelPreferencesService.loadCamelPreferences())
 
   const updatePreferences = (value: boolean | number, key: keyof ICamelPreferences): void => {
-    const updatedPreferences = { ...camelPreferences, ...{ key: value } }
+    const updatedPreferences = { ...camelPreferences, ...{ [key]: value } }
 
     camelPreferencesService.saveCamelPreferences(updatedPreferences)
     setCamelPreferences(updatedPreferences)
@@ -31,9 +31,9 @@ const CamelPreferencesForm: React.FunctionComponent = () => {
     }
   }
 
-  const updateCheckboxValueFor = (key: keyof ICamelPreferences): ((value: boolean, _: any) => void) => {
+  const updateCheckboxValueFor = (key: keyof ICamelPreferences): ((value: boolean, _: React.FormEvent) => void) => {
     //Utility function generator to reduce boilerplate
-    return (value: boolean, _: any) => {
+    return (value: boolean, _: React.FormEvent) => {
       updatePreferences(value, key)
     }
   }

--- a/packages/hawtio/src/plugins/camel/CamelPreferences.tsx
+++ b/packages/hawtio/src/plugins/camel/CamelPreferences.tsx
@@ -1,0 +1,191 @@
+import { CardBody, Checkbox, Form, FormGroup, FormSection, TextInput } from '@patternfly/react-core'
+import React, { useState } from 'react'
+import { storageService } from './camel-preferences-storage-service'
+
+export const CamelPreferences: React.FunctionComponent = () => (
+  <CardBody>
+    <Form isHorizontal>
+      <CamelPreferencesForm />
+    </Form>
+  </CardBody>
+)
+
+const CamelPreferencesForm: React.FunctionComponent = () => {
+  const [isHideOptionDocumentation, setIsHideOptionDocumentation] = useState(
+    storageService.loadIsHideOptionDocumentation(),
+  )
+  const [isHideDefaultOptionValues, setIsHideDefaultOptionValues] = useState(
+    storageService.loadIsHideDefaultOptionValues(),
+  )
+  const [isHideUnusedOptionValues, setIsHideUnusedOptionValues] = useState(
+    storageService.loadIsHideUnusedOptionValues(),
+  )
+  const [isIncludeTraceDebugStreams, setIsIncludeTraceDebugStreams] = useState(
+    storageService.loadIsIncludeTraceDebugStreams(),
+  )
+  const [maximumTraceDebugBodyLength, setMaximumTraceDebugBodyLength] = useState(
+    storageService.loadMaximumTraceDebugBodyLength(),
+  )
+  const [maximumLabelWidth, setMaximumLabelWidth] = useState(storageService.loadMaximumLabelWidth())
+  const [isIgnoreIDForLabel, setIsIgnoreIDForLabel] = useState(storageService.loadIsIgnoreIDForLabel())
+  const [isShowInflightCounter, setIsShowInflightCounter] = useState(storageService.loadIsShowInflightCounter())
+  const [routeMetricMaximumSeconds, setRouteMetricMaximumSeconds] = useState(
+    storageService.loadRouteMetricMaximumSeconds(),
+  )
+
+  const onBooleanValueUpdated = (
+    value: boolean,
+    updateFunction: (value: boolean) => void,
+    saveToStorageFunction: (value: boolean) => void,
+  ): void => {
+    updateFunction(value)
+    saveToStorageFunction(value)
+  }
+
+  const onNumberValueUpdated = (
+    value: string,
+    updateFunction: (value: number) => void,
+    saveToStorageFunction: (value: number) => void,
+  ): void => {
+    const intValue = parseInt(value)
+
+    if (!intValue) return
+
+    updateFunction(intValue)
+    saveToStorageFunction(intValue)
+  }
+
+  const onIsHideOptionDocumentationChange = (value: boolean) =>
+    onBooleanValueUpdated(
+      value,
+      value => setIsHideOptionDocumentation(value),
+      value => storageService.setIsHideOptionDocumentation(value),
+    )
+
+  const onIsHideDefaultOptionValuesChange = (value: boolean) =>
+    onBooleanValueUpdated(
+      value,
+      value => setIsHideDefaultOptionValues(value),
+      value => storageService.setIsHideDefaultOptionValues(value),
+    )
+
+  const onIsHideUnusedOptionValuesChange = (value: boolean) =>
+    onBooleanValueUpdated(
+      value,
+      value => setIsHideUnusedOptionValues(value),
+      value => storageService.setIsHideUnusedOptionValues(value),
+    )
+
+  const onIsIncludeTraceDebugStreamsChange = (value: boolean) =>
+    onBooleanValueUpdated(
+      value,
+      value => setIsIncludeTraceDebugStreams(value),
+      value => storageService.setIsIncludeTraceDebugStreams(value),
+    )
+
+  const onMaximumTraceDebugBodyLengthChange = (value: string) =>
+    onNumberValueUpdated(
+      value,
+      value => setMaximumTraceDebugBodyLength(value),
+      value => storageService.setMaximumTraceDebugBodyLength(value),
+    )
+
+  const onMaximumLabelWidthChange = (value: string) =>
+    onNumberValueUpdated(
+      value,
+      value => setMaximumLabelWidth(value),
+      value => storageService.setMaximumLabelWidth(value),
+    )
+
+  const onIsIgnoreIDForLabelChange = (value: boolean) =>
+    onBooleanValueUpdated(
+      value,
+      value => setIsIgnoreIDForLabel(value),
+      value => storageService.setIsIgnoreIDForLabel(value),
+    )
+
+  const onIsShowInflightCounterChange = (value: boolean) =>
+    onBooleanValueUpdated(
+      value,
+      value => setIsShowInflightCounter(value),
+      value => storageService.setIsShowInflightCounter(value),
+    )
+
+  const onRouteMetricMaximumSecondsChange = (value: string) =>
+    onNumberValueUpdated(
+      value,
+      value => setRouteMetricMaximumSeconds(value),
+      value => storageService.setRouteMetricMaximumSeconds(value),
+    )
+
+  return (
+    <FormSection>
+      <FormGroup label='Hide option documentation' fieldId='camel-form-hide-option-documentation'>
+        <Checkbox
+          id='camel-form-hide-option-documentation'
+          isChecked={isHideOptionDocumentation}
+          onChange={(value, _) => onIsHideOptionDocumentationChange(value)}
+        />
+      </FormGroup>
+      <FormGroup label='Hide default options values' fieldId='camel-form-hide-default-option-value'>
+        <Checkbox
+          id='camel-form-hide-default-option-value'
+          isChecked={isHideDefaultOptionValues}
+          onChange={(value, _) => onIsHideDefaultOptionValuesChange(value)}
+        />
+      </FormGroup>
+      <FormGroup label='Hide unused options values' fieldId='camel-form-hide-unused-option-value'>
+        <Checkbox
+          id='camel-form-hide-unused-option-value'
+          isChecked={isHideUnusedOptionValues}
+          onChange={(value, _) => onIsHideUnusedOptionValuesChange(value)}
+        />
+      </FormGroup>
+      <FormGroup label='Include trace / debug streams' fieldId='camel-form-include-trace-debug-streams'>
+        <Checkbox
+          id='camel-form-include-trace-debug-streams'
+          isChecked={isIncludeTraceDebugStreams}
+          onChange={(value, _) => onIsIncludeTraceDebugStreamsChange(value)}
+        />
+      </FormGroup>
+      <FormGroup label='Maximum trace / debug body length' fieldId='camel-form-maximum-trace-debug-body-length'>
+        <TextInput
+          id='camel-form-maximum-trace-debug-body-length'
+          type='number'
+          value={maximumTraceDebugBodyLength}
+          onChange={onMaximumTraceDebugBodyLengthChange}
+        />
+      </FormGroup>
+      <FormGroup label='Maximum label width' fieldId='camel-form-maximum-label-width'>
+        <TextInput
+          id='camel-form-maximum-label-width'
+          type='number'
+          value={maximumLabelWidth}
+          onChange={onMaximumLabelWidthChange}
+        />
+      </FormGroup>
+      <FormGroup label='Ignore ID for label' fieldId='camel-form-ignore-id-for-label'>
+        <Checkbox
+          id='camel-form-ignore-id-for-label'
+          isChecked={isIgnoreIDForLabel}
+          onChange={(value, _) => onIsIgnoreIDForLabelChange(value)}
+        />
+      </FormGroup>
+      <FormGroup label='Show inflight counter' fieldId='camel-show-inflight-counter'>
+        <Checkbox
+          id='camel-show-inflight-counter'
+          isChecked={isShowInflightCounter}
+          onChange={(value, _) => onIsShowInflightCounterChange(value)}
+        />
+      </FormGroup>
+      <FormGroup label='Route metric maximum seconds' fieldId='camel-form-route-metric-maximum-seconds'>
+        <TextInput
+          id='camel-form-route-metric-maximum-seconds'
+          type='number'
+          value={routeMetricMaximumSeconds}
+          onChange={onRouteMetricMaximumSecondsChange}
+        />
+      </FormGroup>
+    </FormSection>
+  )
+}

--- a/packages/hawtio/src/plugins/camel/CamelPreferences.tsx
+++ b/packages/hawtio/src/plugins/camel/CamelPreferences.tsx
@@ -1,6 +1,6 @@
 import { CardBody, Checkbox, Form, FormGroup, FormSection, TextInput } from '@patternfly/react-core'
 import React, { useState } from 'react'
-import { storageService } from './camel-preferences-storage-service'
+import { camelPreferencesService } from './camel-preferences-service'
 
 export const CamelPreferences: React.FunctionComponent = () => (
   <CardBody>
@@ -12,25 +12,25 @@ export const CamelPreferences: React.FunctionComponent = () => (
 
 const CamelPreferencesForm: React.FunctionComponent = () => {
   const [isHideOptionDocumentation, setIsHideOptionDocumentation] = useState(
-    storageService.loadIsHideOptionDocumentation(),
+    camelPreferencesService.loadIsHideOptionDocumentation(),
   )
   const [isHideDefaultOptionValues, setIsHideDefaultOptionValues] = useState(
-    storageService.loadIsHideDefaultOptionValues(),
+    camelPreferencesService.loadIsHideDefaultOptionValues(),
   )
   const [isHideUnusedOptionValues, setIsHideUnusedOptionValues] = useState(
-    storageService.loadIsHideUnusedOptionValues(),
+    camelPreferencesService.loadIsHideUnusedOptionValues(),
   )
   const [isIncludeTraceDebugStreams, setIsIncludeTraceDebugStreams] = useState(
-    storageService.loadIsIncludeTraceDebugStreams(),
+    camelPreferencesService.loadIsIncludeTraceDebugStreams(),
   )
   const [maximumTraceDebugBodyLength, setMaximumTraceDebugBodyLength] = useState(
-    storageService.loadMaximumTraceDebugBodyLength(),
+    camelPreferencesService.loadMaximumTraceDebugBodyLength(),
   )
-  const [maximumLabelWidth, setMaximumLabelWidth] = useState(storageService.loadMaximumLabelWidth())
-  const [isIgnoreIDForLabel, setIsIgnoreIDForLabel] = useState(storageService.loadIsIgnoreIDForLabel())
-  const [isShowInflightCounter, setIsShowInflightCounter] = useState(storageService.loadIsShowInflightCounter())
+  const [maximumLabelWidth, setMaximumLabelWidth] = useState(camelPreferencesService.loadMaximumLabelWidth())
+  const [isIgnoreIDForLabel, setIsIgnoreIDForLabel] = useState(camelPreferencesService.loadIsIgnoreIDForLabel())
+  const [isShowInflightCounter, setIsShowInflightCounter] = useState(camelPreferencesService.loadIsShowInflightCounter())
   const [routeMetricMaximumSeconds, setRouteMetricMaximumSeconds] = useState(
-    storageService.loadRouteMetricMaximumSeconds(),
+    camelPreferencesService.loadRouteMetricMaximumSeconds(),
   )
 
   const onBooleanValueUpdated = (
@@ -59,63 +59,63 @@ const CamelPreferencesForm: React.FunctionComponent = () => {
     onBooleanValueUpdated(
       value,
       value => setIsHideOptionDocumentation(value),
-      value => storageService.setIsHideOptionDocumentation(value),
+      value => camelPreferencesService.setIsHideOptionDocumentation(value),
     )
 
   const onIsHideDefaultOptionValuesChange = (value: boolean) =>
     onBooleanValueUpdated(
       value,
       value => setIsHideDefaultOptionValues(value),
-      value => storageService.setIsHideDefaultOptionValues(value),
+      value => camelPreferencesService.setIsHideDefaultOptionValues(value),
     )
 
   const onIsHideUnusedOptionValuesChange = (value: boolean) =>
     onBooleanValueUpdated(
       value,
       value => setIsHideUnusedOptionValues(value),
-      value => storageService.setIsHideUnusedOptionValues(value),
+      value => camelPreferencesService.setIsHideUnusedOptionValues(value),
     )
 
   const onIsIncludeTraceDebugStreamsChange = (value: boolean) =>
     onBooleanValueUpdated(
       value,
       value => setIsIncludeTraceDebugStreams(value),
-      value => storageService.setIsIncludeTraceDebugStreams(value),
+      value => camelPreferencesService.setIsIncludeTraceDebugStreams(value),
     )
 
   const onMaximumTraceDebugBodyLengthChange = (value: string) =>
     onNumberValueUpdated(
       value,
       value => setMaximumTraceDebugBodyLength(value),
-      value => storageService.setMaximumTraceDebugBodyLength(value),
+      value => camelPreferencesService.setMaximumTraceDebugBodyLength(value),
     )
 
   const onMaximumLabelWidthChange = (value: string) =>
     onNumberValueUpdated(
       value,
       value => setMaximumLabelWidth(value),
-      value => storageService.setMaximumLabelWidth(value),
+      value => camelPreferencesService.setMaximumLabelWidth(value),
     )
 
   const onIsIgnoreIDForLabelChange = (value: boolean) =>
     onBooleanValueUpdated(
       value,
       value => setIsIgnoreIDForLabel(value),
-      value => storageService.setIsIgnoreIDForLabel(value),
+      value => camelPreferencesService.setIsIgnoreIDForLabel(value),
     )
 
   const onIsShowInflightCounterChange = (value: boolean) =>
     onBooleanValueUpdated(
       value,
       value => setIsShowInflightCounter(value),
-      value => storageService.setIsShowInflightCounter(value),
+      value => camelPreferencesService.setIsShowInflightCounter(value),
     )
 
   const onRouteMetricMaximumSecondsChange = (value: string) =>
     onNumberValueUpdated(
       value,
       value => setRouteMetricMaximumSeconds(value),
-      value => storageService.setRouteMetricMaximumSeconds(value),
+      value => camelPreferencesService.setRouteMetricMaximumSeconds(value),
     )
 
   return (

--- a/packages/hawtio/src/plugins/camel/CamelPreferences.tsx
+++ b/packages/hawtio/src/plugins/camel/CamelPreferences.tsx
@@ -1,6 +1,6 @@
 import { CardBody, Checkbox, Form, FormGroup, FormSection, TextInput } from '@patternfly/react-core'
 import React, { useState } from 'react'
-import { camelPreferencesService, ICamelPreferences } from './camel-preferences-service'
+import { camelPreferencesService, CamelOptions } from './camel-preferences-service'
 
 export const CamelPreferences: React.FunctionComponent = () => (
   <CardBody>
@@ -13,14 +13,14 @@ export const CamelPreferences: React.FunctionComponent = () => (
 const CamelPreferencesForm: React.FunctionComponent = () => {
   const [camelPreferences, setCamelPreferences] = useState(camelPreferencesService.loadCamelPreferences())
 
-  const updatePreferences = (value: boolean | number, key: keyof ICamelPreferences): void => {
+  const updatePreferences = (value: boolean | number, key: keyof CamelOptions): void => {
     const updatedPreferences = { ...camelPreferences, ...{ [key]: value } }
 
     camelPreferencesService.saveCamelPreferences(updatedPreferences)
     setCamelPreferences(updatedPreferences)
   }
 
-  const updateNumberValueFor = (key: keyof ICamelPreferences): ((value: string) => void) => {
+  const updateNumberValueFor = (key: keyof CamelOptions): ((value: string) => void) => {
     //Returning an arrow function to reduce boilerplate
     return (value: string) => {
       const intValue = parseInt(value)
@@ -31,7 +31,7 @@ const CamelPreferencesForm: React.FunctionComponent = () => {
     }
   }
 
-  const updateCheckboxValueFor = (key: keyof ICamelPreferences): ((value: boolean, _: React.FormEvent) => void) => {
+  const updateCheckboxValueFor = (key: keyof CamelOptions): ((value: boolean, _: React.FormEvent) => void) => {
     //Utility function generator to reduce boilerplate
     return (value: boolean, _: React.FormEvent) => {
       updatePreferences(value, key)

--- a/packages/hawtio/src/plugins/camel/CamelPreferences.tsx
+++ b/packages/hawtio/src/plugins/camel/CamelPreferences.tsx
@@ -1,6 +1,6 @@
 import { CardBody, Checkbox, Form, FormGroup, FormSection, TextInput } from '@patternfly/react-core'
 import React, { useState } from 'react'
-import { camelPreferencesService } from './camel-preferences-service'
+import { camelPreferencesService, ICamelPreferences } from './camel-preferences-service'
 
 export const CamelPreferences: React.FunctionComponent = () => (
   <CardBody>
@@ -11,179 +11,99 @@ export const CamelPreferences: React.FunctionComponent = () => (
 )
 
 const CamelPreferencesForm: React.FunctionComponent = () => {
-  const [isHideOptionDocumentation, setIsHideOptionDocumentation] = useState(
-    camelPreferencesService.loadIsHideOptionDocumentation(),
-  )
-  const [isHideDefaultOptionValues, setIsHideDefaultOptionValues] = useState(
-    camelPreferencesService.loadIsHideDefaultOptionValues(),
-  )
-  const [isHideUnusedOptionValues, setIsHideUnusedOptionValues] = useState(
-    camelPreferencesService.loadIsHideUnusedOptionValues(),
-  )
-  const [isIncludeTraceDebugStreams, setIsIncludeTraceDebugStreams] = useState(
-    camelPreferencesService.loadIsIncludeTraceDebugStreams(),
-  )
-  const [maximumTraceDebugBodyLength, setMaximumTraceDebugBodyLength] = useState(
-    camelPreferencesService.loadMaximumTraceDebugBodyLength(),
-  )
-  const [maximumLabelWidth, setMaximumLabelWidth] = useState(camelPreferencesService.loadMaximumLabelWidth())
-  const [isIgnoreIDForLabel, setIsIgnoreIDForLabel] = useState(camelPreferencesService.loadIsIgnoreIDForLabel())
-  const [isShowInflightCounter, setIsShowInflightCounter] = useState(camelPreferencesService.loadIsShowInflightCounter())
-  const [routeMetricMaximumSeconds, setRouteMetricMaximumSeconds] = useState(
-    camelPreferencesService.loadRouteMetricMaximumSeconds(),
-  )
+  const [camelPreferences, setCamelPreferences] = useState(camelPreferencesService.loadCamelPreferences())
 
-  const onBooleanValueUpdated = (
-    value: boolean,
-    updateFunction: (value: boolean) => void,
-    saveToStorageFunction: (value: boolean) => void,
-  ): void => {
-    updateFunction(value)
-    saveToStorageFunction(value)
+  const updatePreferences = (value: boolean | number, key: keyof ICamelPreferences): void => {
+    const updatedPreferences = { ...camelPreferences, ...{ key: value } }
+
+    camelPreferencesService.saveCamelPreferences(updatedPreferences)
+    setCamelPreferences(updatedPreferences)
   }
 
-  const onNumberValueUpdated = (
-    value: string,
-    updateFunction: (value: number) => void,
-    saveToStorageFunction: (value: number) => void,
-  ): void => {
-    const intValue = parseInt(value)
+  const updateNumberValueFor = (key: keyof ICamelPreferences): ((value: string) => void) => {
+    //Returning an arrow function to reduce boilerplate
+    return (value: string) => {
+      const intValue = parseInt(value)
 
-    if (!intValue) return
+      if (!intValue) return
 
-    updateFunction(intValue)
-    saveToStorageFunction(intValue)
+      updatePreferences(intValue, key)
+    }
   }
 
-  const onIsHideOptionDocumentationChange = (value: boolean) =>
-    onBooleanValueUpdated(
-      value,
-      value => setIsHideOptionDocumentation(value),
-      value => camelPreferencesService.setIsHideOptionDocumentation(value),
-    )
-
-  const onIsHideDefaultOptionValuesChange = (value: boolean) =>
-    onBooleanValueUpdated(
-      value,
-      value => setIsHideDefaultOptionValues(value),
-      value => camelPreferencesService.setIsHideDefaultOptionValues(value),
-    )
-
-  const onIsHideUnusedOptionValuesChange = (value: boolean) =>
-    onBooleanValueUpdated(
-      value,
-      value => setIsHideUnusedOptionValues(value),
-      value => camelPreferencesService.setIsHideUnusedOptionValues(value),
-    )
-
-  const onIsIncludeTraceDebugStreamsChange = (value: boolean) =>
-    onBooleanValueUpdated(
-      value,
-      value => setIsIncludeTraceDebugStreams(value),
-      value => camelPreferencesService.setIsIncludeTraceDebugStreams(value),
-    )
-
-  const onMaximumTraceDebugBodyLengthChange = (value: string) =>
-    onNumberValueUpdated(
-      value,
-      value => setMaximumTraceDebugBodyLength(value),
-      value => camelPreferencesService.setMaximumTraceDebugBodyLength(value),
-    )
-
-  const onMaximumLabelWidthChange = (value: string) =>
-    onNumberValueUpdated(
-      value,
-      value => setMaximumLabelWidth(value),
-      value => camelPreferencesService.setMaximumLabelWidth(value),
-    )
-
-  const onIsIgnoreIDForLabelChange = (value: boolean) =>
-    onBooleanValueUpdated(
-      value,
-      value => setIsIgnoreIDForLabel(value),
-      value => camelPreferencesService.setIsIgnoreIDForLabel(value),
-    )
-
-  const onIsShowInflightCounterChange = (value: boolean) =>
-    onBooleanValueUpdated(
-      value,
-      value => setIsShowInflightCounter(value),
-      value => camelPreferencesService.setIsShowInflightCounter(value),
-    )
-
-  const onRouteMetricMaximumSecondsChange = (value: string) =>
-    onNumberValueUpdated(
-      value,
-      value => setRouteMetricMaximumSeconds(value),
-      value => camelPreferencesService.setRouteMetricMaximumSeconds(value),
-    )
+  const updateCheckboxValueFor = (key: keyof ICamelPreferences): ((value: boolean, _: any) => void) => {
+    //Utility function generator to reduce boilerplate
+    return (value: boolean, _: any) => {
+      updatePreferences(value, key)
+    }
+  }
 
   return (
     <FormSection>
       <FormGroup label='Hide option documentation' fieldId='camel-form-hide-option-documentation'>
         <Checkbox
           id='camel-form-hide-option-documentation'
-          isChecked={isHideOptionDocumentation}
-          onChange={(value, _) => onIsHideOptionDocumentationChange(value)}
+          isChecked={camelPreferences.isHideOptionDocumentation}
+          onChange={updateCheckboxValueFor('isHideOptionDocumentation')}
         />
       </FormGroup>
       <FormGroup label='Hide default options values' fieldId='camel-form-hide-default-option-value'>
         <Checkbox
           id='camel-form-hide-default-option-value'
-          isChecked={isHideDefaultOptionValues}
-          onChange={(value, _) => onIsHideDefaultOptionValuesChange(value)}
+          isChecked={camelPreferences.isHideDefaultOptionValues}
+          onChange={updateCheckboxValueFor('isHideDefaultOptionValues')}
         />
       </FormGroup>
       <FormGroup label='Hide unused options values' fieldId='camel-form-hide-unused-option-value'>
         <Checkbox
           id='camel-form-hide-unused-option-value'
-          isChecked={isHideUnusedOptionValues}
-          onChange={(value, _) => onIsHideUnusedOptionValuesChange(value)}
+          isChecked={camelPreferences.isHideUnusedOptionValues}
+          onChange={updateCheckboxValueFor('isHideUnusedOptionValues')}
         />
       </FormGroup>
       <FormGroup label='Include trace / debug streams' fieldId='camel-form-include-trace-debug-streams'>
         <Checkbox
           id='camel-form-include-trace-debug-streams'
-          isChecked={isIncludeTraceDebugStreams}
-          onChange={(value, _) => onIsIncludeTraceDebugStreamsChange(value)}
+          isChecked={camelPreferences.isIncludeTraceDebugStreams}
+          onChange={updateCheckboxValueFor('isIncludeTraceDebugStreams')}
         />
       </FormGroup>
       <FormGroup label='Maximum trace / debug body length' fieldId='camel-form-maximum-trace-debug-body-length'>
         <TextInput
           id='camel-form-maximum-trace-debug-body-length'
           type='number'
-          value={maximumTraceDebugBodyLength}
-          onChange={onMaximumTraceDebugBodyLengthChange}
+          value={camelPreferences.maximumTraceDebugBodyLength}
+          onChange={updateNumberValueFor('maximumTraceDebugBodyLength')}
         />
       </FormGroup>
       <FormGroup label='Maximum label width' fieldId='camel-form-maximum-label-width'>
         <TextInput
           id='camel-form-maximum-label-width'
           type='number'
-          value={maximumLabelWidth}
-          onChange={onMaximumLabelWidthChange}
+          value={camelPreferences.maximumLabelWidth}
+          onChange={updateNumberValueFor('maximumLabelWidth')}
         />
       </FormGroup>
       <FormGroup label='Ignore ID for label' fieldId='camel-form-ignore-id-for-label'>
         <Checkbox
           id='camel-form-ignore-id-for-label'
-          isChecked={isIgnoreIDForLabel}
-          onChange={(value, _) => onIsIgnoreIDForLabelChange(value)}
+          isChecked={camelPreferences.isIgnoreIDForLabel}
+          onChange={updateCheckboxValueFor('isIgnoreIDForLabel')}
         />
       </FormGroup>
       <FormGroup label='Show inflight counter' fieldId='camel-show-inflight-counter'>
         <Checkbox
           id='camel-show-inflight-counter'
-          isChecked={isShowInflightCounter}
-          onChange={(value, _) => onIsShowInflightCounterChange(value)}
+          isChecked={camelPreferences.isShowInflightCounter}
+          onChange={updateCheckboxValueFor('isShowInflightCounter')}
         />
       </FormGroup>
       <FormGroup label='Route metric maximum seconds' fieldId='camel-form-route-metric-maximum-seconds'>
         <TextInput
           id='camel-form-route-metric-maximum-seconds'
           type='number'
-          value={routeMetricMaximumSeconds}
-          onChange={onRouteMetricMaximumSecondsChange}
+          value={camelPreferences.routeMetricMaximumSeconds}
+          onChange={updateNumberValueFor('routeMetricMaximumSeconds')}
         />
       </FormGroup>
     </FormSection>

--- a/packages/hawtio/src/plugins/camel/camel-preferences-service.test.ts
+++ b/packages/hawtio/src/plugins/camel/camel-preferences-service.test.ts
@@ -1,0 +1,92 @@
+import {
+  CamelOptions,
+  camelPreferencesService,
+  CAMEL_PREFERENCES_DEFAULT_VALUES,
+  STORAGE_KEY_CAMEL_PREFERENCES,
+} from './camel-preferences-service'
+
+describe('camel-preferences-service', () => {
+  // Mocking local-storage is not very straightforward so we'll be using it directly
+  beforeEach(() => {
+    localStorage.removeItem(STORAGE_KEY_CAMEL_PREFERENCES)
+  })
+
+  describe('Load preferences', () => {
+    test('Retrieves default values on empty storage', () => {
+      //Given
+      localStorage.removeItem(STORAGE_KEY_CAMEL_PREFERENCES)
+
+      //When
+      const preferences = camelPreferencesService.loadCamelPreferences()
+
+      //Then
+      expect(preferences).toEqual(CAMEL_PREFERENCES_DEFAULT_VALUES)
+    })
+
+    test('Retrieves stored values when they is some key stored, and the default for the others', () => {
+      //Given
+      localStorage.setItem(STORAGE_KEY_CAMEL_PREFERENCES, JSON.stringify({ maximumLabelWidth: 5 }))
+
+      //When
+      const preferences = camelPreferencesService.loadCamelPreferences()
+
+      //Then
+      expect(preferences).toEqual({ ...CAMEL_PREFERENCES_DEFAULT_VALUES, maximumLabelWidth: 5 })
+    })
+
+    test('Retrieves all the values', () => {
+      //Given
+      const savedString =
+        '{"isHideOptionDocumentation":true,"isHideDefaultOptionValues":false,"isHideUnusedOptionValues":true,"isIncludeTraceDebugStreams":false,"maximumTraceDebugBodyLength":134234,"maximumLabelWidth":34,"isIgnoreIDForLabel":true,"isShowInflightCounter":true,"routeMetricMaximumSeconds":10,"key":true}'
+      const expected: Partial<CamelOptions> = {
+        isHideUnusedOptionValues: true,
+        maximumTraceDebugBodyLength: 134234,
+        isIgnoreIDForLabel: true,
+      }
+      localStorage.setItem(STORAGE_KEY_CAMEL_PREFERENCES, savedString)
+
+      //When
+      const preferences = camelPreferencesService.loadCamelPreferences()
+
+      //Then
+      expect(preferences).toMatchObject(expected)
+    })
+  })
+
+  describe('Saving preferences', () => {
+    test('Saving single preference', () => {
+      //Given
+      const savedPreference: Partial<CamelOptions> = {
+        isHideOptionDocumentation: true,
+      }
+      const expectedString = JSON.stringify(savedPreference)
+
+      //When
+      camelPreferencesService.saveCamelPreferences(savedPreference)
+
+      //Then
+      expect(localStorage.getItem(STORAGE_KEY_CAMEL_PREFERENCES)).toEqual(expectedString)
+    })
+
+    test('Overwriting saved preferences correctly overwrites the preference', () => {
+      //Given
+      const savedPreference: Partial<CamelOptions> = {
+        maximumLabelWidth: 5,
+        isHideDefaultOptionValues: true,
+      }
+      const overwrittenPreference: Partial<CamelOptions> = {
+        maximumLabelWidth: 4,
+      }
+      localStorage.setItem(STORAGE_KEY_CAMEL_PREFERENCES, JSON.stringify(savedPreference))
+      const expectedString = JSON.stringify({ ...savedPreference, ...overwrittenPreference })
+
+      //When
+      camelPreferencesService.saveCamelPreferences(overwrittenPreference)
+
+      //Then
+      expect(localStorage.getItem(STORAGE_KEY_CAMEL_PREFERENCES)).toEqual(expectedString)
+    })
+  })
+})
+
+export {}

--- a/packages/hawtio/src/plugins/camel/camel-preferences-service.ts
+++ b/packages/hawtio/src/plugins/camel/camel-preferences-service.ts
@@ -1,18 +1,9 @@
-export interface ICamelStorage {
-  loadIsHideOptionDocumentation(): boolean
-  loadIsHideDefaultOptionValues(): boolean
-  loadIsHideUnusedOptionValues(): boolean
-  loadIsIncludeTraceDebugStreams(): boolean
-  loadMaximumTraceDebugBodyLength(): number
-  loadMaximumLabelWidth(): number
-  loadIsIgnoreIDForLabel(): boolean
-  loadIsShowInflightCounter(): boolean
-  loadRouteMetricMaximumSeconds(): number
-  loadCamelPreferences(): ICamelPreferences
-  saveCamelPreferences(newValues: Partial<ICamelPreferences>): void
+export interface ICamelPreferencesService {
+  loadCamelPreferences(): CamelOptions
+  saveCamelPreferences(newValues: Partial<CamelOptions>): void
 }
 
-export interface ICamelPreferences {
+export type CamelOptions = {
   isHideOptionDocumentation: boolean
   isHideDefaultOptionValues: boolean
   isHideUnusedOptionValues: boolean
@@ -24,7 +15,7 @@ export interface ICamelPreferences {
   routeMetricMaximumSeconds: number
 }
 
-const CAMEL_PREFERENCES_DEFAULT_VALUES: ICamelPreferences = {
+const CAMEL_PREFERENCES_DEFAULT_VALUES: CamelOptions = {
   isHideOptionDocumentation: false,
   isHideDefaultOptionValues: false,
   isHideUnusedOptionValues: false,
@@ -34,58 +25,22 @@ const CAMEL_PREFERENCES_DEFAULT_VALUES: ICamelPreferences = {
   isIgnoreIDForLabel: false,
   isShowInflightCounter: true,
   routeMetricMaximumSeconds: 10,
-}
+} as const
 
 export const STORAGE_KEY_CAMEL_PREFERENCES = 'camel.preferences'
 
-class CamelPreferencesService implements ICamelStorage {
-  loadCamelPreferences(): ICamelPreferences {
+class CamelPreferencesService implements ICamelPreferencesService {
+  loadCamelPreferences(): CamelOptions {
     return { ...CAMEL_PREFERENCES_DEFAULT_VALUES, ...this.loadFromStorage() }
   }
 
-  saveCamelPreferences(newValues: Partial<ICamelPreferences>): void {
+  saveCamelPreferences(newValues: Partial<CamelOptions>): void {
     const preferencesToSave = { ...this.loadFromStorage(), ...newValues }
 
     localStorage.setItem(STORAGE_KEY_CAMEL_PREFERENCES, JSON.stringify(preferencesToSave))
   }
 
-  loadIsHideOptionDocumentation(): boolean {
-    return this.loadCamelPreferences().isHideOptionDocumentation
-  }
-
-  loadIsHideDefaultOptionValues(): boolean {
-    return this.loadCamelPreferences().isHideDefaultOptionValues
-  }
-
-  loadIsHideUnusedOptionValues(): boolean {
-    return this.loadCamelPreferences().isHideUnusedOptionValues
-  }
-
-  loadIsIncludeTraceDebugStreams(): boolean {
-    return this.loadCamelPreferences().isIncludeTraceDebugStreams
-  }
-
-  loadMaximumTraceDebugBodyLength(): number {
-    return this.loadCamelPreferences().maximumTraceDebugBodyLength
-  }
-
-  loadMaximumLabelWidth(): number {
-    return this.loadCamelPreferences().maximumLabelWidth
-  }
-
-  loadIsIgnoreIDForLabel(): boolean {
-    return this.loadCamelPreferences().isIgnoreIDForLabel
-  }
-
-  loadIsShowInflightCounter(): boolean {
-    return this.loadCamelPreferences().isShowInflightCounter
-  }
-
-  loadRouteMetricMaximumSeconds(): number {
-    return this.loadCamelPreferences().routeMetricMaximumSeconds
-  }
-
-  private loadFromStorage(): Partial<ICamelPreferences> {
+  private loadFromStorage(): Partial<CamelOptions> {
     const localStorageData = localStorage.getItem(STORAGE_KEY_CAMEL_PREFERENCES)
 
     return localStorageData ? JSON.parse(localStorageData) : {}

--- a/packages/hawtio/src/plugins/camel/camel-preferences-service.ts
+++ b/packages/hawtio/src/plugins/camel/camel-preferences-service.ts
@@ -1,128 +1,92 @@
 export interface ICamelStorage {
-  setIsHideOptionDocumentation(value: boolean): void
   loadIsHideOptionDocumentation(): boolean
-  setIsHideDefaultOptionValues(value: boolean): void
   loadIsHideDefaultOptionValues(): boolean
-  setIsHideUnusedOptionValues(value: boolean): void
   loadIsHideUnusedOptionValues(): boolean
-  setIsIncludeTraceDebugStreams(value: boolean): void
   loadIsIncludeTraceDebugStreams(): boolean
-  setMaximumTraceDebugBodyLength(value: number): void
   loadMaximumTraceDebugBodyLength(): number
-  setMaximumLabelWidth(value: number): void
   loadMaximumLabelWidth(): number
-  setIsIgnoreIDForLabel(value: boolean): void
   loadIsIgnoreIDForLabel(): boolean
-  setIsShowInflightCounter(value: boolean): void
   loadIsShowInflightCounter(): boolean
-  setRouteMetricMaximumSeconds(value: number): void
   loadRouteMetricMaximumSeconds(): number
+  loadCamelPreferences(): ICamelPreferences
+  saveCamelPreferences(newValues: Partial<ICamelPreferences>): void
 }
 
-export const STORAGE_KEY_IS_HIDE_OPTION_DOCUMENTATION = 'camel.preferences.isHideOptionDocumentation'
-export const STORAGE_KEY_IS_HIDE_DEFAULT_OPTION_VALUES = 'camel.preferences.isHideDefaultOptionValues'
-export const STORAGE_KEY_IS_HIDE_UNUSED_OPTION_VALUES = 'camel.preferences.isHideUnusedOptionValues'
-export const STORAGE_KEY_IS_INCLUDE_TRACE_DEBUG_STREAMS = 'camel.preferences.isIncludeTraceDebugStreams'
-export const STORAGE_KEY_MAXIMUM_TRACE_DEBUG_BODY_LENGTH = 'camel.preferences.maximumTraceDebugBodyLength'
-export const STORAGE_KEY_MAXIMUM_LABEL_WIDTH = 'camel.preferences.maximumLabelWidth'
-export const STORAGE_KEY_IS_IGNORE_ID_FOR_LABEL = 'camel.preferences.isIgnoreIDForLabel'
-export const STORAGE_KEY_IS_SHOW_INFLIGHT_COUNTER = 'camel.preferences.isShowInflightCounter'
-export const STORAGE_KEY_ROUTE_METRIC_MAXIMUM_SECONDS = 'camel.preferences.routeMetricMaximumSeconds'
-
-const PREFERENCES_DEFAULT_VALUES: Record<string, boolean | number> = {
-  [STORAGE_KEY_IS_HIDE_OPTION_DOCUMENTATION]: false,
-  [STORAGE_KEY_IS_HIDE_DEFAULT_OPTION_VALUES]: false,
-  [STORAGE_KEY_IS_HIDE_UNUSED_OPTION_VALUES]: false,
-  [STORAGE_KEY_IS_INCLUDE_TRACE_DEBUG_STREAMS]: false,
-  [STORAGE_KEY_MAXIMUM_TRACE_DEBUG_BODY_LENGTH]: 5000,
-  [STORAGE_KEY_MAXIMUM_LABEL_WIDTH]: 34,
-  [STORAGE_KEY_IS_IGNORE_ID_FOR_LABEL]: false,
-  [STORAGE_KEY_IS_SHOW_INFLIGHT_COUNTER]: true,
-  [STORAGE_KEY_ROUTE_METRIC_MAXIMUM_SECONDS]: 10,
+export interface ICamelPreferences {
+  isHideOptionDocumentation: boolean
+  isHideDefaultOptionValues: boolean
+  isHideUnusedOptionValues: boolean
+  isIncludeTraceDebugStreams: boolean
+  maximumTraceDebugBodyLength: number
+  maximumLabelWidth: number
+  isIgnoreIDForLabel: boolean
+  isShowInflightCounter: boolean
+  routeMetricMaximumSeconds: number
 }
+
+const CAMEL_PREFERENCES_DEFAULT_VALUES: ICamelPreferences = {
+  isHideOptionDocumentation: false,
+  isHideDefaultOptionValues: false,
+  isHideUnusedOptionValues: false,
+  isIncludeTraceDebugStreams: false,
+  maximumTraceDebugBodyLength: 5000,
+  maximumLabelWidth: 34,
+  isIgnoreIDForLabel: false,
+  isShowInflightCounter: true,
+  routeMetricMaximumSeconds: 10,
+}
+
+export const STORAGE_KEY_CAMEL_PREFERENCES = 'camel.preferences'
 
 class CamelPreferencesService implements ICamelStorage {
-  setIsHideOptionDocumentation(value: boolean): void {
-    this.saveValueToStorage(STORAGE_KEY_IS_HIDE_OPTION_DOCUMENTATION, value)
+  loadCamelPreferences(): ICamelPreferences {
+    return { ...CAMEL_PREFERENCES_DEFAULT_VALUES, ...this.loadFromStorage() }
+  }
+
+  saveCamelPreferences(newValues: Partial<ICamelPreferences>): void {
+    const preferencesToSave = { ...this.loadFromStorage(), ...newValues }
+
+    localStorage.setItem(STORAGE_KEY_CAMEL_PREFERENCES, JSON.stringify(preferencesToSave))
   }
 
   loadIsHideOptionDocumentation(): boolean {
-    return this.loadFromStorage(STORAGE_KEY_IS_HIDE_OPTION_DOCUMENTATION)
-  }
-
-  setIsHideDefaultOptionValues(value: boolean): void {
-    this.saveValueToStorage(STORAGE_KEY_IS_HIDE_DEFAULT_OPTION_VALUES, value)
+    return this.loadCamelPreferences().isHideOptionDocumentation
   }
 
   loadIsHideDefaultOptionValues(): boolean {
-    return this.loadFromStorage(STORAGE_KEY_IS_HIDE_DEFAULT_OPTION_VALUES)
-  }
-
-  setIsHideUnusedOptionValues(value: boolean): void {
-    this.saveValueToStorage(STORAGE_KEY_IS_HIDE_UNUSED_OPTION_VALUES, value)
+    return this.loadCamelPreferences().isHideDefaultOptionValues
   }
 
   loadIsHideUnusedOptionValues(): boolean {
-    return this.loadFromStorage(STORAGE_KEY_IS_HIDE_UNUSED_OPTION_VALUES)
-  }
-
-  setIsIncludeTraceDebugStreams(value: boolean): void {
-    this.saveValueToStorage(STORAGE_KEY_IS_INCLUDE_TRACE_DEBUG_STREAMS, value)
+    return this.loadCamelPreferences().isHideUnusedOptionValues
   }
 
   loadIsIncludeTraceDebugStreams(): boolean {
-    return this.loadFromStorage(STORAGE_KEY_IS_INCLUDE_TRACE_DEBUG_STREAMS)
-  }
-
-  setMaximumTraceDebugBodyLength(value: number): void {
-    this.saveValueToStorage(STORAGE_KEY_MAXIMUM_TRACE_DEBUG_BODY_LENGTH, value)
+    return this.loadCamelPreferences().isIncludeTraceDebugStreams
   }
 
   loadMaximumTraceDebugBodyLength(): number {
-    return this.loadFromStorage(STORAGE_KEY_MAXIMUM_TRACE_DEBUG_BODY_LENGTH)
-  }
-
-  setMaximumLabelWidth(value: number): void {
-    this.saveValueToStorage(STORAGE_KEY_MAXIMUM_LABEL_WIDTH, value)
+    return this.loadCamelPreferences().maximumTraceDebugBodyLength
   }
 
   loadMaximumLabelWidth(): number {
-    return this.loadFromStorage(STORAGE_KEY_MAXIMUM_LABEL_WIDTH)
-  }
-
-  setIsIgnoreIDForLabel(value: boolean): void {
-    this.saveValueToStorage(STORAGE_KEY_IS_IGNORE_ID_FOR_LABEL, value)
+    return this.loadCamelPreferences().maximumLabelWidth
   }
 
   loadIsIgnoreIDForLabel(): boolean {
-    return this.loadFromStorage(STORAGE_KEY_IS_IGNORE_ID_FOR_LABEL)
-  }
-
-  setIsShowInflightCounter(value: boolean): void {
-    this.saveValueToStorage(STORAGE_KEY_IS_SHOW_INFLIGHT_COUNTER, value)
+    return this.loadCamelPreferences().isIgnoreIDForLabel
   }
 
   loadIsShowInflightCounter(): boolean {
-    return this.loadFromStorage(STORAGE_KEY_IS_SHOW_INFLIGHT_COUNTER)
-  }
-
-  setRouteMetricMaximumSeconds(value: number): void {
-    this.saveValueToStorage(STORAGE_KEY_ROUTE_METRIC_MAXIMUM_SECONDS, value)
+    return this.loadCamelPreferences().isShowInflightCounter
   }
 
   loadRouteMetricMaximumSeconds(): number {
-    return this.loadFromStorage(STORAGE_KEY_ROUTE_METRIC_MAXIMUM_SECONDS)
+    return this.loadCamelPreferences().routeMetricMaximumSeconds
   }
 
-  private saveValueToStorage(storageKey: string, value: number | boolean) {
-    localStorage.setItem(storageKey, JSON.stringify(value))
-  }
-
-  private loadFromStorage<T>(storageKey: string): T {
-    const localStorageValue = localStorage.getItem(storageKey)
-
-    if (!localStorageValue) return PREFERENCES_DEFAULT_VALUES[storageKey] as T
-    return JSON.parse(localStorageValue) as T
+  private loadFromStorage(): Partial<ICamelPreferences> {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY_CAMEL_PREFERENCES) || '')
   }
 }
 

--- a/packages/hawtio/src/plugins/camel/camel-preferences-service.ts
+++ b/packages/hawtio/src/plugins/camel/camel-preferences-service.ts
@@ -86,7 +86,9 @@ class CamelPreferencesService implements ICamelStorage {
   }
 
   private loadFromStorage(): Partial<ICamelPreferences> {
-    return JSON.parse(localStorage.getItem(STORAGE_KEY_CAMEL_PREFERENCES) || '')
+    const localStorageData = localStorage.getItem(STORAGE_KEY_CAMEL_PREFERENCES)
+
+    return localStorageData ? JSON.parse(localStorageData) : {}
   }
 }
 

--- a/packages/hawtio/src/plugins/camel/camel-preferences-service.ts
+++ b/packages/hawtio/src/plugins/camel/camel-preferences-service.ts
@@ -15,7 +15,7 @@ export type CamelOptions = {
   routeMetricMaximumSeconds: number
 }
 
-const CAMEL_PREFERENCES_DEFAULT_VALUES: CamelOptions = {
+export const CAMEL_PREFERENCES_DEFAULT_VALUES: CamelOptions = {
   isHideOptionDocumentation: false,
   isHideDefaultOptionValues: false,
   isHideUnusedOptionValues: false,

--- a/packages/hawtio/src/plugins/camel/camel-preferences-service.ts
+++ b/packages/hawtio/src/plugins/camel/camel-preferences-service.ts
@@ -41,7 +41,7 @@ const PREFERENCES_DEFAULT_VALUES: Record<string, boolean | number> = {
   [STORAGE_KEY_ROUTE_METRIC_MAXIMUM_SECONDS]: 10,
 }
 
-class CamelPreferencesStorageService implements ICamelStorage {
+class CamelPreferencesService implements ICamelStorage {
   setIsHideOptionDocumentation(value: boolean): void {
     this.saveValueToStorage(STORAGE_KEY_IS_HIDE_OPTION_DOCUMENTATION, value)
   }
@@ -126,4 +126,4 @@ class CamelPreferencesStorageService implements ICamelStorage {
   }
 }
 
-export const storageService = new CamelPreferencesStorageService()
+export const camelPreferencesService = new CamelPreferencesService()

--- a/packages/hawtio/src/plugins/camel/camel-preferences-storage-service.ts
+++ b/packages/hawtio/src/plugins/camel/camel-preferences-storage-service.ts
@@ -1,0 +1,129 @@
+export interface ICamelStorage {
+  setIsHideOptionDocumentation(value: boolean): void
+  loadIsHideOptionDocumentation(): boolean
+  setIsHideDefaultOptionValues(value: boolean): void
+  loadIsHideDefaultOptionValues(): boolean
+  setIsHideUnusedOptionValues(value: boolean): void
+  loadIsHideUnusedOptionValues(): boolean
+  setIsIncludeTraceDebugStreams(value: boolean): void
+  loadIsIncludeTraceDebugStreams(): boolean
+  setMaximumTraceDebugBodyLength(value: number): void
+  loadMaximumTraceDebugBodyLength(): number
+  setMaximumLabelWidth(value: number): void
+  loadMaximumLabelWidth(): number
+  setIsIgnoreIDForLabel(value: boolean): void
+  loadIsIgnoreIDForLabel(): boolean
+  setIsShowInflightCounter(value: boolean): void
+  loadIsShowInflightCounter(): boolean
+  setRouteMetricMaximumSeconds(value: number): void
+  loadRouteMetricMaximumSeconds(): number
+}
+
+export const STORAGE_KEY_IS_HIDE_OPTION_DOCUMENTATION = 'camel.preferences.isHideOptionDocumentation'
+export const STORAGE_KEY_IS_HIDE_DEFAULT_OPTION_VALUES = 'camel.preferences.isHideDefaultOptionValues'
+export const STORAGE_KEY_IS_HIDE_UNUSED_OPTION_VALUES = 'camel.preferences.isHideUnusedOptionValues'
+export const STORAGE_KEY_IS_INCLUDE_TRACE_DEBUG_STREAMS = 'camel.preferences.isIncludeTraceDebugStreams'
+export const STORAGE_KEY_MAXIMUM_TRACE_DEBUG_BODY_LENGTH = 'camel.preferences.maximumTraceDebugBodyLength'
+export const STORAGE_KEY_MAXIMUM_LABEL_WIDTH = 'camel.preferences.maximumLabelWidth'
+export const STORAGE_KEY_IS_IGNORE_ID_FOR_LABEL = 'camel.preferences.isIgnoreIDForLabel'
+export const STORAGE_KEY_IS_SHOW_INFLIGHT_COUNTER = 'camel.preferences.isShowInflightCounter'
+export const STORAGE_KEY_ROUTE_METRIC_MAXIMUM_SECONDS = 'camel.preferences.routeMetricMaximumSeconds'
+
+const PREFERENCES_DEFAULT_VALUES: Record<string, boolean | number> = {
+  [STORAGE_KEY_IS_HIDE_OPTION_DOCUMENTATION]: false,
+  [STORAGE_KEY_IS_HIDE_DEFAULT_OPTION_VALUES]: false,
+  [STORAGE_KEY_IS_HIDE_UNUSED_OPTION_VALUES]: false,
+  [STORAGE_KEY_IS_INCLUDE_TRACE_DEBUG_STREAMS]: false,
+  [STORAGE_KEY_MAXIMUM_TRACE_DEBUG_BODY_LENGTH]: 5000,
+  [STORAGE_KEY_MAXIMUM_LABEL_WIDTH]: 34,
+  [STORAGE_KEY_IS_IGNORE_ID_FOR_LABEL]: false,
+  [STORAGE_KEY_IS_SHOW_INFLIGHT_COUNTER]: true,
+  [STORAGE_KEY_ROUTE_METRIC_MAXIMUM_SECONDS]: 10,
+}
+
+class CamelPreferencesStorageService implements ICamelStorage {
+  setIsHideOptionDocumentation(value: boolean): void {
+    this.saveValueToStorage(STORAGE_KEY_IS_HIDE_OPTION_DOCUMENTATION, value)
+  }
+
+  loadIsHideOptionDocumentation(): boolean {
+    return this.loadFromStorage(STORAGE_KEY_IS_HIDE_OPTION_DOCUMENTATION)
+  }
+
+  setIsHideDefaultOptionValues(value: boolean): void {
+    this.saveValueToStorage(STORAGE_KEY_IS_HIDE_DEFAULT_OPTION_VALUES, value)
+  }
+
+  loadIsHideDefaultOptionValues(): boolean {
+    return this.loadFromStorage(STORAGE_KEY_IS_HIDE_DEFAULT_OPTION_VALUES)
+  }
+
+  setIsHideUnusedOptionValues(value: boolean): void {
+    this.saveValueToStorage(STORAGE_KEY_IS_HIDE_UNUSED_OPTION_VALUES, value)
+  }
+
+  loadIsHideUnusedOptionValues(): boolean {
+    return this.loadFromStorage(STORAGE_KEY_IS_HIDE_UNUSED_OPTION_VALUES)
+  }
+
+  setIsIncludeTraceDebugStreams(value: boolean): void {
+    this.saveValueToStorage(STORAGE_KEY_IS_INCLUDE_TRACE_DEBUG_STREAMS, value)
+  }
+
+  loadIsIncludeTraceDebugStreams(): boolean {
+    return this.loadFromStorage(STORAGE_KEY_IS_INCLUDE_TRACE_DEBUG_STREAMS)
+  }
+
+  setMaximumTraceDebugBodyLength(value: number): void {
+    this.saveValueToStorage(STORAGE_KEY_MAXIMUM_TRACE_DEBUG_BODY_LENGTH, value)
+  }
+
+  loadMaximumTraceDebugBodyLength(): number {
+    return this.loadFromStorage(STORAGE_KEY_MAXIMUM_TRACE_DEBUG_BODY_LENGTH)
+  }
+
+  setMaximumLabelWidth(value: number): void {
+    this.saveValueToStorage(STORAGE_KEY_MAXIMUM_LABEL_WIDTH, value)
+  }
+
+  loadMaximumLabelWidth(): number {
+    return this.loadFromStorage(STORAGE_KEY_MAXIMUM_LABEL_WIDTH)
+  }
+
+  setIsIgnoreIDForLabel(value: boolean): void {
+    this.saveValueToStorage(STORAGE_KEY_IS_IGNORE_ID_FOR_LABEL, value)
+  }
+
+  loadIsIgnoreIDForLabel(): boolean {
+    return this.loadFromStorage(STORAGE_KEY_IS_IGNORE_ID_FOR_LABEL)
+  }
+
+  setIsShowInflightCounter(value: boolean): void {
+    this.saveValueToStorage(STORAGE_KEY_IS_SHOW_INFLIGHT_COUNTER, value)
+  }
+
+  loadIsShowInflightCounter(): boolean {
+    return this.loadFromStorage(STORAGE_KEY_IS_SHOW_INFLIGHT_COUNTER)
+  }
+
+  setRouteMetricMaximumSeconds(value: number): void {
+    this.saveValueToStorage(STORAGE_KEY_ROUTE_METRIC_MAXIMUM_SECONDS, value)
+  }
+
+  loadRouteMetricMaximumSeconds(): number {
+    return this.loadFromStorage(STORAGE_KEY_ROUTE_METRIC_MAXIMUM_SECONDS)
+  }
+
+  private saveValueToStorage(storageKey: string, value: number | boolean) {
+    localStorage.setItem(storageKey, JSON.stringify(value))
+  }
+
+  private loadFromStorage<T>(storageKey: string): T {
+    const localStorageValue = localStorage.getItem(storageKey)
+
+    if (!localStorageValue) return PREFERENCES_DEFAULT_VALUES[storageKey] as T
+    return JSON.parse(localStorageValue) as T
+  }
+}
+
+export const storageService = new CamelPreferencesStorageService()

--- a/packages/hawtio/src/plugins/camel/index.ts
+++ b/packages/hawtio/src/plugins/camel/index.ts
@@ -3,11 +3,10 @@ import { helpRegistry } from '@hawtiosrc/help/registry'
 import { treeProcessorRegistry, workspace } from '@hawtiosrc/plugins/shared'
 import { jmxDomain, pluginPath } from './globals'
 import { camelTreeProcessor } from './tree-processor'
-// import { preferencesRegistry } from '@hawtiosrc/preferences/registry'
+import { preferencesRegistry } from '@hawtiosrc/preferences/registry'
 import { Camel } from './Camel'
-// import { CamelPreferences } from './CamelPreferences'
+import { CamelPreferences } from './CamelPreferences'
 import help from './help.md'
-// import { jolokiaService } from './jolokia-service'
 
 export const camel = () => {
   hawtio.addPlugin({
@@ -22,5 +21,5 @@ export const camel = () => {
 
   treeProcessorRegistry.add('camel', camelTreeProcessor)
   helpRegistry.add('camel', 'Camel', help, 13)
-  // preferencesRegistry.add('camel', 'Camel', ConnectPreferences, 11)
+  preferencesRegistry.add('camel', 'Camel', CamelPreferences, 13)
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/17336236/226976535-41fca456-6652-4e03-94f3-8f3daf708a10.png)

This together with #191 completes #41 

Notes:
- Right now values are being saved to local storage and little else. Would like to get your input in if any components already exist to put the wiring on them.
- Reset button. Should I add it? Home preferences didn't have a Reset button before and it has it, same for Jolokla settings. I guess it's a yes but wanted to confirm.
- Hint icons. I saw we dropped this from other preferences pages. Should I file a separate issue to implement them on all preferences pages?
- Overuse of arrow functions on the component: trying to reduce the amount of duplicated code for type checking, I had to use arrow functions because I lose the "this" when passing them as parameters. Is not too much boilerplate... until prettier comes up and puts everything in different lines :(. If
  - I remember that the correct pattern to avoid that was to store this in a const variable in the class, but typescript seemed to not like it.
  
I think that's all I will otherwise put another comment tomorrow