### PR TITLE
fix(#311) consider operation result type for printing output

### DIFF
--- a/packages/hawtio/src/plugins/shared/operations/OperationForm.css
+++ b/packages/hawtio/src/plugins/shared/operations/OperationForm.css
@@ -1,3 +1,7 @@
 .jmx-operation-error .pf-c-clipboard-copy__expandable-content {
   background-color: #ffe6e6;
 }
+
+.operation-datatype {
+  margin-right: 0.5em;
+}

--- a/packages/hawtio/src/plugins/shared/operations/OperationForm.tsx
+++ b/packages/hawtio/src/plugins/shared/operations/OperationForm.tsx
@@ -64,6 +64,7 @@ export const OperationForm: React.FunctionComponent<OperationFormProps> = props 
     <DataListItemCells
       dataListCells={[
         <DataListCell key={`operation-cell-name-${name}`} isFilled={false}>
+          <code className='operation-datatype'>{operation.getReadableReturnType()}</code>
           <b>{operation.readableName}</b>
         </DataListCell>,
         <DataListCell key={`operation-cell-desc-${name}`} isFilled={false}>
@@ -141,12 +142,31 @@ const OperationFormContents: React.FunctionComponent<OperationFormContentsProps>
     setArgValues(values)
   }
 
+  const processResult = (result: unknown) => {
+    if (operation.returnType === 'void' && (!result || result === 'null')) {
+      return 'Operation successful'
+    }
+    switch (typeof result) {
+      case 'boolean':
+        return result.toString()
+      case 'string': {
+        const trimmed = result.trim()
+        if (trimmed === '') {
+          return 'Empty string'
+        }
+        return trimmed
+      }
+      default:
+        return JSON.stringify(result, null, 2)
+    }
+  }
+
   const execute = async () => {
     setIsExecuting(true)
     try {
       const result = await operationService.execute(objectName, name, argValues)
       setIsFailed(false)
-      setResult(result)
+      setResult(processResult(result))
     } catch (err) {
       setIsFailed(true)
       setResult(String(err))

--- a/packages/hawtio/src/plugins/shared/operations/operation-service.ts
+++ b/packages/hawtio/src/plugins/shared/operations/operation-service.ts
@@ -2,21 +2,9 @@ import { jolokiaService } from '@hawtiosrc/plugins/connect/jolokia-service'
 import { log } from '../globals'
 
 class OperationService {
-  async execute(mbean: string, operation: string, args: unknown[]): Promise<string> {
+  async execute(mbean: string, operation: string, args: unknown[]): Promise<unknown> {
     log.debug('Execute:', mbean, '-', operation, '-', args)
-    const response = await jolokiaService.execute(mbean, operation, args)
-    if (!response || response === 'null') {
-      return 'Operation Succeeded!'
-    }
-    if (typeof response === 'string') {
-      const trimmed = response.trim()
-      if (trimmed === '') {
-        return 'Empty string'
-      }
-      return trimmed
-    }
-    // pretty printing
-    return JSON.stringify(response, null, 2)
+    return jolokiaService.execute(mbean, operation, args)
   }
 }
 

--- a/packages/hawtio/src/plugins/shared/operations/operation.ts
+++ b/packages/hawtio/src/plugins/shared/operations/operation.ts
@@ -27,6 +27,7 @@ function addOperation(operations: Operation[], operationMap: OperationMap, name:
     name,
     op.args.map(arg => new OperationArgument(arg.name, arg.type, arg.desc)),
     op.desc,
+    op.ret,
   )
   operations.push(operation)
   operationMap[operation.name] = operation
@@ -42,7 +43,14 @@ export class Operation {
   readonly readableName: string
   canInvoke: boolean
 
-  constructor(method: string, readonly args: OperationArgument[], readonly description: string) {
+  static IGNORED_PACKAGES = ['java.util', 'java.lang']
+
+  constructor(
+    method: string,
+    readonly args: OperationArgument[],
+    readonly description: string,
+    readonly returnType: string,
+  ) {
     this.name = this.buildName(method)
     this.readableName = this.buildReadableName(method)
     this.canInvoke = true
@@ -54,6 +62,18 @@ export class Operation {
 
   private buildReadableName(method: string): string {
     return method + '(' + this.args.map(arg => arg.readableType).join(', ') + ')'
+  }
+
+  getReadableReturnType(): string {
+    const splitName = this.returnType.split('.')
+    const typeName = splitName.pop()
+    const packageName = splitName.join('.')
+
+    if (typeName && Operation.IGNORED_PACKAGES.includes(packageName)) {
+      return typeName
+    } else {
+      return this.returnType
+    }
   }
 }
 


### PR DESCRIPTION
Closes #311 
Moved the logic for string representation of the result value to the component which has the context about the return type.
Also added return type hint to the operation so users know what they should expect when executing an operation:

![image](https://github.com/hawtio/hawtio-next/assets/46345469/cf6895a2-4b4f-406e-8b85-0ce8020c5fec)
