### PR TITLE
(#194): Implements workspace monitoring of tree server changes

### DIFF
--- a/packages/hawtio/src/plugins/camel/CamelTreeView.tsx
+++ b/packages/hawtio/src/plugins/camel/CamelTreeView.tsx
@@ -1,6 +1,6 @@
 import { MBeanNode, MBeanTree, PluginTreeViewToolbar } from '@hawtiosrc/plugins/shared'
 import { TreeView, TreeViewDataItem } from '@patternfly/react-core'
-import React, { ChangeEvent, useContext, useState } from 'react'
+import React, { ChangeEvent, useContext, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import './CamelTreeView.css'
 import { CamelContext } from './context'
@@ -31,6 +31,15 @@ export const CamelTreeView: React.FunctionComponent = () => {
   const [expanded, setExpanded] = useState(ExpansionValue.Default)
   const [filteredTree, setFilteredTree] = useState(tree.getTree())
   const navigate = useNavigate()
+
+  /**
+   * Listen for changes to the tree that may occur as a result
+   * of events being monitored by the Tree:Watcher in workspace
+   * eg. new endpoint being created
+   */
+  useEffect(() => {
+    setFilteredTree(tree.getTree())
+  }, [tree])
 
   const onSearch = (event: ChangeEvent<HTMLInputElement>) => {
     // Ensure no node from the 'old' filtered is lingering

--- a/packages/hawtio/src/plugins/connect/ConnectPreferences.tsx
+++ b/packages/hawtio/src/plugins/connect/ConnectPreferences.tsx
@@ -2,6 +2,7 @@ import {
   Alert,
   Button,
   CardBody,
+  Checkbox,
   Form,
   FormGroup,
   FormSection,
@@ -30,6 +31,7 @@ const JolokiaForm: React.FunctionComponent = () => {
 
   const jolokiaStoredOptions = jolokiaService.loadJolokiaOptionsFromStorage()
   const [updateRate, setUpdateRate] = useState(jolokiaService.loadUpdateRate())
+  const [autoRefresh, setAutoRefresh] = useState(jolokiaService.loadAutoRefresh())
   const [maxDepth, setMaxDepth] = useState(jolokiaStoredOptions.maxDepth)
   const [maxCollectionSize, setMaxCollectionSize] = useState(jolokiaStoredOptions.maxCollectionSize)
 
@@ -49,6 +51,11 @@ const JolokiaForm: React.FunctionComponent = () => {
       jolokiaService.saveMaxDepth(intValue)
       setMaxDepth(intValue)
     }
+  }
+
+  const onAutoRefreshChanged = (autoRefresh: boolean) => {
+    jolokiaService.saveAutoRefresh(autoRefresh)
+    setAutoRefresh(autoRefresh)
   }
 
   const onMaxCollectionSizeChanged = (maxCollectionSize: string) => {
@@ -85,6 +92,9 @@ const JolokiaForm: React.FunctionComponent = () => {
           value={maxCollectionSize}
           onChange={onMaxCollectionSizeChanged}
         />
+      </FormGroup>
+      <FormGroup label='Auto refresh' fieldId='jolokia-form-auto-refresh'>
+        <Checkbox id='jolokia-form-auto-refresh-input' isChecked={autoRefresh} onChange={onAutoRefreshChanged} />
       </FormGroup>
       <FormGroup fieldId='jolokia-form-apply' helperText='Restart Hawtio with the new values in effect.'>
         <Button onClick={applyJolokia}>Apply</Button>

--- a/packages/hawtio/src/plugins/connect/jolokia-service.ts
+++ b/packages/hawtio/src/plugins/connect/jolokia-service.ts
@@ -11,6 +11,7 @@ import {
   onSuccess,
 } from '@hawtiosrc/util/jolokia'
 import { isObject } from '@hawtiosrc/util/objects'
+import { parseBoolean } from '@hawtiosrc/util/strings'
 import Jolokia, {
   IAjaxErrorFn,
   IErrorResponse,
@@ -47,6 +48,7 @@ const DEFAULT_JOLOKIA_OPTIONS: IOptions = {
 } as const
 
 export const DEFAULT_UPDATE_RATE = 5000
+export const DEFAULT_AUTO_REFRESH = false
 
 const JOLOKIA_PATHS = ['jolokia', '/hawtio/jolokia', '/jolokia'] as const
 
@@ -77,6 +79,7 @@ export interface IJolokiaStoredOptions {
 
 export const STORAGE_KEY_JOLOKIA_OPTIONS = 'connect.jolokia.options'
 export const STORAGE_KEY_UPDATE_RATE = 'connect.jolokia.updateRate'
+export const STORAGE_KEY_AUTO_REFRESH = 'connect.jolokia.autoRefresh'
 
 export interface IJolokiaService {
   getJolokiaUrl(): Promise<string | null>
@@ -445,6 +448,15 @@ class JolokiaService implements IJolokiaService {
 
   saveUpdateRate(value: number): void {
     localStorage.setItem(STORAGE_KEY_UPDATE_RATE, JSON.stringify(value))
+  }
+
+  loadAutoRefresh(): boolean {
+    const value = localStorage.getItem(STORAGE_KEY_AUTO_REFRESH)
+    return value ? parseBoolean(value) : DEFAULT_AUTO_REFRESH
+  }
+
+  saveAutoRefresh(value: boolean): void {
+    localStorage.setItem(STORAGE_KEY_AUTO_REFRESH, JSON.stringify(value))
   }
 
   loadJolokiaOptionsFromStorage(): IJolokiaStoredOptions {

--- a/packages/hawtio/src/plugins/jmx/JmxTreeView.tsx
+++ b/packages/hawtio/src/plugins/jmx/JmxTreeView.tsx
@@ -1,18 +1,50 @@
 import { TreeView, TreeViewDataItem } from '@patternfly/react-core'
-import React, { ChangeEvent, useContext, useState } from 'react'
+import React, { ChangeEvent, useContext, useEffect, useState } from 'react'
 import { PluginTreeViewToolbar, MBeanNode, MBeanTree } from '@hawtiosrc/plugins/shared'
 import { MBeanTreeContext } from './context'
 import './JmxTreeView.css'
 import { useNavigate } from 'react-router-dom'
 import { pluginPath } from './globals'
 
+/**
+ * Expansion requires more than 2 states since the expandAll
+ * must be removed completely to defer to the expanded state
+ * of each data node
+ */
+enum ExpansionValue {
+  /**
+   * should revert to the expanded state of the data
+   */
+  Default,
+  /**
+   * all data should be expanded
+   */
+  ExpandAll,
+  /**
+   * all data should be collapsed
+   */
+  CollapseAll,
+}
+
 export const JmxTreeView: React.FunctionComponent = () => {
   const { tree, selectedNode, setSelectedNode } = useContext(MBeanTreeContext)
-  const [expanded, setExpanded] = useState(false)
+  const [expanded, setExpanded] = useState(ExpansionValue.Default)
   const [filteredTree, setFilteredTree] = useState(tree.getTree())
   const navigate = useNavigate()
 
+  /**
+   * Listen for changes to the tree that may occur as a result
+   * of events being monitored by the Tree:Watcher in workspace
+   * eg. new endpoint being created
+   */
+  useEffect(() => {
+    setFilteredTree(tree.getTree())
+  }, [tree])
+
   const onSearch = (event: ChangeEvent<HTMLInputElement>) => {
+    // Ensure no node from the 'old' filtered is lingering
+    setSelectedNode(null)
+    setExpanded(ExpansionValue.Default)
     const input = event.target.value
 
     if (!input) setFilteredTree(tree.getTree())
@@ -20,13 +52,31 @@ export const JmxTreeView: React.FunctionComponent = () => {
     const treeElements = MBeanTree.filter(tree.getTree(), node => node.name.toLowerCase().includes(input.toLowerCase()))
 
     if (treeElements.length === 0) setFilteredTree(tree.getTree())
-    else setFilteredTree(treeElements)
+    else {
+      setFilteredTree(treeElements)
+      setExpanded(ExpansionValue.ExpandAll)
+    }
   }
 
   const onSelect = (event: React.MouseEvent<Element, MouseEvent>, item: TreeViewDataItem) => {
     setSelectedNode(item as MBeanNode)
     /* On change of node selection update the url to the base plugin path */
     navigate(pluginPath)
+  }
+
+  const setAllExpanded = (value: boolean) => {
+    setExpanded(value ? ExpansionValue.ExpandAll : ExpansionValue.CollapseAll)
+  }
+
+  const expandedProp = (): object => {
+    switch (expanded) {
+      case ExpansionValue.ExpandAll:
+        return { allExpanded: true }
+      case ExpansionValue.CollapseAll:
+        return { allExpanded: false }
+      default:
+        return {}
+    }
   }
 
   return (
@@ -36,9 +86,9 @@ export const JmxTreeView: React.FunctionComponent = () => {
       hasGuides={true}
       hasSelectableNodes={true}
       activeItems={selectedNode ? [selectedNode] : []}
-      allExpanded={expanded}
+      {...expandedProp()}
       onSelect={onSelect}
-      toolbar={<PluginTreeViewToolbar onSearch={onSearch} onSetExpanded={setExpanded} />}
+      toolbar={<PluginTreeViewToolbar onSearch={onSearch} onSetExpanded={setAllExpanded} />}
     />
   )
 }

--- a/packages/hawtio/src/plugins/jmx/context.ts
+++ b/packages/hawtio/src/plugins/jmx/context.ts
@@ -1,8 +1,10 @@
-import { createContext, useEffect, useState, useContext } from 'react'
+import { createContext, useEffect, useState, useContext, useRef } from 'react'
 import { PluginNodeSelectionContext } from '@hawtiosrc/plugins'
 import { workspace, MBeanNode, MBeanTree } from '@hawtiosrc/plugins/shared'
-import { pluginName } from './globals'
+import { pluginName, pluginPath } from './globals'
 import { eventService, EVENT_REFRESH } from '@hawtiosrc/core'
+import { TreeViewDataItem } from '@patternfly/react-core'
+import { useNavigate } from 'react-router-dom'
 
 /**
  * Custom React hook for using JMX MBean tree.
@@ -11,16 +13,45 @@ export function useMBeanTree() {
   const [tree, setTree] = useState(MBeanTree.createEmpty(pluginName))
   const [loaded, setLoaded] = useState(false)
   const { selectedNode, setSelectedNode } = useContext(PluginNodeSelectionContext)
+  const navigate = useNavigate()
+
+  /*
+   * Need to preserve the selected node between re-renders since the
+   * populateTree function called via the refresh listener does not
+   * cache the value and stores it as null
+   */
+  const refSelectedNode = useRef<MBeanNode | null>()
+  refSelectedNode.current = selectedNode
+
+  const populateTree = async () => {
+    const wkspTree: MBeanTree = await workspace.getTree()
+    setTree(wkspTree)
+
+    if (!refSelectedNode.current) return
+
+    const path = [...refSelectedNode.current.path()]
+
+    // Expand the nodes to redisplay the path
+    wkspTree.forEach(path, (node: MBeanNode) => {
+      const tvd = node as TreeViewDataItem
+      tvd.defaultExpanded = true
+    })
+
+    // Ensure the new version of the selected node is selected
+    const newSelected = wkspTree.navigate(...path)
+    if (newSelected) setSelectedNode(newSelected)
+
+    /* On population of tree, ensure the url path is returned to the base plugin path */
+    navigate(pluginPath)
+  }
 
   useEffect(() => {
     const loadTree = async () => {
-      const tree = await workspace.getTree()
-      setTree(tree)
+      await populateTree()
       setLoaded(true)
     }
 
     const listener = () => {
-      setSelectedNode(null)
       setLoaded(false)
       loadTree()
     }

--- a/packages/hawtio/src/plugins/shared/globals.ts
+++ b/packages/hawtio/src/plugins/shared/globals.ts
@@ -2,3 +2,6 @@ import { Logger } from '@hawtiosrc/core'
 
 export const pluginName = 'hawtio-shared'
 export const log = Logger.get(pluginName)
+
+export const HAWTIO_REGISTRY_MBEAN = 'hawtio:type=Registry'
+export const HAWTIO_TREE_WATCHER_MBEAN = 'hawtio:type=TreeWatcher'

--- a/packages/hawtio/src/plugins/shared/tree/node.test.ts
+++ b/packages/hawtio/src/plugins/shared/tree/node.test.ts
@@ -172,15 +172,30 @@ describe('MBeanNode', () => {
     const domainNode = tree.get('org.apache.camel') as MBeanNode
     expect(domainNode).not.toBeNull()
 
-    let path = ['SampleCamel', 'components', 'quartz']
+    let path = ['org.apache.camel', 'SampleCamel', 'components', 'quartz']
     let qNode = domainNode.navigate(...path) as MBeanNode
     expect(qNode).not.toBeNull()
     expect(qNode.id).toBe('quartz-1')
 
-    path = ['SampleCame*', 'c*ponents', '*artz']
+    path = ['org.apache.camel', 'SampleCame*', 'c*ponents', '*artz']
     qNode = domainNode.navigate(...path) as MBeanNode
     expect(qNode).not.toBeNull()
     expect(qNode.id).toBe('quartz-1')
+  })
+
+  test('forEach', async () => {
+    const domainNode = tree.get('org.apache.camel') as MBeanNode
+    expect(domainNode).not.toBeNull()
+
+    let path = ['org.apache.camel', 'SampleCamel', 'components', 'quartz']
+    let counter = 0
+    domainNode.forEach(path, _ => (counter = counter + 1))
+    expect(counter).toEqual(path.length)
+
+    path = ['org.apache.camel', 'SampleCame*', 'c*ponents', '*artz']
+    counter = 0
+    domainNode.forEach(path, _ => (counter = counter + 1))
+    expect(counter).toEqual(path.length)
   })
 
   test('findAncestors', async () => {

--- a/packages/hawtio/src/plugins/shared/tree/tree.test.ts
+++ b/packages/hawtio/src/plugins/shared/tree/tree.test.ts
@@ -1,9 +1,16 @@
+import { workspace } from '../workspace'
 import { MBeanNode } from './node'
 import { treeProcessorRegistry } from './processor-registry'
 import { MBeanTree } from './tree'
 
+jest.mock('@hawtiosrc/plugins/connect/jolokia-service')
+
 describe('MBeanTree', () => {
-  beforeEach(() => {
+  let wkspTree: MBeanTree
+
+  beforeEach(async () => {
+    wkspTree = await workspace.getTree()
+    workspace.refreshTree()
     treeProcessorRegistry.reset()
   })
 
@@ -28,6 +35,30 @@ describe('MBeanTree', () => {
       'test:name=node1': node1,
       'test:name=node2': node2,
     })
+  })
+
+  test('navigate', async () => {
+    let path = ['org.apache.camel', 'SampleCamel', 'components', 'quartz']
+    let qNode = wkspTree.navigate(...path) as MBeanNode
+    expect(qNode).not.toBeNull()
+    expect(qNode.id).toBe('quartz-1')
+
+    path = ['org.apache.camel', 'SampleCame*', 'c*ponents', '*artz']
+    qNode = wkspTree.navigate(...path) as MBeanNode
+    expect(qNode).not.toBeNull()
+    expect(qNode.id).toBe('quartz-1')
+  })
+
+  test('forEach', async () => {
+    let path = ['org.apache.camel', 'SampleCamel', 'components', 'quartz']
+    let counter = 0
+    wkspTree.forEach(path, _ => (counter = counter + 1))
+    expect(counter).toEqual(path.length)
+
+    path = ['org.apache.camel', 'SampleCame*', 'c*ponents', '*artz']
+    counter = 0
+    wkspTree.forEach(path, _ => (counter = counter + 1))
+    expect(counter).toEqual(path.length)
   })
 })
 

--- a/packages/hawtio/src/plugins/shared/workspace.ts
+++ b/packages/hawtio/src/plugins/shared/workspace.ts
@@ -1,6 +1,6 @@
 import { eventService, Logger } from '@hawtiosrc/core'
 import { jolokiaService } from '@hawtiosrc/plugins/connect/jolokia-service'
-import { isString, parseBoolean } from '@hawtiosrc/util/strings'
+import { isString } from '@hawtiosrc/util/strings'
 import { IErrorResponse, IJmxOperation, IJmxOperations, IResponse, ISimpleOptions } from 'jolokia.js'
 import { isArray } from '@hawtiosrc/util/objects'
 import { is, object } from 'superstruct'
@@ -62,7 +62,7 @@ class Workspace {
       return
     }
     if (this.pluginUpdateCounter !== response.value) {
-      if (parseBoolean(localStorage['autoRefresh'])) {
+      if (jolokiaService.loadAutoRefresh()) {
         window.location.reload()
       }
     }

--- a/packages/hawtio/src/util/strings.test.ts
+++ b/packages/hawtio/src/util/strings.test.ts
@@ -1,4 +1,4 @@
-import { isString, toString, trimQuotes } from './strings'
+import { isString, parseBoolean, toString, trimQuotes } from './strings'
 
 describe('strings', () => {
   test('isString', () => {
@@ -27,5 +27,18 @@ describe('strings', () => {
 
     // it should not cause exception when null is passed
     expect(trimQuotes(null as never)).toBeNull()
+  })
+
+  test('parseBoolean()', () => {
+    expect(parseBoolean('true')).toBeTruthy()
+    expect(parseBoolean('TRUE')).toBeTruthy()
+    expect(parseBoolean('tRuE')).toBeTruthy()
+    expect(parseBoolean('1')).toBeTruthy()
+
+    expect(parseBoolean('')).toBeFalsy()
+    expect(parseBoolean('false')).toBeFalsy()
+    expect(parseBoolean('FALSE')).toBeFalsy()
+    expect(parseBoolean('FaLsE')).toBeFalsy()
+    expect(parseBoolean('0')).toBeFalsy()
   })
 })

--- a/packages/hawtio/src/util/strings.ts
+++ b/packages/hawtio/src/util/strings.ts
@@ -94,7 +94,8 @@ export function stringSorter(a: string, b: string): number {
   return 0
 }
 
-export function parseBoolean(value: string) {
+export function parseBoolean(value: string): boolean {
   if (!value) return false
-  return JSON.parse(value)
+
+  return /^true$/i.test(value) || parseInt(value) === 1
 }

--- a/packages/hawtio/src/util/strings.ts
+++ b/packages/hawtio/src/util/strings.ts
@@ -93,3 +93,8 @@ export function stringSorter(a: string, b: string): number {
   }
   return 0
 }
+
+export function parseBoolean(value: string) {
+  if (!value) return false
+  return JSON.parse(value)
+}


### PR DESCRIPTION
* workspace.ts
  * Ports the functions for the Registry and TreeWatcher jolokia mbeans
  * The response for the TreeWatcher is to call workspace.refresh()
  * Allows new nodes created by async calls on target apps to be added to the JMX and Camel trees

* .../context.ts
  * Adds a react ref for holding onto the selected node between renderings which allows the existing selected node to be re-selected upon a change to the underlying nodes trees
  * Since both camel and JMX trees use the same instances of nodes (taken from workspace.getTree() then they can be directly selected in both trees
  * Ensure the trees expand to show the node selections if the one tree happens to have not ever selected the selection before, eg. select a context in Camel Plugin then click on JMX Plugin would expand and highlight the same context in the JMX Plugin tree

* [Camel|Jmx]TreeView
  * Adds a useEffect() dependent on a change to the tree to redisplay the treeview - important for workspace refreshing after a TreeWatcher report

* JmxTreeView
  * Enhances the tree expansion logic in the same way as the CamelTreeView to either include or not include the allExpanded prop. If not included then the node.defaultExpanded properties are observed instead

* node.ts
  * path() method for extracting the string path [] of the node -> root
  * forEach() method for calling a callback on a path of nodes

* tree.ts
  * Adds navigate and forEach methods to mirror those used in node.ts