### PR TITLE
feat(#262): Prevent overlay on smaller screens

### DIFF
--- a/packages/hawtio/src/plugins/camel/CamelTreeView.css
+++ b/packages/hawtio/src/plugins/camel/CamelTreeView.css
@@ -18,3 +18,13 @@
   padding-top: 2px;
   font-size: smaller;
 }
+
+#camel-tree-view .pf-c-tree-view__node-icon {
+  flex-shrink: 0;
+}
+
+#camel-tree-view .pf-c-tree-view__node-text {
+  overflow-x: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}

--- a/packages/hawtio/src/plugins/jmx/JmxTreeView.css
+++ b/packages/hawtio/src/plugins/jmx/JmxTreeView.css
@@ -18,3 +18,13 @@
   padding-top: 2px;
   font-size: smaller;
 }
+
+#jmx-tree-view .pf-c-tree-view__node-icon {
+  flex-shrink: 0;
+}
+
+#jmx-tree-view .pf-c-tree-view__node-text {
+  overflow-x: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}


### PR DESCRIPTION
Implements #262 . Implemented in Camel and JMX view

Before
![overflow-1](https://github.com/hawtio/hawtio-next/assets/17336236/bc5a4a1b-8c39-4d05-9756-659e1d460bf6)

After
![overflow-2](https://github.com/hawtio/hawtio-next/assets/17336236/beadd6cb-3497-4152-b31f-d024e2d5d6ab)

Also working in JMX tree
![image](https://github.com/hawtio/hawtio-next/assets/17336236/84871ac1-de37-4986-8d5a-c19a98d96cbc)


Although one side effect is that on very small screens the text is outright hidden,
![image](https://github.com/hawtio/hawtio-next/assets/17336236/84c54a00-5787-4731-b5de-f3c92d760359)

but the alternative is to have it all outside which looks bad. 

![image](https://github.com/hawtio/hawtio-next/assets/17336236/96c83e62-a244-4b36-b524-d52c7cc26709)

I feel like in that case the user should just adjust the slider to increase the space.