### PR TITLE
feat: Add Send message page for the endpoint

### DIFF
--- a/app/craco.config.js
+++ b/app/craco.config.js
@@ -35,7 +35,7 @@ module.exports = {
           },
         }),
         new MonacoWebpackPlugin({
-          languages: ['xml'],
+          languages: ['xml', 'json', 'html', 'plaintext'],
           globalAPI: true,
         }),
       ],

--- a/packages/hawtio/package.json
+++ b/packages/hawtio/package.json
@@ -61,7 +61,8 @@
     "react-split": "^2.0.14",
     "reactflow": "^11.7.2",
     "superstruct": "^1.0.3",
-    "typescript": "^4.9.5"
+    "typescript": "^4.9.5",
+    "xml-formatter": "^3.4.1"
   },
   "devDependencies": {
     "@simbathesailor/use-what-changed": "^2.0.0",

--- a/packages/hawtio/src/plugins/camel/CamelContent.tsx
+++ b/packages/hawtio/src/plugins/camel/CamelContent.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import {
   EmptyState,
   EmptyStateIcon,
@@ -15,10 +14,11 @@ import {
 } from '@patternfly/react-core'
 import './CamelContent.css'
 import { CubesIcon } from '@patternfly/react-icons'
+import React from 'react'
 import { NavLink, Navigate, Route, Routes, useLocation } from 'react-router-dom'
 import { Attributes, Operations, Chart, JmxContentMBeans, MBeanNode } from '@hawtiosrc/plugins/shared'
 import { RouteDiagramContext, useRouteDiagramContext } from './route-diagram/route-diagram-context'
-import { RouteDiagram } from '@hawtiosrc/plugins/camel/route-diagram/RouteDiagram'
+import { RouteDiagram } from './route-diagram/RouteDiagram'
 import { Contexts } from './contexts'
 import { Endpoints } from './endpoints'
 import { Exchanges } from './exchanges'
@@ -26,8 +26,9 @@ import { TypeConverters } from './type-converters'
 import { Debug } from './debug'
 import { Trace } from './trace'
 import * as ccs from './camel-content-service'
-import { CamelRoutes } from '@hawtiosrc/plugins/camel/routes/CamelRoutes'
-import { Source } from '@hawtiosrc/plugins/camel/routes/Source'
+import { CamelRoutes } from './routes/CamelRoutes'
+import { Source } from './routes/Source'
+import { SendMessage } from './endpoints/SendMessage'
 
 export const CamelContent: React.FunctionComponent = () => {
   const ctx = useRouteDiagramContext()
@@ -101,6 +102,12 @@ export const CamelContent: React.FunctionComponent = () => {
         !ccs.isEndpointNode(node) &&
         !ccs.isEndpointsFolder(node) &&
         (ccs.isRouteNode(node) || ccs.isRoutesFolder(node)),
+    },
+    {
+      id: 'send',
+      title: 'Send',
+      component: <SendMessage />,
+      isApplicable: (node: MBeanNode) => ccs.isEndpointNode(node),
     },
     {
       id: 'exchanges',

--- a/packages/hawtio/src/plugins/camel/endpoints/SendMessage.tsx
+++ b/packages/hawtio/src/plugins/camel/endpoints/SendMessage.tsx
@@ -1,0 +1,215 @@
+import React, { FormEvent, useContext, useRef, useState } from 'react'
+import * as monacoEditor from 'monaco-editor'
+import { CamelContext } from '../context'
+import xmlFormat from 'xml-formatter'
+
+import {
+  Button,
+  Flex,
+  FlexItem,
+  Form,
+  FormGroup,
+  PageSection,
+  Select,
+  SelectOption,
+  SelectVariant,
+  TextInput,
+  Title,
+} from '@patternfly/react-core'
+import { TrashIcon } from '@patternfly/react-icons'
+import { CodeEditor, Language } from '@patternfly/react-code-editor'
+import { doSendMessage } from '@hawtiosrc/plugins/camel/endpoints/endpoints-service'
+import { eventService, NotificationType } from '@hawtiosrc/core'
+import { SelectOptionObject } from '@patternfly/react-core/src/components/Select/SelectOption'
+
+type SendBodyMessageProps = {
+  onBodyChange: (body: string) => void
+}
+const MessageBody: React.FunctionComponent<SendBodyMessageProps> = props => {
+  const [messageBody, setMessageBody] = useState<string>('')
+  const [selectedFormat, setSelectedFormat] = useState<Language>(Language.xml)
+  const [isDropdownOpen, setDropdownOpen] = useState(false)
+  const editorRef = useRef<monacoEditor.editor.IStandaloneCodeEditor | null>(null)
+
+  const editorDidMount = (editor: monacoEditor.editor.IStandaloneCodeEditor) => {
+    editorRef.current = editor
+  }
+
+  const handleAutoFormat = () => {
+    if (editorRef.current) {
+      const model = editorRef.current.getModel()
+      if (model) {
+        if (selectedFormat === Language.xml) {
+          //monaco doesn't have built in xml formatter
+          updateMessageBody(xmlFormat(messageBody))
+        } else {
+          const range = model.getFullModelRange()
+          editorRef.current.trigger('', 'editor.action.formatDocument', { range })
+        }
+      }
+    }
+  }
+
+  const updateMessageBody = (body: string) => {
+    setMessageBody(body)
+    props.onBodyChange(body)
+  }
+  const handleToggle = () => {
+    setDropdownOpen(!isDropdownOpen)
+  }
+  const handleFormatChange = (event: React.MouseEvent | React.ChangeEvent, value: string | SelectOptionObject) => {
+    setSelectedFormat(value as Language)
+    setDropdownOpen(false)
+  }
+
+  return (
+    <>
+      <FormGroup label='Message'>
+        <CodeEditor
+          code={messageBody}
+          onEditorDidMount={editorDidMount}
+          language={selectedFormat}
+          height={'300px'}
+          onChange={updateMessageBody}
+        />
+      </FormGroup>
+      <FormGroup>
+        <Flex>
+          <FlexItem flex={{ default: 'flexNone', md: 'flex_2' }}>
+            {' '}
+            <Select
+              variant={SelectVariant.single}
+              aria-label='Select Format'
+              onToggle={handleToggle}
+              onSelect={handleFormatChange}
+              selections={selectedFormat}
+              isOpen={isDropdownOpen}
+            >
+              <SelectOption label='xml' value={Language.xml} />
+              <SelectOption label='json' value={Language.json} />
+              <SelectOption label='plaintext' value={Language.plaintext} />
+            </Select>
+          </FlexItem>{' '}
+          <FlexItem flex={{ default: 'flexNone', md: 'flex_1' }}>
+            <Button onClick={handleAutoFormat}>Format</Button>
+          </FlexItem>
+        </Flex>
+      </FormGroup>
+    </>
+  )
+}
+
+type MessageHeadersProps = {
+  onHeadersChange: (headers: { name: string; value: string }[]) => void
+}
+const MessageHeaders: React.FunctionComponent<MessageHeadersProps> = props => {
+  const [headers, setHeaders] = useState<Array<{ name: string; value: string }>>([])
+
+  const handleInputChange = (index: number, newValue: string, event: React.FormEvent<HTMLInputElement>) => {
+    const updatedHeaders = [...headers]
+    updatedHeaders[index] = { ...updatedHeaders[index], [event.currentTarget.name]: newValue }
+    setHeaders(updatedHeaders)
+    props.onHeadersChange(updatedHeaders)
+  }
+  const handleAddHeader = () => {
+    const updatedHeaders = [...headers, { name: '', value: '' }]
+    setHeaders(updatedHeaders)
+    props.onHeadersChange(updatedHeaders)
+  }
+
+  const handleRemoveHeader = (index: number) => {
+    const updatedHeaders = [...headers]
+    updatedHeaders.splice(index, 1)
+    setHeaders(updatedHeaders)
+    props.onHeadersChange(updatedHeaders)
+  }
+
+  return (
+    <>
+      <FormGroup>
+        {/* eslint-disable-next-line react/jsx-no-undef */}
+        <Button variant='link' onClick={handleAddHeader}>
+          Add Headers
+        </Button>
+      </FormGroup>
+      <FormGroup>
+        {headers.length > 0 && (
+          <Flex>
+            <FlexItem flex={{ default: 'flexNone', md: 'flex_2' }}>Name</FlexItem>
+            <FlexItem flex={{ default: 'flexNone', md: 'flex_2' }}>Value</FlexItem>
+            <FlexItem flex={{ default: 'flexNone', md: 'flex_1' }}></FlexItem>
+          </Flex>
+        )}
+
+        {headers.length > 0 &&
+          headers.map((header, index) => (
+            <Flex key={index}>
+              <FlexItem flex={{ default: 'flexNone', md: 'flex_2' }}>
+                <TextInput
+                  type='text'
+                  aria-label={'name-input-' + index}
+                  name='name'
+                  value={header.name}
+                  onChange={(newValue, event) => handleInputChange(index, newValue, event)}
+                />
+              </FlexItem>
+              <FlexItem flex={{ default: 'flexNone', md: 'flex_2' }}>
+                <TextInput
+                  type='text'
+                  name='value'
+                  aria-label={'value-input-' + index}
+                  value={header.value}
+                  onChange={(newValue, event) => handleInputChange(index, newValue, event)}
+                />
+              </FlexItem>
+              <FlexItem flex={{ default: 'flexNone', md: 'flex_1' }} span={4}>
+                <Button variant='link' onClick={() => handleRemoveHeader(index)} aria-label='Remove Header'>
+                  <TrashIcon />
+                </Button>
+              </FlexItem>
+            </Flex>
+          ))}
+      </FormGroup>
+    </>
+  )
+}
+
+export const SendMessage: React.FunctionComponent = () => {
+  const { selectedNode } = useContext(CamelContext)
+  const messageHeaders = useRef<Array<{ name: string; value: string }>>([])
+  const messageBody = useRef<string>('')
+
+  const updateHeaders = (headers: { name: string; value: string }[]) => {
+    messageHeaders.current = [...headers]
+  }
+  const updateTheMessageBody = (body: string) => {
+    messageBody.current = body
+  }
+  const createNotification = (type: NotificationType, message: string) => {
+    eventService.notify({
+      type: type,
+      message: message,
+    })
+  }
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault()
+    if (selectedNode) {
+      doSendMessage(selectedNode, messageBody.current, messageHeaders.current, createNotification)
+    }
+  }
+
+  return (
+    <PageSection variant='light'>
+      <Title headingLevel='h1'>Send Message</Title>
+      <Form onSubmit={handleSubmit}>
+        <MessageHeaders onHeadersChange={updateHeaders} />
+        <MessageBody onBodyChange={updateTheMessageBody} />
+        <FormGroup>
+          <Button type='submit' className='pf-m-1-col'>
+            Send
+          </Button>
+        </FormGroup>
+      </Form>
+    </PageSection>
+  )
+}

--- a/packages/hawtio/src/plugins/camel/tree-processor.ts
+++ b/packages/hawtio/src/plugins/camel/tree-processor.ts
@@ -24,6 +24,9 @@ function adoptChild(parent: MBeanNode | null, child: MBeanNode | null, type: str
 
   parent.adopt(child)
   child.setIcons(childIcon)
+  if (ccs.isContext(parent)) {
+    child.addProperty(contextNodeType, parent.objectName ?? '')
+  }
   ccs.setType(child, type)
   ccs.setDomain(child)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2035,6 +2035,7 @@ __metadata:
     ts-jest: ^29.1.0
     tsup: ^6.7.0
     typescript: ^4.9.5
+    xml-formatter: ^3.4.1
   peerDependencies:
     "@patternfly/react-core": ^4.276.8
     react: ^16.8 || ^17 || ^18
@@ -17212,6 +17213,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"xml-formatter@npm:^3.4.1":
+  version: 3.4.1
+  resolution: "xml-formatter@npm:3.4.1"
+  dependencies:
+    xml-parser-xo: ^4.1.0
+  checksum: ca0bdee58eeb62d4749bb4ad49bf18e678bd3e1ddb6ae076ae145e5f423f1d98285111bf062afac374f10c360f6543ab28ee14657d152933a74a792074cc3747
+  languageName: node
+  linkType: hard
+
 "xml-name-validator@npm:^3.0.0":
   version: 3.0.0
   resolution: "xml-name-validator@npm:3.0.0"
@@ -17223,6 +17233,13 @@ __metadata:
   version: 4.0.0
   resolution: "xml-name-validator@npm:4.0.0"
   checksum: af100b79c29804f05fa35aa3683e29a321db9b9685d5e5febda3fa1e40f13f85abc40f45a6b2bf7bee33f68a1dc5e8eaef4cec100a304a9db565e6061d4cb5ad
+  languageName: node
+  linkType: hard
+
+"xml-parser-xo@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "xml-parser-xo@npm:4.1.0"
+  checksum: a216e7d522a5f15a560cd5c929004c7b5d99c7fc958dc8ceeb259c077e918657ae210d84eebeffce175d1202fe5ecb072243080b9015874ba837ee0642ab2aae
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
close #181 
<img width="1092" alt="Screenshot 2023-05-18 at 16 26 29" src="https://github.com/hawtio/hawtio-next/assets/6814482/0a6d84a1-7bdb-4acd-a676-6e15b6c0e874">
 Added new Send message page:
 - monaco editor with XML and JSON syntax, 
 - added formatting the message 
 - added context property for mbeans to easily retrieve the context 