### PR TITLE
fix(connect): Jolokia service not setting right max collection size to requests

### DIFF
--- a/packages/hawtio/src/plugins/connect/ConnectPreferences.tsx
+++ b/packages/hawtio/src/plugins/connect/ConnectPreferences.tsx
@@ -29,7 +29,7 @@ export const ConnectPreferences: React.FunctionComponent = () => (
 const JolokiaForm: React.FunctionComponent = () => {
   const navigate = useNavigate()
 
-  const jolokiaStoredOptions = jolokiaService.loadJolokiaOptionsFromStorage()
+  const jolokiaStoredOptions = jolokiaService.loadJolokiaStoredOptions()
   const [updateRate, setUpdateRate] = useState(jolokiaService.loadUpdateRate())
   const [autoRefresh, setAutoRefresh] = useState(jolokiaService.loadAutoRefresh())
   const [maxDepth, setMaxDepth] = useState(jolokiaStoredOptions.maxDepth)
@@ -48,7 +48,7 @@ const JolokiaForm: React.FunctionComponent = () => {
     const intValue = parseInt(maxDepth)
 
     if (intValue) {
-      jolokiaService.saveMaxDepth(intValue)
+      jolokiaService.saveJolokiaStoredOptions({ maxDepth: intValue, maxCollectionSize })
       setMaxDepth(intValue)
     }
   }
@@ -62,7 +62,7 @@ const JolokiaForm: React.FunctionComponent = () => {
     const intValue = parseInt(maxCollectionSize)
 
     if (intValue) {
-      jolokiaService.saveMaxCollectionSize(intValue)
+      jolokiaService.saveJolokiaStoredOptions({ maxDepth, maxCollectionSize: intValue })
       setMaxCollectionSize(intValue)
     }
   }

--- a/packages/hawtio/src/plugins/connect/__mocks__/jolokia-service.ts
+++ b/packages/hawtio/src/plugins/connect/__mocks__/jolokia-service.ts
@@ -1,5 +1,5 @@
 import { IRequest, IResponse, IResponseFn, ISimpleOptions } from 'jolokia.js'
-import { AttributeValues, IJolokiaService, IJolokiaStoredOptions, JolokiaListMethod } from '../jolokia-service'
+import { AttributeValues, IJolokiaService, JolokiaStoredOptions, JolokiaListMethod } from '../jolokia-service'
 import jmxCamelResponse from './jmx-camel-tree.json'
 
 class MockJolokiaService implements IJolokiaService {
@@ -51,22 +51,26 @@ class MockJolokiaService implements IJolokiaService {
     return 0
   }
 
-  saveUpdateRate(value: number): void {
+  saveUpdateRate(value: number) {
     //no-op
   }
 
-  loadJolokiaOptionsFromStorage(): IJolokiaStoredOptions {
+  loadAutoRefresh(): boolean {
+    return false
+  }
+
+  saveAutoRefresh(value: boolean) {
+    //no-op
+  }
+
+  loadJolokiaStoredOptions(): JolokiaStoredOptions {
     return {
       maxDepth: 0,
       maxCollectionSize: 0,
     }
   }
 
-  saveMaxDepth(value: number): void {
-    //no-op
-  }
-
-  saveMaxCollectionSize(value: number): void {
+  saveJolokiaStoredOptions(options: JolokiaStoredOptions) {
     //no-op
   }
 }

--- a/packages/hawtio/src/plugins/connect/jolokia-service.test.ts
+++ b/packages/hawtio/src/plugins/connect/jolokia-service.test.ts
@@ -1,0 +1,18 @@
+import { DEFAULT_MAX_COLLECTION_SIZE, DEFAULT_MAX_DEPTH, jolokiaService } from './jolokia-service'
+
+describe('JolokiaService', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  test('load and save Jolokia options', () => {
+    let options = jolokiaService.loadJolokiaStoredOptions()
+    expect(options.maxDepth).toEqual(DEFAULT_MAX_DEPTH)
+    expect(options.maxCollectionSize).toEqual(DEFAULT_MAX_COLLECTION_SIZE)
+
+    jolokiaService.saveJolokiaStoredOptions({ maxDepth: 3, maxCollectionSize: 10000 })
+    options = jolokiaService.loadJolokiaStoredOptions()
+    expect(options.maxDepth).toEqual(3)
+    expect(options.maxCollectionSize).toEqual(10000)
+  })
+})

--- a/packages/hawtio/src/plugins/connect/jolokia-service.ts
+++ b/packages/hawtio/src/plugins/connect/jolokia-service.ts
@@ -466,7 +466,7 @@ class JolokiaService implements IJolokiaService {
       maxDepth: currentJolokiaUpdateOptions['maxDepth'] ? currentJolokiaUpdateOptions['maxDepth'] : DEFAULT_MAX_DEPTH,
       maxCollectionSize: currentJolokiaUpdateOptions['maxCollectionSize']
         ? currentJolokiaUpdateOptions['maxCollectionSize']
-        : DEFAULT_MAX_DEPTH,
+        : DEFAULT_MAX_COLLECTION_SIZE,
     }
 
     return jolokiaOptions

--- a/packages/hawtio/src/plugins/connect/jolokia-service.ts
+++ b/packages/hawtio/src/plugins/connect/jolokia-service.ts
@@ -72,7 +72,7 @@ export interface JolokiaConfig {
   mbean: string
 }
 
-export interface IJolokiaStoredOptions {
+export interface JolokiaStoredOptions {
   maxDepth: number
   maxCollectionSize: number
 }
@@ -94,9 +94,10 @@ export interface IJolokiaService {
   unregister(handle: number): void
   loadUpdateRate(): number
   saveUpdateRate(value: number): void
-  loadJolokiaOptionsFromStorage(): IJolokiaStoredOptions
-  saveMaxDepth(value: number): void
-  saveMaxCollectionSize(value: number): void
+  loadAutoRefresh(): boolean
+  saveAutoRefresh(value: boolean): void
+  loadJolokiaStoredOptions(): JolokiaStoredOptions
+  saveJolokiaStoredOptions(options: JolokiaStoredOptions): void
 }
 
 class JolokiaService implements IJolokiaService {
@@ -310,7 +311,7 @@ class JolokiaService implements IJolokiaService {
   }
 
   private async loadJolokiaOptions(): Promise<IOptions> {
-    const opts = { ...DEFAULT_JOLOKIA_OPTIONS, ...this.loadJolokiaOptionsFromStorage() }
+    const opts = { ...DEFAULT_JOLOKIA_OPTIONS, ...this.loadJolokiaStoredOptions() }
 
     const jolokiaUrl = await this.jolokiaUrl
     if (jolokiaUrl) {
@@ -437,10 +438,6 @@ class JolokiaService implements IJolokiaService {
     jolokia.unregister(handle)
   }
 
-  saveJolokiaOptions(params: IOptions) {
-    localStorage.setItem(STORAGE_KEY_JOLOKIA_OPTIONS, JSON.stringify(params))
-  }
-
   loadUpdateRate(): number {
     const value = localStorage.getItem(STORAGE_KEY_UPDATE_RATE)
     return value ? parseInt(JSON.parse(value)) : DEFAULT_UPDATE_RATE
@@ -459,33 +456,16 @@ class JolokiaService implements IJolokiaService {
     localStorage.setItem(STORAGE_KEY_AUTO_REFRESH, JSON.stringify(value))
   }
 
-  loadJolokiaOptionsFromStorage(): IJolokiaStoredOptions {
-    const currentStorageJolokiaOptions = localStorage.getItem(STORAGE_KEY_JOLOKIA_OPTIONS)
-    const currentJolokiaUpdateOptions = currentStorageJolokiaOptions ? JSON.parse(currentStorageJolokiaOptions) : {}
-    const jolokiaOptions = {
-      maxDepth: currentJolokiaUpdateOptions['maxDepth'] ? currentJolokiaUpdateOptions['maxDepth'] : DEFAULT_MAX_DEPTH,
-      maxCollectionSize: currentJolokiaUpdateOptions['maxCollectionSize']
-        ? currentJolokiaUpdateOptions['maxCollectionSize']
-        : DEFAULT_MAX_COLLECTION_SIZE,
-    }
-
-    return jolokiaOptions
+  loadJolokiaStoredOptions(): JolokiaStoredOptions {
+    const item = localStorage.getItem(STORAGE_KEY_JOLOKIA_OPTIONS)
+    const options: JolokiaStoredOptions = item ? JSON.parse(item) : {}
+    const maxDepth = options.maxDepth || DEFAULT_MAX_DEPTH
+    const maxCollectionSize = options.maxCollectionSize || DEFAULT_MAX_COLLECTION_SIZE
+    return { maxDepth, maxCollectionSize }
   }
 
-  saveMaxDepth(value: number): void {
-    const currentStorageJolokiaOptions = localStorage.getItem(STORAGE_KEY_JOLOKIA_OPTIONS)
-    const currentJolokiaUpdateOptions = currentStorageJolokiaOptions ? JSON.parse(currentStorageJolokiaOptions) : {}
-    currentJolokiaUpdateOptions['maxDepth'] = value
-
-    localStorage.setItem(STORAGE_KEY_JOLOKIA_OPTIONS, JSON.stringify(currentJolokiaUpdateOptions))
-  }
-
-  saveMaxCollectionSize(value: number): void {
-    const currentStorageJolokiaOptions = localStorage.getItem(STORAGE_KEY_JOLOKIA_OPTIONS)
-    const currentJolokiaUpdateOptions = currentStorageJolokiaOptions ? JSON.parse(currentStorageJolokiaOptions) : {}
-    currentJolokiaUpdateOptions['maxCollectionSize'] = value
-
-    localStorage.setItem(STORAGE_KEY_JOLOKIA_OPTIONS, JSON.stringify(currentJolokiaUpdateOptions))
+  saveJolokiaStoredOptions(options: JolokiaStoredOptions) {
+    localStorage.setItem(STORAGE_KEY_JOLOKIA_OPTIONS, JSON.stringify(options))
   }
 }
 

--- a/packages/hawtio/src/setupTests.ts
+++ b/packages/hawtio/src/setupTests.ts
@@ -4,6 +4,7 @@
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom/extend-expect'
 import fetchMock from 'jest-fetch-mock'
+import $ from 'jquery'
 
 fetchMock.enableMocks()
 
@@ -19,3 +20,8 @@ fetchMock.mockResponse(req => {
   }
   return Promise.resolve(res)
 })
+
+// To fix "jQuery is not defined" error
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const global: any
+global.$ = global.jQuery = $


### PR DESCRIPTION
There is a bug in Connect preferences/Jolokia service visible in the downstream main Hawtio distribution that Hawtio and Camel MBeans are dropped from the loaded MBean tree. This fixes the bug.