### PR TITLE
fix(proxy): aligns the dev server proxy url with the real backend

### DIFF
--- a/app/craco.config.js
+++ b/app/craco.config.js
@@ -97,6 +97,14 @@ module.exports = {
     },
   },
   devServer: {
+    proxy: {
+      '/hawtio/proxy/**': {
+        target: 'http://localhost:3000',
+        pathRewrite: { '^/hawtio': '' },
+        changeOrigin: true,
+        logLevel: 'debug',
+      },
+    },
     setupMiddlewares: (middlewares, devServer) => {
       // Redirect / or /hawtio to /hawtio/
       devServer.app.get('/', (_, res) => res.redirect('/hawtio/'))

--- a/packages/hawtio/src/plugins/connect/connect-service.ts
+++ b/packages/hawtio/src/plugins/connect/connect-service.ts
@@ -163,12 +163,12 @@ class ConnectService implements IConnectService {
       return connection.jolokiaUrl
     }
 
-    // TODO: Better handling of doc base and proxy URL construction
     const url = joinPaths(
+      hawtio.getBasePath() ?? '',
       '/proxy',
-      connection.scheme || 'http',
-      connection.host || 'localhost',
-      String(connection.port || 80),
+      connection.scheme ?? 'http',
+      connection.host ?? 'localhost',
+      String(connection.port ?? 80),
       connection.path,
     )
     log.debug('Using URL:', url)


### PR DESCRIPTION
* The proxy url in hawtio-backend includes the context in the form: host:port/hawtio/proxy/

* The hawtio-backend-middleware provides an express server that makes the backend available via the '/proxy' url

* Rather than trying to redo the hawtio-backend-middleware, aligns the dev server with the hawtio-backend by setting up a 'proxy' to rewrite 'hawtio/proxy' and point to '/proxy'

* connect-service.ts
 * Adds the base path to the proxy url creation