### PR TITLE
feat(plugin): export plugin API to plugin developers

### DIFF
--- a/app/src/examples/index.ts
+++ b/app/src/examples/index.ts
@@ -1,9 +1,10 @@
+import { HawtioPlugin } from '@hawtio/react'
 import { registerDisabled } from './disabled'
 import { registerExample1 } from './example1'
 import { registerExample2 } from './example2'
 import { registerExample3 } from './example3'
 
-export const registerExamples = () => {
+export const registerExamples: HawtioPlugin = () => {
   registerExample1()
   registerExample2()
   registerExample3()

--- a/packages/hawtio/src/index.ts
+++ b/packages/hawtio/src/index.ts
@@ -1,10 +1,12 @@
 import { configManager } from './core'
 
-export * from './core'
+// Hawtio React component
 export * from './Hawtio'
-export { helpRegistry } from './help'
+// Hawtio API
+export * from './core'
+export * from './help'
 export * from './plugins'
-export { preferencesRegistry } from './preferences'
+export * from './preferences'
 
 // Register Hawtio React component version
 configManager.addProductInfo('Hawtio React', '__PACKAGE_VERSION_PLACEHOLDER__')

--- a/packages/hawtio/src/plugins/connect/index.ts
+++ b/packages/hawtio/src/plugins/connect/index.ts
@@ -18,4 +18,4 @@ export const connect: HawtioPlugin = () => {
   preferencesRegistry.add('connect', 'Connect', ConnectPreferences, 11)
 }
 
-export { JolokiaListMethod, jolokiaService } from './jolokia-service'
+export * from './jolokia-service'

--- a/packages/hawtio/src/plugins/index.ts
+++ b/packages/hawtio/src/plugins/index.ts
@@ -1,14 +1,16 @@
+import { HawtioPlugin } from '@hawtiosrc/core'
 import { camel } from './camel'
 import { connect } from './connect'
 import { jmx } from './jmx'
 import { rbac } from './rbac'
 
-export const registerPlugins = () => {
+export const registerPlugins: HawtioPlugin = () => {
   connect()
   jmx()
   rbac()
   camel()
 }
 
-export { jolokiaService } from './connect'
-export { PluginNodeSelectionContext, usePluginNodeSelected } from './selectionNodeContext'
+export * from './connect'
+export * from './selectionNodeContext'
+export * from './shared'

--- a/packages/hawtio/src/preferences/index.ts
+++ b/packages/hawtio/src/preferences/index.ts
@@ -1,3 +1,1 @@
-export * from './HawtioPreferences'
-export * from './preferences-service'
 export * from './registry'

--- a/packages/hawtio/src/ui/page/HawtioHeader.tsx
+++ b/packages/hawtio/src/ui/page/HawtioHeader.tsx
@@ -1,7 +1,7 @@
 import { PUBLIC_USER, userService } from '@hawtiosrc/auth'
 import { DEFAULT_APP_NAME, useHawtconfig } from '@hawtiosrc/core'
 import { hawtioLogo, userAvatar } from '@hawtiosrc/img'
-import { preferencesService } from '@hawtiosrc/preferences'
+import { preferencesService } from '@hawtiosrc/preferences/preferences-service'
 import { HawtioAbout } from '@hawtiosrc/ui/about'
 import {
   Avatar,
@@ -23,8 +23,8 @@ import {
 import { BarsIcon, HelpIcon } from '@patternfly/react-icons'
 import React, { useContext, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { PageContext } from './context'
 import './HawtioHeader.css'
+import { PageContext } from './context'
 
 export const HawtioHeader: React.FunctionComponent = () => {
   const [navOpen, setNavOpen] = useState(preferencesService.isShowVerticalNavByDefault())

--- a/packages/hawtio/src/ui/page/HawtioPage.tsx
+++ b/packages/hawtio/src/ui/page/HawtioPage.tsx
@@ -3,7 +3,8 @@ import { usePlugins } from '@hawtiosrc/core'
 import { HawtioHelp } from '@hawtiosrc/help/HawtioHelp'
 import { backgroundImages } from '@hawtiosrc/img'
 import { PluginNodeSelectionContext, usePluginNodeSelected } from '@hawtiosrc/plugins'
-import { HawtioPreferences, preferencesService } from '@hawtiosrc/preferences'
+import { HawtioPreferences } from '@hawtiosrc/preferences/HawtioPreferences'
+import { preferencesService } from '@hawtiosrc/preferences/preferences-service'
 import {
   BackgroundImage,
   EmptyState,
@@ -18,11 +19,11 @@ import { CubesIcon } from '@patternfly/react-icons'
 import React from 'react'
 import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-dom'
 import { HawtioNotification } from '../notification'
-import { PageContext } from './context'
-import { log } from './globals'
 import { HawtioHeader } from './HawtioHeader'
 import { HawtioLoading } from './HawtioLoading'
 import { HawtioSidebar } from './HawtioSidebar'
+import { PageContext } from './context'
+import { log } from './globals'
 
 export const HawtioPage: React.FunctionComponent = () => {
   const { username, isLogin, userLoaded } = useUser()


### PR DESCRIPTION
fix #229 and supercede #232

Splitting packages for exposing plugin API (#232) seems to be too much by introducing a bit too much complexity to the project. And there are issues with splitting it: 1) util module, 2) circular dependency between core and plugins, thus it couldn't be cleanly achieved with the current codebase.

For now, we can just expose every required API from `@hawtio/react` (this pull req) to move things forward. We can revisit the plugin API exposure issue later once we've learned better about the problem space.