### PR TITLE
fix(#238): Remove camel domain node from display

### DIFF
--- a/packages/hawtio/src/plugins/camel/CamelContent.css
+++ b/packages/hawtio/src/plugins/camel/CamelContent.css
@@ -1,3 +1,9 @@
 .camel-main > article {
   overflow: auto;
 }
+
+#camel-content-header > #toolbar-items {
+  float: right;
+  padding-top: 0;
+  padding-bottom: 0.5em;
+}

--- a/packages/hawtio/src/plugins/camel/CamelTreeView.test.tsx
+++ b/packages/hawtio/src/plugins/camel/CamelTreeView.test.tsx
@@ -48,16 +48,18 @@ describe('CamelTreeView', () => {
     const wkspTree = await workspace.getTree()
     camelTreeProcessor(wkspTree)
     const rootNode = wkspTree.findDescendant(node => node.name === jmxDomain)
-    if (rootNode) tree = MBeanTree.createFromNodes(pluginName, [rootNode])
+
+    if (rootNode) {
+      const ctxNode = rootNode.getChildren()[0]
+      tree = MBeanTree.createFromNodes(pluginName, ctxNode.getChildren())
+    }
   })
 
   test('Tree Display', async () => {
     expect(tree).not.toBeUndefined()
 
     const domainNode: MBeanNode = tree.get(jmxDomain) as MBeanNode
-    expect(domainNode).not.toBeNull()
-    const contextsNode: MBeanNode = domainNode.getIndex(0) as MBeanNode
-    expect(contextsNode).not.toBeNull()
+    expect(domainNode).toBeNull()
 
     render(
       <CamelContext.Provider value={{ tree, selectedNode, setSelectedNode }}>
@@ -67,7 +69,9 @@ describe('CamelTreeView', () => {
 
     const domainItem = screen.queryByLabelText(jmxDomain)
     expect(domainItem).toBeNull()
-    const contextItem = screen.queryByLabelText(camelContexts)
-    expect(contextItem).not.toBeNull()
+    const contextsItem = screen.queryByLabelText(camelContexts)
+    expect(contextsItem).toBeNull()
+    const ctxItem = screen.queryByLabelText('SampleCamel')
+    expect(ctxItem).not.toBeNull()
   })
 })

--- a/packages/hawtio/src/plugins/camel/CamelTreeView.tsx
+++ b/packages/hawtio/src/plugins/camel/CamelTreeView.tsx
@@ -1,10 +1,9 @@
 import { MBeanNode, MBeanTree, PluginTreeViewToolbar } from '@hawtiosrc/plugins/shared'
 import { TreeView, TreeViewDataItem } from '@patternfly/react-core'
-import React, { ChangeEvent, useContext, useEffect, useState, useCallback } from 'react'
+import React, { ChangeEvent, useContext, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import './CamelTreeView.css'
 import { CamelContext } from './context'
-import * as ccs from './camel-content-service'
 import { pluginPath } from './globals'
 
 /**
@@ -32,17 +31,7 @@ export const CamelTreeView: React.FunctionComponent = () => {
   const [expanded, setExpanded] = useState(ExpansionValue.Default)
   const navigate = useNavigate()
 
-  const deriveTree = useCallback((): MBeanNode[] => {
-    const t = tree.getTree()
-    if (t.length === 0) return t
-
-    if (!ccs.isDomainNode(t[0])) return t
-
-    // Exclude the domain node from the tree display
-    return t[0].getChildren()
-  }, [tree])
-
-  const [filteredTree, setFilteredTree] = useState(deriveTree())
+  const [filteredTree, setFilteredTree] = useState(tree.getTree())
 
   /**
    * Listen for changes to the tree that may occur as a result
@@ -50,8 +39,8 @@ export const CamelTreeView: React.FunctionComponent = () => {
    * eg. new endpoint being created
    */
   useEffect(() => {
-    setFilteredTree(deriveTree())
-  }, [deriveTree])
+    setFilteredTree(tree.getTree())
+  }, [tree])
 
   const onSearch = (event: ChangeEvent<HTMLInputElement>) => {
     // Ensure no node from the 'old' filtered is lingering
@@ -60,10 +49,10 @@ export const CamelTreeView: React.FunctionComponent = () => {
 
     const input = event.target.value
     if (input === '') {
-      setFilteredTree(deriveTree())
+      setFilteredTree(tree.getTree())
     } else {
       setFilteredTree(
-        MBeanTree.filter(deriveTree(), (node: MBeanNode) => node.name.toLowerCase().includes(input.toLowerCase())),
+        MBeanTree.filter(tree.getTree(), (node: MBeanNode) => node.name.toLowerCase().includes(input.toLowerCase())),
       )
       setExpanded(ExpansionValue.ExpandAll)
     }

--- a/packages/hawtio/src/plugins/camel/camel-content-service.ts
+++ b/packages/hawtio/src/plugins/camel/camel-content-service.ts
@@ -77,8 +77,8 @@ export function findContext(node: MBeanNode): MBeanNode | null {
   if (!node || !hasDomain(node)) return null
 
   if (isDomainNode(node)) {
-    // The camel domain node
-    return node.getIndex(0)
+    // The camel domain node so traverse to context folder & recurse
+    return findContext(node.getIndex(0) as MBeanNode)
   }
 
   if (isContextsFolder(node)) {

--- a/packages/hawtio/src/plugins/camel/context.ts
+++ b/packages/hawtio/src/plugins/camel/context.ts
@@ -5,6 +5,7 @@ import { workspace, MBeanNode, MBeanTree } from '@hawtiosrc/plugins/shared'
 import { pluginName, pluginPath, jmxDomain } from './globals'
 import { useNavigate } from 'react-router-dom'
 import { eventService, EVENT_REFRESH } from '@hawtiosrc/core'
+import * as ccs from './camel-content-service'
 
 /**
  * Custom React hook for using Camel MBean tree.
@@ -35,10 +36,23 @@ export function useCamelTree() {
       setTree(subTree)
       if (rootNode && rootNode.children && rootNode.children.length > 0) {
         const path: string[] = []
-        if (refSelectedNode.current) {
+        /*
+         * Make the selection the camel selected node if
+         * - It is not null
+         * - It is a camel domain node
+         * - It is not the domain node (not visible)
+         */
+        if (
+          refSelectedNode.current &&
+          ccs.hasDomain(refSelectedNode.current) &&
+          !ccs.isDomainNode(refSelectedNode.current)
+        ) {
           path.push(...refSelectedNode.current.path())
         } else {
-          path.push(...rootNode.getChildren()[0].path())
+          // Find the first context from the rootNode
+          const ctx = ccs.findContext(rootNode)
+          if (ctx) path.push(...ctx.path())
+          else path.push(...rootNode.getChildren()[0].path())
         }
 
         // Expand the nodes to redisplay the path

--- a/packages/hawtio/src/plugins/camel/contexts/ContextToolbar.tsx
+++ b/packages/hawtio/src/plugins/camel/contexts/ContextToolbar.tsx
@@ -1,0 +1,221 @@
+import {
+  Button,
+  Dropdown,
+  DropdownItem,
+  KebabToggle,
+  Modal,
+  ModalVariant,
+  Skeleton,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
+} from '@patternfly/react-core'
+import { AsleepIcon, PlayIcon, Remove2Icon } from '@patternfly/react-icons'
+import React, { useState } from 'react'
+import { contextsService, ContextAttributes } from './contexts-service'
+import { eventService } from '@hawtiosrc/core'
+import { workspace } from '@hawtiosrc/plugins/shared'
+
+type ContextToolbarProps = {
+  contexts: ContextAttributes[]
+  deleteCallback: (contexts: ContextAttributes[]) => void
+}
+
+export const ContextToolbar: React.FunctionComponent<ContextToolbarProps> = (props: ContextToolbarProps) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const [isConfirmDeleteOpen, setIsConfirmDeleteOpen] = useState(false)
+  const [isDeleting, setIsDeleting] = useState<boolean>(false)
+
+  const onDropdownToggle = (isOpen: boolean) => {
+    setIsOpen(isOpen)
+  }
+
+  const isStartEnabled = (): boolean => {
+    if (props.contexts.length === 0) return false
+
+    return props.contexts.some(ctx => {
+      return ctx.state === 'Suspended'
+    })
+  }
+
+  const onStartClicked = () => {
+    props.contexts
+      .filter(ctx => {
+        return ctx.state === 'Suspended'
+      })
+      .forEach(ctx => {
+        contextsService
+          .startContext(ctx)
+          .then(() => {
+            eventService.notify({
+              type: 'success',
+              message: 'Camel context start requested',
+            })
+          })
+          .catch((error: Error) => {
+            eventService.notify({
+              type: 'danger',
+              message: error.message,
+            })
+          })
+      })
+  }
+
+  const isSuspendEnabled = (): boolean => {
+    if (props.contexts.length === 0) return false
+
+    return props.contexts.some(ctx => {
+      return ctx.state === 'Started'
+    })
+  }
+
+  const onSuspendClicked = () => {
+    for (const ctx of props.contexts) {
+      if (ctx.state !== 'Started') continue
+
+      try {
+        contextsService.suspendContext(ctx)
+        eventService.notify({
+          type: 'success',
+          message: 'Camel context suspension requested',
+        })
+      } catch (error) {
+        eventService.notify({
+          type: 'danger',
+          message: error as string,
+        })
+      }
+    }
+  }
+
+  const isDeleteEnabled = (): boolean => {
+    return props.contexts.length > 0
+  }
+
+  const handleConfirmDeleteToggle = () => {
+    setIsConfirmDeleteOpen(!isConfirmDeleteOpen)
+  }
+
+  const onDeleteClicked = () => {
+    setIsOpen(false)
+    handleConfirmDeleteToggle()
+  }
+
+  const onDeleteConfirmClicked = () => {
+    setIsDeleting(true)
+  }
+
+  const deleteContexts = async () => {
+    for (const ctx of props.contexts) {
+      try {
+        await contextsService.stopContext(ctx)
+        eventService.notify({
+          type: 'success',
+          message: 'Camel context deleted.',
+        })
+      } catch (error) {
+        eventService.notify({
+          type: 'danger',
+          message: error as string,
+        })
+      }
+    }
+
+    props.deleteCallback(props.contexts)
+    setIsDeleting(false)
+    workspace.refreshTree()
+  }
+
+  if (isDeleting) {
+    deleteContexts()
+
+    const title = 'Deleting Context' + (props.contexts.length > 1 ? 's' : '') + ' ...'
+    return (
+      <Modal variant={ModalVariant.small} title={title} titleIconVariant='warning' isOpen={isDeleting}>
+        <Skeleton screenreaderText={title} />
+      </Modal>
+    )
+  }
+
+  const toolbarButtons = (
+    <React.Fragment>
+      <ToolbarItem>
+        <Button
+          variant='secondary'
+          isSmall={true}
+          isDisabled={!isStartEnabled()}
+          icon={React.createElement(PlayIcon)}
+          onClick={onStartClicked}
+        >
+          Start
+        </Button>
+      </ToolbarItem>
+      <ToolbarItem>
+        <Button
+          variant='secondary'
+          isSmall={true}
+          isDisabled={!isSuspendEnabled()}
+          icon={React.createElement(AsleepIcon)}
+          onClick={onSuspendClicked}
+        >
+          Suspend
+        </Button>
+      </ToolbarItem>
+    </React.Fragment>
+  )
+
+  const ConfirmDeleteModal = () => (
+    <Modal
+      variant={ModalVariant.small}
+      title='Are you sure?'
+      titleIconVariant='danger'
+      isOpen={isConfirmDeleteOpen}
+      onClose={handleConfirmDeleteToggle}
+      actions={[
+        <Button key='delete' variant='danger' onClick={onDeleteConfirmClicked}>
+          Delete
+        </Button>,
+        <Button key='cancel' variant='link' onClick={handleConfirmDeleteToggle}>
+          Cancel
+        </Button>,
+      ]}
+    >
+      <p>You are about to delete this Camel Context.</p>
+      <p>This operation cannot be undone so please be careful.</p>
+    </Modal>
+  )
+
+  const dropdownItems = [
+    <DropdownItem key='action' componentID='deleteAction'>
+      <Button
+        variant='control'
+        isSmall={true}
+        isDisabled={!isDeleteEnabled()}
+        icon={React.createElement(Remove2Icon)}
+        onClick={onDeleteClicked}
+      >
+        Delete
+      </Button>
+    </DropdownItem>,
+  ]
+
+  return (
+    <React.Fragment>
+      <Toolbar id='toolbar-items'>
+        <ToolbarContent>
+          {toolbarButtons}
+          <ToolbarItem>
+            <Dropdown
+              autoFocus={true}
+              toggle={<KebabToggle id='toggle-kebab' onToggle={onDropdownToggle} />}
+              isOpen={isOpen}
+              dropdownItems={dropdownItems}
+            />
+          </ToolbarItem>
+          <ToolbarItem variant='separator' />
+        </ToolbarContent>
+      </Toolbar>
+      <ConfirmDeleteModal />
+    </React.Fragment>
+  )
+}

--- a/packages/hawtio/src/plugins/camel/contexts/contexts-service.ts
+++ b/packages/hawtio/src/plugins/camel/contexts/contexts-service.ts
@@ -22,6 +22,13 @@ class ContextsService {
     return actx
   }
 
+  async getContext(ctxNode: MBeanNode | null): Promise<ContextAttributes | null> {
+    if (!ctxNode || !ctxNode.objectName) return null
+
+    const attributes = await jolokiaService.readAttributes(ctxNode.objectName)
+    return this.createContextAttibutes(ctxNode.name, ctxNode.objectName, attributes)
+  }
+
   async getContexts(ctxsNode: MBeanNode | null): Promise<ContextAttributes[]> {
     if (!ctxsNode) return []
 

--- a/packages/hawtio/src/plugins/camel/route-diagram/route-diagram-context.ts
+++ b/packages/hawtio/src/plugins/camel/route-diagram/route-diagram-context.ts
@@ -8,7 +8,7 @@ const noOpAction = (nodeData: CamelNodeData) => {
 }
 
 export function useRouteDiagramContext() {
-  const { selectedNode } = useContext(CamelContext)
+  const { selectedNode, setSelectedNode } = useContext(CamelContext)
   const [graphNodeData, setGraphNodeData] = useState<CamelNodeData[]>([])
   const [graphSelection, setGraphSelection] = useState<string>('')
   const [showStatistics, setShowStatistics] = useState<boolean>(true)
@@ -17,6 +17,7 @@ export function useRouteDiagramContext() {
 
   return {
     selectedNode,
+    setSelectedNode,
     graphNodeData,
     setGraphNodeData,
     graphSelection,

--- a/packages/hawtio/src/plugins/camel/tree-processor.ts
+++ b/packages/hawtio/src/plugins/camel/tree-processor.ts
@@ -74,6 +74,7 @@ export const camelTreeProcessor: TreeProcessor = async (tree: MBeanTree) => {
     ccs.setDomain(newCtxNode)
     // Set the camel version as a property on the context
     ccs.setCamelVersion(newCtxNode)
+    newCtxNode.setIcons(getIcon(IconNames.CamelIcon))
 
     const endPointFolderIcon = getIcon(IconNames.EndpointsFolderIcon)
     const endPointIcon = getIcon(IconNames.EndpointsNodeIcon)

--- a/packages/hawtio/src/plugins/camel/tree-processor.ts
+++ b/packages/hawtio/src/plugins/camel/tree-processor.ts
@@ -47,6 +47,7 @@ export const camelTreeProcessor: TreeProcessor = async (tree: MBeanTree) => {
 
   camelDomain.setIcons(getIcon(IconNames.CamelIcon))
   ccs.setType(camelDomain, domainNodeType)
+  ccs.setDomain(camelDomain)
 
   // Detach current children from domain node
   const oldContexts = camelDomain.removeChildren()


### PR DESCRIPTION
* Domain node remains available in the original tree yet it is filtered out of the tree displayed in the Camel Tree View