### PR TITLE
feat(camel-plugin): Add 'Endpoint (in/out)' view into the camel plugin

### DIFF
--- a/packages/hawtio/src/plugins/camel/CamelContent.tsx
+++ b/packages/hawtio/src/plugins/camel/CamelContent.tsx
@@ -38,6 +38,8 @@ import { CamelRoutes } from './routes/CamelRoutes'
 import { Source } from './routes/Source'
 import { Trace } from './trace'
 import { TypeConverters } from './type-converters'
+import { EndpointStats } from './endpoints/EndpointsStats'
+import { canSeeEndpointStats } from './camel-content-service'
 
 export const CamelContent: React.FunctionComponent = () => {
   const ctx = useRouteDiagramContext()
@@ -159,6 +161,12 @@ export const CamelContent: React.FunctionComponent = () => {
       title: 'Browse',
       component: <BrowseMessages />,
       isApplicable: (node: MBeanNode) => ccs.isEndpointNode(node) && ccs.canBrowseMessages(node),
+    },
+    {
+      id: 'endpoint-stats',
+      title: 'Endpoints (in/out)',
+      component: <EndpointStats />,
+      isApplicable: (node: MBeanNode) => canSeeEndpointStats(node),
     },
     {
       id: 'exchanges',

--- a/packages/hawtio/src/plugins/camel/camel-content-service.ts
+++ b/packages/hawtio/src/plugins/camel/camel-content-service.ts
@@ -153,6 +153,25 @@ export function canBrowseMessages(node: MBeanNode): boolean {
   return !!browseMessages
 }
 
+export function canSeeEndpointStats(node: MBeanNode): boolean {
+  const registry = getDefaultRuntimeEndpointRegistry(node)
+  if (!registry) return false
+
+  const canInvoke = workspace.hasInvokeRights(registry, 'endpointStatistics')
+  return (
+    !isEndpointsFolder(node) &&
+    !isEndpointNode(node) &&
+    !isComponentsFolder(node) &&
+    !isComponentNode(node) &&
+    (isContext(node) || isRoutesFolder(node)) &&
+    isCamelVersionEQGT_2_16(node) &&
+    canInvoke
+  )
+}
+
+export function getDefaultRuntimeEndpointRegistry(node: MBeanNode): MBeanNode | null {
+  return findMBean(node, 'services', 'DefaultRuntimeEndpointRegistry')
+}
 export function hasExchange(node: MBeanNode): boolean {
   return (
     node &&

--- a/packages/hawtio/src/plugins/camel/endpoints/EndpointStats.test.tsx
+++ b/packages/hawtio/src/plugins/camel/endpoints/EndpointStats.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import { CamelContext } from '@hawtiosrc/plugins/camel/context'
+import { MBeanNode, MBeanTree } from '@hawtiosrc/plugins'
+import { EndpointStatistics } from '@hawtiosrc/plugins/camel/endpoints/endpoints-service'
+import userEvent from '@testing-library/user-event'
+import { EndpointStats } from '@hawtiosrc/plugins/camel/endpoints/EndpointsStats'
+
+function getMockedStatistics(): EndpointStatistics[] {
+  return [
+    { url: 'urlA', routeId: 'ID0', static: false, dynamic: false, hits: 1, direction: 'in1', index: 0 },
+    { url: 'urlB', routeId: 'ID1', static: false, dynamic: false, hits: 2, direction: 'in2', index: 1 },
+    { url: 'urlC', routeId: 'ID2', static: false, dynamic: false, hits: 3, direction: 'out1', index: 2 },
+    { url: 'urlD', routeId: 'ID3', static: false, dynamic: false, hits: 4, direction: 'out2', index: 3 },
+    { url: 'urlE', routeId: 'ID4', static: false, dynamic: false, hits: 5, direction: 'out3', index: 4 },
+  ]
+}
+
+jest.mock('@hawtiosrc/plugins/camel/endpoints/endpoints-service', () => ({
+  getEndpointStatistics: jest.fn().mockResolvedValue(getMockedStatistics()),
+}))
+describe('EndpointStats.tsx', () => {
+  const renderWithContext = () => {
+    return render(
+      <CamelContext.Provider
+        value={{
+          selectedNode: new MBeanNode(null, 'mock', false),
+          tree: {} as MBeanTree,
+          setSelectedNode: jest.fn(),
+        }}
+      >
+        <EndpointStats />
+      </CamelContext.Provider>,
+    )
+  }
+
+  test('Component renders correctly', async () => {
+    renderWithContext()
+    expect(screen.getByText('Endpoints (in/out)')).toBeInTheDocument()
+  })
+
+  test('Statistics are displayed correctly', async () => {
+    renderWithContext()
+
+    for (const stat of getMockedStatistics()) {
+      await waitFor(() => {
+        expect(screen.getByText(stat.url)).toBeInTheDocument()
+      })
+      expect(screen.getByText(stat.hits)).toBeInTheDocument()
+      expect(screen.getByText(stat.routeId)).toBeInTheDocument()
+      expect(screen.getByText(stat.direction)).toBeInTheDocument()
+    }
+  })
+
+  test('Statistics can be filtered', async () => {
+    renderWithContext()
+    const input = within(screen.getByTestId('filter-input')).getByRole('textbox')
+
+    const statistic = getMockedStatistics()[2]
+    expect(input).toBeInTheDocument()
+    await userEvent.type(input, statistic.url)
+
+    expect(input).toHaveValue(statistic.url)
+    expect(screen.getByText(statistic.url)).toBeInTheDocument()
+    expect(screen.queryByText('urlA')).not.toBeInTheDocument()
+
+    expect(screen.getByText(statistic.hits)).toBeInTheDocument()
+    expect(screen.getByText(statistic.routeId)).toBeInTheDocument()
+
+    // search acording different attribute
+    const dropdown = screen.getByTestId('attribute-select-toggle')
+    await userEvent.click(dropdown)
+    await userEvent.click(screen.getAllByText('Route ID')[0])
+
+    await userEvent.clear(input)
+    await userEvent.type(input, statistic.url)
+    expect(screen.getByText('No results found.')).toBeInTheDocument()
+
+    await userEvent.clear(input)
+    await userEvent.type(input, statistic.routeId)
+    await waitFor(() => {
+      expect(screen.getByText(statistic.url)).toBeInTheDocument()
+    })
+
+    expect(screen.queryByText('urlA')).not.toBeInTheDocument()
+    expect(screen.getByText(statistic.routeId)).toBeInTheDocument()
+  })
+})

--- a/packages/hawtio/src/plugins/camel/endpoints/EndpointsStats.tsx
+++ b/packages/hawtio/src/plugins/camel/endpoints/EndpointsStats.tsx
@@ -1,0 +1,181 @@
+import React, { useContext, useEffect, useState } from 'react'
+import { CamelContext } from '@hawtiosrc/plugins/camel/context'
+import { EndpointStatistics, getEndpointStatistics } from '@hawtiosrc/plugins/camel/endpoints/endpoints-service'
+import {
+  Bullseye,
+  Button,
+  Dropdown,
+  DropdownItem,
+  DropdownToggle,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  FormGroup,
+  PageSection,
+  SearchInput,
+  Title,
+  Toolbar,
+  ToolbarContent,
+  ToolbarFilter,
+  ToolbarGroup,
+} from '@patternfly/react-core'
+import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table'
+import { SearchIcon } from '@patternfly/react-icons'
+
+export const EndpointStats: React.FunctionComponent = () => {
+  const { selectedNode } = useContext(CamelContext)
+  const [stats, setStats] = useState<EndpointStatistics[]>([])
+  const [filteredStats, setFilteredStats] = useState<EndpointStatistics[]>([])
+  const [searchTerm, setSearchTerm] = useState<string>('')
+  const [filters, setFilters] = useState<string[]>([])
+  const [attributeMenuItem, setAttributeMenuItem] = useState('url')
+  const [isDropdownOpen, setIsDropdownOpen] = React.useState(false)
+
+  useEffect(() => {
+    if (selectedNode) {
+      getEndpointStatistics(selectedNode).then(st => {
+        setStats(st)
+        setFilteredStats(st)
+      })
+    }
+  }, [selectedNode])
+
+  const clearFilters = () => {
+    setFilters([])
+    setSearchTerm('')
+    handleSearch('', attributeMenuItem, [])
+  }
+
+  const handleSearch = (value: string, attribute: string, filters: string[]) => {
+    setSearchTerm(value)
+    //filter with findTerm
+    let filtered: EndpointStatistics[] = []
+    if (value === '') {
+      filtered = [...stats]
+    } else {
+      filtered = stats.filter(stat => {
+        return (stat[attribute] as string).toLowerCase().includes(value.toLowerCase())
+      })
+    }
+
+    //filter with the rest of the filters
+    filters.forEach(value => {
+      const attr = value.split(':')[0]
+      const searchTerm = value.split(':')[1]
+      filtered = filtered.filter(stat => (stat[attr] as string).toLowerCase().includes(searchTerm.toLowerCase()))
+    })
+
+    setSearchTerm(value)
+    setFilteredStats([...filtered])
+  }
+
+  const onDeleteFilter = (filter: string) => {
+    const newFilters = filters.filter(f => f !== filter)
+    setFilters(newFilters)
+    handleSearch(searchTerm, attributeMenuItem, newFilters)
+  }
+
+  const addToFilters = () => {
+    setFilters([...filters, `${attributeMenuItem}:${searchTerm}`])
+    setSearchTerm('')
+  }
+  const attributes = [
+    { key: 'url', value: 'URL' },
+    { key: 'routeId', value: 'Route ID' },
+    { key: 'direction', value: 'Direction' },
+  ]
+  const dropdownItems = attributes.map(a => (
+    <DropdownItem
+      onClick={() => {
+        setAttributeMenuItem(a.key)
+        handleSearch(searchTerm, a.key, filters)
+      }}
+      key={a.key}
+    >
+      {a.value}
+    </DropdownItem>
+  ))
+
+  return (
+    <PageSection variant='light'>
+      <Title headingLevel='h1'>Endpoints (in/out)</Title>
+
+      <Toolbar clearAllFilters={clearFilters}>
+        <ToolbarContent>
+          <ToolbarGroup>
+            <Dropdown
+              data-testid='attribute-select'
+              onSelect={() => setIsDropdownOpen(false)}
+              defaultValue='url'
+              toggle={
+                <DropdownToggle data-testid='attribute-select-toggle' id='toggle-basic' onToggle={setIsDropdownOpen}>
+                  {attributes.find(att => att.key === attributeMenuItem)?.value}
+                </DropdownToggle>
+              }
+              isOpen={isDropdownOpen}
+              dropdownItems={dropdownItems}
+            />
+
+            <ToolbarFilter
+              chips={filters}
+              deleteChip={(_e, filter) => onDeleteFilter(filter as string)}
+              deleteChipGroup={clearFilters}
+              categoryName='Filters'
+            >
+              <SearchInput
+                type='text'
+                data-testid='filter-input'
+                id='search-input'
+                placeholder='Search...'
+                value={searchTerm}
+                onChange={(_event, value) => {
+                  handleSearch(value, attributeMenuItem, filters)
+                }}
+                aria-label='Search input'
+              />
+            </ToolbarFilter>
+            <Button onClick={addToFilters}>Add Filter</Button>
+          </ToolbarGroup>
+        </ToolbarContent>
+      </Toolbar>
+
+      {filteredStats.length > 0 ? (
+        <FormGroup>
+          <TableComposable aria-label='Endpoints Table' variant='compact' height='80vh'>
+            <Thead>
+              <Tr>
+                <Th>URL</Th>
+                <Th>Route ID</Th>
+                <Th>Direction</Th>
+                <Th>Static</Th>
+                <Th>Dynamic</Th>
+                <Th>Hits</Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {filteredStats.map((stat: EndpointStatistics, index) => {
+                return (
+                  <Tr key={index}>
+                    <Td style={{ flex: 3 }}>{stat.url}</Td>
+                    <Td style={{ width: '20%' }}>{stat.routeId}</Td>
+                    <Td style={{ flex: 1 }}>{stat.direction}</Td>
+                    <Td style={{ flex: 1 }}>{stat.static + ''}</Td>
+                    <Td style={{ flex: 1 }}>{stat.dynamic + ''}</Td>
+                    <Td style={{ flex: 1 }}>{stat.hits}</Td>
+                  </Tr>
+                )
+              })}
+            </Tbody>
+          </TableComposable>
+        </FormGroup>
+      ) : (
+        <Bullseye>
+          <EmptyState>
+            <EmptyStateIcon icon={SearchIcon} />
+            <EmptyStateBody>No results found.</EmptyStateBody>
+          </EmptyState>
+        </Bullseye>
+      )}
+    </PageSection>
+  )
+}


### PR DESCRIPTION
Add component test to cover rendering EndpointStats component.
closes #282 
<img width="1201" alt="Screenshot 2023-06-14 at 15 18 31" src="https://github.com/hawtio/hawtio-next/assets/6814482/abbc0bcc-f3f4-4198-84ac-3da9df5f4a30">
Filtering:
<img width="879" alt="Screenshot 2023-06-14 at 15 18 48" src="https://github.com/hawtio/hawtio-next/assets/6814482/bde383af-cced-4a86-b07e-e65282f87c12">
