### PR TITLE
fix(test): Normalized tags for testing

### DIFF
--- a/packages/hawtio/src/plugins/camel/CamelTreeView.tsx
+++ b/packages/hawtio/src/plugins/camel/CamelTreeView.tsx
@@ -86,6 +86,29 @@ export const CamelTreeView: React.FunctionComponent = () => {
     }
   }
 
+  const actuallyRenameAccordingToParents = (mbean: MBeanNode) => {
+    // The names concats all parent names together. I was unable to find source on base version, but from debugging the app,
+    // it seems like that is the logic
+    const elementNamesParentToChild = []
+    let currentNode: MBeanNode | null = mbean
+    while (currentNode) {
+      elementNamesParentToChild.unshift(currentNode.name)
+      currentNode = currentNode.parent
+    }
+
+    mbean.id = elementNamesParentToChild.join('-')
+  }
+  const renameAccordingToParents = (mbean: MBeanNode) => {
+    mbean.getChildren().forEach(mbean => {
+      renameAccordingToParents(mbean)
+    })
+
+    actuallyRenameAccordingToParents(mbean)
+  }
+  filteredTree.forEach(mbean => {
+    renameAccordingToParents(mbean)
+  })
+
   return (
     <TreeView
       id='camel-tree-view'

--- a/packages/hawtio/src/plugins/jmx/JmxTreeView.tsx
+++ b/packages/hawtio/src/plugins/jmx/JmxTreeView.tsx
@@ -79,6 +79,29 @@ export const JmxTreeView: React.FunctionComponent = () => {
     }
   }
 
+  const actuallyRenameAccordingToParents = (mbean: MBeanNode) => {
+    // The names concats all parent names together. I was unable to find source on base version, but from debugging the app,
+    // it seems like that is the logic
+    const elementNamesParentToChild = []
+    let currentNode: MBeanNode | null = mbean
+    while (currentNode) {
+      elementNamesParentToChild.unshift(currentNode.name)
+      currentNode = currentNode.parent
+    }
+
+    mbean.id = elementNamesParentToChild.join('-')
+  }
+  const renameAccordingToParents = (mbean: MBeanNode) => {
+    mbean.getChildren().forEach(mbean => {
+      renameAccordingToParents(mbean)
+    })
+
+    actuallyRenameAccordingToParents(mbean)
+  }
+  filteredTree.forEach(mbean => {
+    renameAccordingToParents(mbean)
+  })
+
   return (
     <TreeView
       id='jmx-tree-view'


### PR DESCRIPTION
Quick fix to unblock https://github.com/hawtio/hawtio/issues/2826.

I was unable to find how it was generated in other version actually, but from inspecting the other version, it seems to just be concatenating the parents.

This is just a quick fix and will need to be refactored:
- The ideal is to maybe change the IDs generated by the MBeans to be like this, but I was unable to find this info for JMX, only for Camel (in the Camel Tree Processor).
- I don't know if those ids are used for something else
- If there is no search done I'm quite sure I'm mutating the MBeans themselves as well when doing this. While navigating a bit through the app, I didn't find any bugs though.
- As the tree comes from patternfly, there was no way to just change the component to have another logic in the tag, unfortunately

![Screenshot from 2023-04-25 19-06-19](https://user-images.githubusercontent.com/17336236/234351850-013c59c5-8255-4cb3-a0f8-ab391daba456.png)

Sorry for the quick thingie but I saw it was blocking him and I'm on holiday from tomorrow onwards. But this should help in the testing process I think and make it consistent. We can further refine it after he has this merged and decide on another solution following this naming convention



