### PR TITLE
fix(jmx,camel): consistent tree node id generation for e2e testing

### DIFF
--- a/packages/hawtio/src/plugins/camel/CamelTreeView.tsx
+++ b/packages/hawtio/src/plugins/camel/CamelTreeView.tsx
@@ -86,29 +86,6 @@ export const CamelTreeView: React.FunctionComponent = () => {
     }
   }
 
-  const actuallyRenameAccordingToParents = (mbean: MBeanNode) => {
-    // The names concats all parent names together. I was unable to find source on base version, but from debugging the app,
-    // it seems like that is the logic
-    const elementNamesParentToChild = []
-    let currentNode: MBeanNode | null = mbean
-    while (currentNode) {
-      elementNamesParentToChild.unshift(currentNode.name)
-      currentNode = currentNode.parent
-    }
-
-    mbean.id = elementNamesParentToChild.join('-')
-  }
-  const renameAccordingToParents = (mbean: MBeanNode) => {
-    mbean.getChildren().forEach(mbean => {
-      renameAccordingToParents(mbean)
-    })
-
-    actuallyRenameAccordingToParents(mbean)
-  }
-  filteredTree.forEach(mbean => {
-    renameAccordingToParents(mbean)
-  })
-
   return (
     <TreeView
       id='camel-tree-view'

--- a/packages/hawtio/src/plugins/camel/camel-content-service.test.ts
+++ b/packages/hawtio/src/plugins/camel/camel-content-service.test.ts
@@ -1,12 +1,12 @@
 import { MBeanNode } from '@hawtiosrc/plugins/shared/tree'
-import { jmxDomain, endpointNodeType, endpointsType, contextNodeType } from './globals'
 import * as ccs from './camel-content-service'
+import { contextNodeType, endpointNodeType, endpointsType, jmxDomain } from './globals'
 
 jest.mock('@hawtiosrc/plugins/connect/jolokia-service')
 
 describe('camel-content-service', () => {
   test('syncChildProperties', async () => {
-    const domainNode = new MBeanNode(null, jmxDomain, jmxDomain, true)
+    const domainNode = new MBeanNode(null, jmxDomain, true)
     const endpointsNode = domainNode.create(endpointsType, true)
 
     const childNames = [
@@ -61,7 +61,7 @@ describe('camel-content-service', () => {
   })
 
   test('isCamelVersionEQGT', () => {
-    const ctxNode = new MBeanNode(null, 'sampleapp', 'sampleapp', true)
+    const ctxNode = new MBeanNode(null, 'sampleapp', true)
     ccs.setDomain(ctxNode)
     ccs.setType(ctxNode, contextNodeType)
 

--- a/packages/hawtio/src/plugins/camel/routes-service.test.ts
+++ b/packages/hawtio/src/plugins/camel/routes-service.test.ts
@@ -34,13 +34,13 @@ describe('routes-service', () => {
   })
 
   beforeEach(() => {
-    contextNode = new MBeanNode(null, 'SampleCamel', 'sample-camel-1', true)
+    contextNode = new MBeanNode(null, 'sample-camel-1', true)
     contextNode.objectName = 'org.apache.camel:context=SampleCamel,type=context,name="SampleCamel"'
 
-    routesNode = new MBeanNode(null, 'Routes', 'routes-2', true)
+    routesNode = new MBeanNode(null, 'routes-2', true)
     routesNode.addProperty('type', 'routes')
 
-    simpleRouteNode = new MBeanNode(null, 'simple', testRouteId, false)
+    simpleRouteNode = new MBeanNode(null, testRouteId, false)
 
     routesNode.adopt(simpleRouteNode)
     contextNode.adopt(routesNode)
@@ -65,20 +65,18 @@ describe('routes-service', () => {
 
   test('getRoutesXml no mbean', async () => {
     contextNode.objectName = undefined
-    const t = async () => {
-      await routesService.getRoutesXml(contextNode)
-    }
 
-    await expect(t).rejects.toThrow('Cannot process route xml as mbean name not available')
+    await expect(() => routesService.getRoutesXml(contextNode)).rejects.toThrow(
+      'Cannot process route xml as mbean name not available',
+    )
   })
 
   test('getRoutesXml wrong mbean', async () => {
     contextNode.objectName = 'wrong:mbean:name'
-    const t = async () => {
-      await routesService.getRoutesXml(contextNode)
-    }
 
-    await expect(t).rejects.toThrow('Failed to extract any xml from mbean: ' + contextNode.objectName)
+    await expect(() => routesService.getRoutesXml(contextNode)).rejects.toThrow(
+      'Failed to extract any xml from mbean: ' + contextNode.objectName,
+    )
   })
 
   test('loadRouteChildren', async () => {
@@ -92,19 +90,19 @@ describe('routes-service', () => {
       children?: MBeanAttr[]
     }
 
-    const exp: MBeanAttr[] = [
+    const expected: MBeanAttr[] = [
       { id: 'from', name: 'from' },
-      { id: 'setBody2', name: 'setBody' },
-      { id: 'to3', name: 'to' },
-      { id: 'to4', name: 'to' },
+      { id: 'setBody', name: 'setBody' },
+      { id: 'to', name: 'to' },
+      { id: 'to', name: 'to' },
     ]
 
     for (let i = 0; i < simpleRouteNode.childCount(); ++i) {
       let childNode: MBeanNode | null = simpleRouteNode.getIndex(i)
       expect(childNode).not.toBeNull()
       childNode = childNode as MBeanNode
-      expect(childNode.id).toBe(exp[i].id)
-      expect(childNode.name).toBe(exp[i].name)
+      expect(childNode.id).toBe(expected[i].id)
+      expect(childNode.name).toBe(expected[i].name)
       expect(childNode.getChildren().length).toBe(0)
       expect(childNode.icon).not.toBeNull()
       render(childNode.icon as React.ReactElement)

--- a/packages/hawtio/src/plugins/camel/routes-service.ts
+++ b/packages/hawtio/src/plugins/camel/routes-service.ts
@@ -103,8 +103,7 @@ class RoutesService {
     const nodeName = routeXml.localName
     const nodeSettings = schemaService.getSchema(nodeName)
     if (nodeSettings) {
-      const id = routeXml.getAttribute('id') || nodeName
-      const node = new MBeanNode(null, id, nodeName, false)
+      const node = new MBeanNode(null, nodeName, false)
       ccs.setType(node, routeXmlNodeType)
       ccs.setDomain(node)
       const icon: React.ReactNode = this.getIcon(nodeSettings)

--- a/packages/hawtio/src/plugins/camel/tree-processor.test.ts
+++ b/packages/hawtio/src/plugins/camel/tree-processor.test.ts
@@ -1,5 +1,8 @@
 import { jolokiaService } from '@hawtiosrc/plugins/connect/jolokia-service'
 import { MBeanNode, MBeanTree, workspace } from '@hawtiosrc/plugins/shared'
+import fs from 'fs'
+import path from 'path'
+import * as ccs from './camel-content-service'
 import {
   camelContexts,
   componentsType,
@@ -7,14 +10,11 @@ import {
   contextsType,
   endpointsType,
   jmxDomain,
-  routesType,
   mbeansType,
   routeNodeType,
+  routesType,
 } from './globals'
-import * as ccs from './camel-content-service'
 import { camelTreeProcessor } from './tree-processor'
-import fs from 'fs'
-import path from 'path'
 
 jest.mock('@hawtiosrc/plugins/connect/jolokia-service')
 
@@ -67,35 +67,35 @@ describe('tree-processor', () => {
     expect(contextsNode).not.toBeNull()
     expect(ccs.hasDomain(contextsNode)).toBeTruthy()
     expect(ccs.hasType(contextsNode, contextsType)).toBeTruthy()
-    expect(contextsNode.id).toBe(`${camelContexts}-1`)
+    expect(contextsNode.id).toBe('org.apache.camel-CamelContexts')
     expect(contextsNode.name).toBe(camelContexts)
     expect(contextsNode.childCount()).toBe(1)
 
     const contextNode = contextsNode.getIndex(0) as MBeanNode
     expect(ccs.hasDomain(contextNode)).toBeTruthy()
     expect(ccs.hasType(contextNode, contextNodeType)).toBeTruthy()
-    expect(contextNode.id).toBe('SampleCamel-1')
+    expect(contextNode.id).toBe('org.apache.camel-CamelContexts-SampleCamel')
     expect(contextNode.name).toBe('SampleCamel')
     expect(ccs.getCamelVersion(contextNode)).toBe(CAMEL_MODEL_VERSION)
     expect(contextNode.childCount()).toBe(4)
 
     const types = [routesType, endpointsType, componentsType, mbeansType]
-    for (const t of types) {
-      const n = contextNode.get(t) as MBeanNode
-      expect(n).toBeDefined()
-      expect(ccs.hasDomain(n)).toBeTruthy()
-      expect(ccs.hasType(n, t)).toBeTruthy()
-      expect(n.id).toMatch(new RegExp(`^${t}-[0-9]+`))
-      expect(n.name).toBe(t)
-      expect(ccs.getCamelVersion(n)).toBe(CAMEL_MODEL_VERSION)
-      expect(n.childCount()).toBeGreaterThan(0)
+    for (const type of types) {
+      const node = contextNode.get(type) as MBeanNode
+      expect(node).toBeDefined()
+      expect(ccs.hasDomain(node)).toBeTruthy()
+      expect(ccs.hasType(node, type)).toBeTruthy()
+      expect(node.id).toEqual(`org.apache.camel-CamelContexts-SampleCamel-${type}`)
+      expect(node.name).toBe(type)
+      expect(ccs.getCamelVersion(node)).toBe(CAMEL_MODEL_VERSION)
+      expect(node.childCount()).toBeGreaterThan(0)
     }
 
     const routesNode = contextNode.get(routesType) as MBeanNode
-    for (const c of routesNode.getChildren()) {
-      expect(c).toBeDefined()
-      expect(ccs.hasDomain(c)).toBeTruthy()
-      expect(ccs.hasType(c, routeNodeType)).toBeTruthy()
+    for (const child of routesNode.getChildren()) {
+      expect(child).toBeDefined()
+      expect(ccs.hasDomain(child)).toBeTruthy()
+      expect(ccs.hasType(child, routeNodeType)).toBeTruthy()
     }
   })
 })

--- a/packages/hawtio/src/plugins/jmx/JmxTreeView.tsx
+++ b/packages/hawtio/src/plugins/jmx/JmxTreeView.tsx
@@ -1,9 +1,9 @@
+import { MBeanNode, MBeanTree, PluginTreeViewToolbar } from '@hawtiosrc/plugins/shared'
 import { TreeView, TreeViewDataItem } from '@patternfly/react-core'
 import React, { ChangeEvent, useContext, useEffect, useState } from 'react'
-import { PluginTreeViewToolbar, MBeanNode, MBeanTree } from '@hawtiosrc/plugins/shared'
-import { MBeanTreeContext } from './context'
-import './JmxTreeView.css'
 import { useNavigate } from 'react-router-dom'
+import './JmxTreeView.css'
+import { MBeanTreeContext } from './context'
 import { pluginPath } from './globals'
 
 /**
@@ -78,29 +78,6 @@ export const JmxTreeView: React.FunctionComponent = () => {
         return {}
     }
   }
-
-  const actuallyRenameAccordingToParents = (mbean: MBeanNode) => {
-    // The names concats all parent names together. I was unable to find source on base version, but from debugging the app,
-    // it seems like that is the logic
-    const elementNamesParentToChild = []
-    let currentNode: MBeanNode | null = mbean
-    while (currentNode) {
-      elementNamesParentToChild.unshift(currentNode.name)
-      currentNode = currentNode.parent
-    }
-
-    mbean.id = elementNamesParentToChild.join('-')
-  }
-  const renameAccordingToParents = (mbean: MBeanNode) => {
-    mbean.getChildren().forEach(mbean => {
-      renameAccordingToParents(mbean)
-    })
-
-    actuallyRenameAccordingToParents(mbean)
-  }
-  filteredTree.forEach(mbean => {
-    renameAccordingToParents(mbean)
-  })
 
   return (
     <TreeView

--- a/packages/hawtio/src/plugins/shared/tree/node.test.ts
+++ b/packages/hawtio/src/plugins/shared/tree/node.test.ts
@@ -1,7 +1,7 @@
-import { Icons, MBeanNode, PropertyList } from './node'
-import { workspace } from '../workspace'
-import { MBeanTree } from './tree'
 import { domainNodeType } from '@hawtiosrc/plugins/camel/globals'
+import { workspace } from '../workspace'
+import { Icons, MBeanNode, PropertyList } from './node'
+import { MBeanTree } from './tree'
 
 jest.mock('@hawtiosrc/plugins/connect/jolokia-service')
 
@@ -74,7 +74,7 @@ describe('MBeanNode', () => {
       canInvoke: true,
     }
 
-    const node1 = new MBeanNode(null, 'test.node', 'test.node', false)
+    const node1 = new MBeanNode(null, 'test.node', false)
     node1.populateMBean('context=SampleContext,type=context,name="SampleCamel"', mbean)
     expect(node1.icon).toBe(Icons.folder)
     expect(node1.expandedIcon).toBe(Icons.folderOpen)
@@ -101,7 +101,7 @@ describe('MBeanNode', () => {
 
     // When canInvoke is false
     mbean.canInvoke = false
-    const node2 = new MBeanNode(null, 'test.node', 'test.node', false)
+    const node2 = new MBeanNode(null, 'test.node', false)
     node2.populateMBean('context=SampleContext,type=context,name="SampleCamel"', mbean)
 
     const child2 = node2.children?.[0].children?.[0].children?.[0]
@@ -175,12 +175,12 @@ describe('MBeanNode', () => {
     let path = ['org.apache.camel', 'SampleCamel', 'components', 'quartz']
     let qNode = domainNode.navigate(...path) as MBeanNode
     expect(qNode).not.toBeNull()
-    expect(qNode.id).toBe('quartz-1')
+    expect(qNode.id).toBe('org.apache.camel-SampleCamel-components-quartz')
 
     path = ['org.apache.camel', 'SampleCame*', 'c*ponents', '*artz']
     qNode = domainNode.navigate(...path) as MBeanNode
     expect(qNode).not.toBeNull()
-    expect(qNode.id).toBe('quartz-1')
+    expect(qNode.id).toBe('org.apache.camel-SampleCamel-components-quartz')
   })
 
   test('forEach', async () => {
@@ -201,16 +201,16 @@ describe('MBeanNode', () => {
   test('findAncestors', async () => {
     const camelNode = tree.get('org.apache.camel') as MBeanNode
     expect(camelNode).not.toBeNull()
-    expect(camelNode.id).toBe('org-apache-camel')
+    expect(camelNode.id).toBe('org.apache.camel')
 
     const ctxNode = camelNode.getIndex(0) as MBeanNode
     expect(ctxNode).not.toBeNull()
-    expect(ctxNode.id).toBe('SampleCamel-1')
+    expect(ctxNode.id).toBe('org.apache.camel-SampleCamel')
     expect(ctxNode.name).toBe('SampleCamel')
 
     const compNode = ctxNode.get('components') as MBeanNode
     expect(compNode).not.toBeNull()
-    expect(compNode.id).toBe('components-4')
+    expect(compNode.id).toBe('org.apache.camel-SampleCamel-components')
 
     const chain: string[] = [camelNode.name, ctxNode.name]
     expect(compNode.findAncestors().map((n: MBeanNode) => n.name)).toEqual(chain)
@@ -220,16 +220,16 @@ describe('MBeanNode', () => {
     const tree: MBeanTree = await workspace.getTree()
     const camelNode = tree.get('org.apache.camel') as MBeanNode
     expect(camelNode).not.toBeNull()
-    expect(camelNode.id).toBe('org-apache-camel')
+    expect(camelNode.id).toBe('org.apache.camel')
 
     const ctxNode = camelNode.getIndex(0) as MBeanNode
     expect(ctxNode).not.toBeNull()
-    expect(ctxNode.id).toBe('SampleCamel-1')
+    expect(ctxNode.id).toBe('org.apache.camel-SampleCamel')
     expect(ctxNode.name).toBe('SampleCamel')
 
     const compNode = ctxNode.get('components') as MBeanNode
     expect(compNode).not.toBeNull()
-    expect(compNode.id).toBe('components-4')
+    expect(compNode.id).toBe('org.apache.camel-SampleCamel-components')
 
     expect(compNode.findAncestor((node: MBeanNode) => node.name === ctxNode.name)).toBe(ctxNode)
     expect(compNode.findAncestor((node: MBeanNode) => node.name === camelNode.name)).toBe(camelNode)
@@ -239,9 +239,9 @@ describe('MBeanNode', () => {
     const tree: MBeanTree = await workspace.getTree()
     const camelNode = tree.get('org.apache.camel') as MBeanNode
     expect(camelNode).not.toBeNull()
-    expect(camelNode.id).toBe('org-apache-camel')
+    expect(camelNode.id).toBe('org.apache.camel')
 
-    const newCtx = new MBeanNode(null, 'test', 'TestNode', false)
+    const newCtx = new MBeanNode(null, 'TestNode', false)
     expect(newCtx.parent).toBeNull()
 
     camelNode.adopt(newCtx)
@@ -252,24 +252,24 @@ describe('MBeanNode', () => {
 
 describe('PropertyList', () => {
   test('objectName', () => {
-    const node = new MBeanNode(null, 'org.apache.camel', 'org.apache.camel', false)
+    const node = new MBeanNode(null, 'org.apache.camel', false)
     const propList = new PropertyList(node, 'context=SampleContext,type=context,name="SampleCamel"')
     expect(propList.objectName()).toEqual('org.apache.camel:context=SampleContext,type=context,name="SampleCamel"')
   })
 
   test('getPaths', () => {
-    const node1 = new MBeanNode(null, 'java.lang', 'java.lang', false)
+    const node1 = new MBeanNode(null, 'java.lang', false)
     const propList1 = new PropertyList(node1, 'name=Metaspace,type=MemoryPool')
     expect(propList1.getPaths()).toEqual(['MemoryPool', 'Metaspace'])
 
-    const node2 = new MBeanNode(null, 'org.apache.camel', 'org.apache.camel', false)
+    const node2 = new MBeanNode(null, 'org.apache.camel', false)
     const propList2 = new PropertyList(node2, 'context=SampleContext,type=context,name="SampleCamel"')
     expect(propList2.getPaths()).toEqual(['SampleContext', 'context', 'SampleCamel'])
   })
 
   test('getPaths for special domains', () => {
     // osgi.compendium
-    const osgiCompendiumNode = new MBeanNode(null, 'osgi.compendium', 'osgi.compendium', false)
+    const osgiCompendiumNode = new MBeanNode(null, 'osgi.compendium', false)
     const osgiCompendiumPropList = new PropertyList(
       osgiCompendiumNode,
       'name=Name1,framework=Framework1,service=Service1,version=Version1',
@@ -277,7 +277,7 @@ describe('PropertyList', () => {
     expect(osgiCompendiumPropList.getPaths()).toEqual(['Service1', 'Version1', 'Framework1', 'Name1'])
 
     // osgi.core
-    const osgiCoreNode = new MBeanNode(null, 'osgi.core', 'osgi.core', false)
+    const osgiCoreNode = new MBeanNode(null, 'osgi.core', false)
     const osgiCorePropList = new PropertyList(
       osgiCoreNode,
       'name=Name1,framework=Framework1,type=Type1,version=Version1',

--- a/packages/hawtio/src/plugins/shared/tree/node.ts
+++ b/packages/hawtio/src/plugins/shared/tree/node.ts
@@ -29,13 +29,9 @@ export interface OptimisedJmxMBean extends IJmxMBean {
   opByString?: { [name: string]: unknown }
 }
 
-export interface FilterFunc {
-  (node: MBeanNode): boolean
-}
+export type FilterFn = (node: MBeanNode) => boolean
 
-export interface ForEachFunc {
-  (node: MBeanNode): void
-}
+export type ForEachFn = (node: MBeanNode) => void
 
 export class MBeanNode implements TreeViewDataItem {
   id: string
@@ -254,7 +250,7 @@ export class MBeanNode implements TreeViewDataItem {
    * where the namePath drills down to descendants from
    * this node
    */
-  forEach(namePath: string[], eachFn: ForEachFunc) {
+  forEach(namePath: string[], eachFn: ForEachFn) {
     if (namePath.length === 0) return // path empty so nothing to do
 
     const child: MBeanNode | null = this.getDescendentOrThis(namePath[0])
@@ -264,7 +260,7 @@ export class MBeanNode implements TreeViewDataItem {
     child.forEach(namePath.slice(1), eachFn)
   }
 
-  findDescendant(filter: FilterFunc): MBeanNode | null {
+  findDescendant(filter: FilterFn): MBeanNode | null {
     if (filter(this)) {
       return this
     }
@@ -303,7 +299,7 @@ export class MBeanNode implements TreeViewDataItem {
    * @for Node
    * @return {MBeanNode}
    */
-  findAncestor(filter: FilterFunc): MBeanNode | null {
+  findAncestor(filter: FilterFn): MBeanNode | null {
     let ancestor: MBeanNode | null = this.parent
     while (ancestor !== null) {
       if (filter(ancestor)) return ancestor
@@ -314,7 +310,7 @@ export class MBeanNode implements TreeViewDataItem {
     return null
   }
 
-  filterClone(filter: FilterFunc): MBeanNode | null {
+  filterClone(filter: FilterFn): MBeanNode | null {
     const copyChildren: MBeanNode[] = []
     if (this.children) {
       this.children.forEach(child => {

--- a/packages/hawtio/src/plugins/shared/tree/tree.test.ts
+++ b/packages/hawtio/src/plugins/shared/tree/tree.test.ts
@@ -20,12 +20,12 @@ describe('MBeanTree', () => {
   })
 
   test('flatten tree', async () => {
-    const child1 = createNode('child1', 'child1', 'test:type=folder1,name=child1')
-    const child2 = createNode('child2', 'child2', 'test:type=folder1,name=child2')
-    const child3 = createNode('child3', 'child3', 'test:type=folder1,name=child3')
-    const folder1 = createFolder('folder1', 'folder1', [child1, child2, child3])
-    const node1 = createNode('node1', 'node1', 'test:name=node1')
-    const node2 = createNode('node2', 'node2', 'test:name=node2')
+    const child1 = createNode('child1', 'test:type=folder1,name=child1')
+    const child2 = createNode('child2', 'test:type=folder1,name=child2')
+    const child3 = createNode('child3', 'test:type=folder1,name=child3')
+    const folder1 = createFolder('folder1', [child1, child2, child3])
+    const node1 = createNode('node1', 'test:name=node1')
+    const node2 = createNode('node2', 'test:name=node2')
     const tree = MBeanTree.createFromNodes('test', [folder1, node1, node2])
 
     expect(tree.flatten()).toEqual({
@@ -41,12 +41,12 @@ describe('MBeanTree', () => {
     let path = ['org.apache.camel', 'SampleCamel', 'components', 'quartz']
     let qNode = wkspTree.navigate(...path) as MBeanNode
     expect(qNode).not.toBeNull()
-    expect(qNode.id).toBe('quartz-1')
+    expect(qNode.id).toBe('org.apache.camel-SampleCamel-components-quartz')
 
     path = ['org.apache.camel', 'SampleCame*', 'c*ponents', '*artz']
     qNode = wkspTree.navigate(...path) as MBeanNode
     expect(qNode).not.toBeNull()
-    expect(qNode.id).toBe('quartz-1')
+    expect(qNode.id).toBe('org.apache.camel-SampleCamel-components-quartz')
   })
 
   test('forEach', async () => {
@@ -62,14 +62,14 @@ describe('MBeanTree', () => {
   })
 })
 
-function createNode(id: string, name: string, objectName: string): MBeanNode {
-  const node = new MBeanNode(null, id, name, false)
+function createNode(name: string, objectName: string): MBeanNode {
+  const node = new MBeanNode(null, name, false)
   node.objectName = objectName
   return node
 }
 
-function createFolder(id: string, name: string, children: MBeanNode[]): MBeanNode {
-  const folder = new MBeanNode(null, id, name, true)
+function createFolder(name: string, children: MBeanNode[]): MBeanNode {
+  const folder = new MBeanNode(null, name, true)
   folder.children = children
   return folder
 }

--- a/packages/hawtio/src/plugins/shared/tree/tree.ts
+++ b/packages/hawtio/src/plugins/shared/tree/tree.ts
@@ -1,7 +1,7 @@
-import { escapeDots, escapeTags } from '@hawtiosrc/util/jolokia'
+import { escapeTags } from '@hawtiosrc/util/jolokia'
 import { stringSorter } from '@hawtiosrc/util/strings'
-import { MBeanNode, OptimisedJmxDomain, OptimisedJmxDomains, FilterFn, ForEachFn } from './node'
 import { log } from '../globals'
+import { FilterFn, ForEachFn, MBeanNode, OptimisedJmxDomain, OptimisedJmxDomains } from './node'
 import { treeProcessorRegistry } from './processor-registry'
 
 /**
@@ -89,8 +89,7 @@ export class MBeanTree {
       return node
     }
 
-    const id = escapeDots(name)
-    const newNode = new MBeanNode(null, id, name, true)
+    const newNode = new MBeanNode(null, name, true)
     this.tree.push(newNode)
     return newNode
   }

--- a/packages/hawtio/src/plugins/shared/tree/tree.ts
+++ b/packages/hawtio/src/plugins/shared/tree/tree.ts
@@ -1,9 +1,13 @@
 import { escapeDots, escapeTags } from '@hawtiosrc/util/jolokia'
 import { stringSorter } from '@hawtiosrc/util/strings'
-import { MBeanNode, OptimisedJmxDomain, OptimisedJmxDomains, FilterFunc, ForEachFunc } from './node'
+import { MBeanNode, OptimisedJmxDomain, OptimisedJmxDomains, FilterFn, ForEachFn } from './node'
 import { log } from '../globals'
 import { treeProcessorRegistry } from './processor-registry'
 
+/**
+ * The object representation of MBean tree.
+ * Internally, it is constructed of MBeanNode[].
+ */
 export class MBeanTree {
   private tree: MBeanNode[] = []
 
@@ -23,7 +27,7 @@ export class MBeanTree {
     return mBeanTree
   }
 
-  static filter(originalTree: MBeanNode[], filter: FilterFunc): MBeanNode[] {
+  static filter(originalTree: MBeanNode[], filter: FilterFn): MBeanNode[] {
     //Filter behaviour is the following:
     // 1) If there is a hit in a parent bean, bring everything under the parent
     // 2) If there is no hit in the parent, but there is in a sub bean
@@ -115,7 +119,7 @@ export class MBeanTree {
   /**
    * Searches this folder and all its descendants for the first folder to match the filter
    */
-  findDescendant(filter: FilterFunc): MBeanNode | null {
+  findDescendant(filter: FilterFn): MBeanNode | null {
     let answer: MBeanNode | null = null
     this.tree.forEach(child => {
       if (!answer) {
@@ -142,7 +146,7 @@ export class MBeanTree {
    * Perform a function on each node in the given path
    * where the namePath drills down to descendants of this tree
    */
-  forEach(namePath: string[], eachFn: ForEachFunc) {
+  forEach(namePath: string[], eachFn: ForEachFn) {
     if (namePath.length === 0) return // path empty so nothing to do
 
     const child: MBeanNode | null = this.descendentByPathEntry(namePath[0])

--- a/packages/hawtio/src/plugins/shared/workspace.test.ts
+++ b/packages/hawtio/src/plugins/shared/workspace.test.ts
@@ -30,7 +30,7 @@ describe('workspace', () => {
       workspace.treeContainsDomainAndProperties('quartz', { id: 'quartz', name: 'quartz' }),
     ).resolves.toBeTruthy()
     await expect(
-      workspace.treeContainsDomainAndProperties('quartz', { id: 'QuartzScheduler', name: 'QuartzScheduler' }),
+      workspace.treeContainsDomainAndProperties('quartz', { id: 'quartz-QuartzScheduler', name: 'QuartzScheduler' }),
     ).resolves.toBeTruthy()
     await expect(
       workspace.treeContainsDomainAndProperties('quartz', { id: 'SomeRandomChild', name: 'NoThisChildIsNotHere' }),

--- a/packages/hawtio/src/util/jolokia.test.ts
+++ b/packages/hawtio/src/util/jolokia.test.ts
@@ -1,4 +1,4 @@
-import { escapeDots, escapeTags, operationToString } from './jolokia'
+import { escapeHtmlId, escapeTags, operationToString } from './jolokia'
 
 describe('jolokia', () => {
   test('escapeTags', () => {
@@ -7,8 +7,9 @@ describe('jolokia', () => {
     expect(escapeTags('"SampleContext"')).toEqual('"SampleContext"')
   })
 
-  test('escapeDots', () => {
-    expect(escapeDots('java.lang')).toEqual('java-lang')
+  test('escapeHtmlId', () => {
+    expect(escapeHtmlId('java.lang')).toEqual('java.lang')
+    expect(escapeHtmlId('Camel Contexts')).toEqual('CamelContexts')
   })
 
   test('operationToString', () => {

--- a/packages/hawtio/src/util/jolokia.test.ts
+++ b/packages/hawtio/src/util/jolokia.test.ts
@@ -1,6 +1,12 @@
-import { escapeDots, operationToString } from './jolokia'
+import { escapeDots, escapeTags, operationToString } from './jolokia'
 
 describe('jolokia', () => {
+  test('escapeTags', () => {
+    expect(escapeTags('domain-name')).toEqual('domain-name')
+    expect(escapeTags('<domain-name>')).toEqual('&lt;domain-name&gt;')
+    expect(escapeTags('"SampleContext"')).toEqual('"SampleContext"')
+  })
+
   test('escapeDots', () => {
     expect(escapeDots('java.lang')).toEqual('java-lang')
   })

--- a/packages/hawtio/src/util/jolokia.ts
+++ b/packages/hawtio/src/util/jolokia.ts
@@ -146,9 +146,7 @@ function applyJolokiaEscapeRules(mbean: string): string {
  * @param text string to be escaped
  */
 export function escapeTags(text: string): string {
-  let escaped = text.replace('<', '&lt;')
-  escaped = escaped.replace('>', '&gt;')
-  return escaped
+  return text.replace('<', '&lt;').replace('>', '&gt;')
 }
 
 /**

--- a/packages/hawtio/src/util/jolokia.ts
+++ b/packages/hawtio/src/util/jolokia.ts
@@ -150,12 +150,15 @@ export function escapeTags(text: string): string {
 }
 
 /**
- * Escapes dots ('.') to '-'.
+ * Escapes characters that cannot be used as HTML `id` attribute.
+ * https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id
+ *
+ * Space characters are escaped to ''.
  *
  * @param text string to be escaped
  */
-export function escapeDots(text: string): string {
-  return text.replace(/\./g, '-')
+export function escapeHtmlId(text: string): string {
+  return text.replace(/\s/g, '')
 }
 
 export function operationToString(operation: string, args: IJmxOperationArgument[]): string {


### PR DESCRIPTION
Address hawtio/hawtio#2826

Now we hide HTML `id` generation behind `MBeanNode` constructor and have it autogenerated based on its name and parent, since the `id` is not some logical identifier for a node, but the HTML `id` that is rendered in HTML. We don't need to care about assigning `id` when creating a node. But their consistency is required for e2e testing downstream at the hawtio standalone project.