### PR TITLE
fix(#268): Removes overflow auto and sets to inherit so selects in card can go over the div boundary

### DIFF
--- a/packages/hawtio/src/plugins/camel/CamelContent.css
+++ b/packages/hawtio/src/plugins/camel/CamelContent.css
@@ -1,5 +1,9 @@
 #camel-content-main > article {
-  overflow: inherit;
+  overflow-y: inherit;
+}
+
+#camel-content-main .pf-c-page__main {
+  overflow-x: auto;
 }
 
 #camel-content-header > #camel-contexts-toolbar {

--- a/packages/hawtio/src/plugins/camel/CamelContent.css
+++ b/packages/hawtio/src/plugins/camel/CamelContent.css
@@ -1,5 +1,5 @@
 #camel-content-main > article {
-  overflow: auto;
+  overflow: inherit;
 }
 
 #camel-content-header > #camel-contexts-toolbar {


### PR DESCRIPTION
Fixes #268 

![image](https://github.com/hawtio/hawtio-next/assets/17336236/b0edc5c9-f8ed-43f9-8940-ca6426d97229)


@phantomjinx Do you know why you hard-set the value to auto on the css? I checked all the camel pages to see if the change breaks something but it'd be great to know if you remember what was it so I can double check.

In any case, using inherit should be extra safe instead of removing the rule altogether