### PR TITLE
fix(#350): Fixes connection errors when running against plain jolokia

### DIFF
--- a/packages/hawtio/src/plugins/connect/jolokia-service.test.ts
+++ b/packages/hawtio/src/plugins/connect/jolokia-service.test.ts
@@ -1,6 +1,82 @@
-import { DEFAULT_MAX_COLLECTION_SIZE, DEFAULT_MAX_DEPTH, jolokiaService } from './jolokia-service'
+import {
+  DEFAULT_MAX_COLLECTION_SIZE,
+  DEFAULT_MAX_DEPTH,
+  JolokiaListMethod,
+  jolokiaService,
+  __testing_jolokia_service__,
+} from './jolokia-service'
+import { IJolokia, IListOptions, IErrorResponse } from 'jolokia.js'
 
-describe('JolokiaService', () => {
+const { JolokiaService, DummyJolokia } = __testing_jolokia_service__
+
+class ListJolokiaTest extends DummyJolokia {
+  private fireSuccess = true
+
+  constructor(fireSuccess: boolean) {
+    super()
+    this.fireSuccess = fireSuccess
+  }
+
+  list(path: string, opts?: IListOptions) {
+    if (!opts) throw new Error('No options set')
+
+    if (this.fireSuccess) {
+      if (!opts.success) throw new Error('No success option set')
+
+      opts.success({
+        desc: '',
+        attr: {},
+        op: {
+          value: { desc: 'exec', args: [], ret: '' },
+        },
+      })
+    } else {
+      if (!opts.error) throw new Error('No error option set')
+
+      const response: IErrorResponse = {
+        status: -1,
+        timestamp: 123456789,
+        request: { type: 'list', path: path },
+        value: null,
+        error_type: 'non-exist',
+        error: 'ERROR HAS OCCURRED',
+        stacktrace: 'not available',
+      }
+
+      opts.error(response)
+    }
+
+    return null
+  }
+}
+
+class JolokiaServiceTest extends JolokiaService {
+  checkListOptimisationTest(jolokia: IJolokia): Promise<void> {
+    return this.checkListOptimisation(jolokia)
+  }
+}
+
+describe('JolokiaService class', () => {
+  test('checkListOptimizationSuccess', async () => {
+    const delegate: ListJolokiaTest = new ListJolokiaTest(true)
+    const service: JolokiaServiceTest = new JolokiaServiceTest()
+
+    console.log(service.getListMethod())
+
+    await expect(service.checkListOptimisationTest(delegate)).resolves.not.toThrow()
+    expect(await service.getListMethod()).toEqual(JolokiaListMethod.OPTIMISED)
+  })
+
+  test('checkListOptimizationError', async () => {
+    const delegate: ListJolokiaTest = new ListJolokiaTest(false)
+    const service: JolokiaServiceTest = new JolokiaServiceTest()
+
+    await expect(service.checkListOptimisationTest(delegate)).resolves.not.toThrow()
+    expect(await service.getListMethod()).toEqual(JolokiaListMethod.DEFAULT)
+  })
+})
+
+describe('jolokiaService singleton', () => {
   beforeEach(() => {
     localStorage.clear()
   })

--- a/packages/hawtio/src/plugins/rbac/tree-processor.ts
+++ b/packages/hawtio/src/plugins/rbac/tree-processor.ts
@@ -29,6 +29,16 @@ import { rbacService } from './rbac-service'
 export const rbacTreeProcessor: TreeProcessor = async (tree: MBeanTree) => {
   log.debug('Processing tree:', tree)
   const aclMBean = await rbacService.getACLMBean()
+
+  if (!aclMBean || aclMBean.length === 0) {
+    /*
+     * Some implementations of jolokia provision, eg. running with java -javaagent
+     * do not provide an acl mbean or implement server-side RBAC so need to skip
+     */
+    log.debug('No acl mbean available. RBAC decoration of JMX tree skipped')
+    return
+  }
+
   const mbeans = tree.flatten()
   const listMethod = await jolokiaService.getListMethod()
   switch (listMethod) {

--- a/packages/hawtio/src/plugins/shared/workspace.ts
+++ b/packages/hawtio/src/plugins/shared/workspace.ts
@@ -36,17 +36,22 @@ class Workspace {
         log.debug('Error fetching JMX tree:', xhr)
       },
     }
-    const value = await jolokiaService.list(options)
+    try {
+      const value = await jolokiaService.list(options)
 
-    const domains = this.unwindResponseWithRBACCache(value)
-    log.debug('JMX tree loaded:', domains)
+      const domains = this.unwindResponseWithRBACCache(value)
+      log.debug('JMX tree loaded:', domains)
 
-    const tree = await MBeanTree.createFromDomains(pluginName, domains)
+      const tree = await MBeanTree.createFromDomains(pluginName, domains)
 
-    this.maybeMonitorPlugins()
-    this.maybeMonitorTree()
+      this.maybeMonitorPlugins()
+      this.maybeMonitorTree()
 
-    return tree
+      return tree
+    } catch (response) {
+      log.error('A request to list the JMX tree failed: ' + response)
+      return MBeanTree.createEmpty(pluginName)
+    }
   }
 
   /**

--- a/packages/hawtio/src/util/jolokia.ts
+++ b/packages/hawtio/src/util/jolokia.ts
@@ -39,8 +39,12 @@ export function onSearchSuccess(successFn: ISearchResponseFn, options: ISearchOp
   return onGenericSuccess(successFn, options)
 }
 
-export function onListSuccess(successFn: IListResponseFn, options: IListOptions = {}): IListOptions {
-  return onGenericSuccess(successFn, options)
+export function onListSuccessAndError(
+  successFn: IListResponseFn,
+  errorFn: IErrorResponseFn,
+  options: IListOptions = {},
+): IListOptions {
+  return onGenericSuccessAndError(successFn, errorFn, options)
 }
 
 export function onVersionSuccess(successFn: IVersionResponseFn, options: IVersionOptions = {}): IVersionOptions {


### PR DESCRIPTION
* jolokia-service
 * Refactor checkListOptimisation function to reject correctly on error
 * In case of plain jolokia javaagent, no hawtio:security mbean exists so function will be exepcted to fail
 * Ensures the error fn is properly implemented & rejects correctly
 * Ensures that implemented list() function also implements error function

* jolokia.ts
 * Adds onListSucccessAndError to support custom error implementations

* tree-processor.ts
 * In the event of no acl mbean, stop the bulk requests failing to identify any RBAC operations