### PR TITLE
test(#258),fix(#377): Tree ids test and fixes

### DIFF
--- a/packages/hawtio/src/plugins/camel/routes-service.test.ts
+++ b/packages/hawtio/src/plugins/camel/routes-service.test.ts
@@ -91,10 +91,10 @@ describe('routes-service', () => {
     }
 
     const expected: MBeanAttr[] = [
-      { id: 'from', name: 'from' },
-      { id: 'setBody', name: 'setBody' },
-      { id: 'to', name: 'to' },
-      { id: 'to', name: 'to' },
+      { id: 'sample-camel-1-folder-routes-2-folder-simple-folder-from', name: 'from' },
+      { id: 'sample-camel-1-folder-routes-2-folder-simple-folder-setBody', name: 'setBody' },
+      { id: 'sample-camel-1-folder-routes-2-folder-simple-folder-to', name: 'to' },
+      { id: 'sample-camel-1-folder-routes-2-folder-simple-folder-to', name: 'to' },
     ]
 
     for (let i = 0; i < simpleRouteNode.childCount(); ++i) {

--- a/packages/hawtio/src/plugins/shared/tree/node.ts
+++ b/packages/hawtio/src/plugins/shared/tree/node.ts
@@ -73,6 +73,7 @@ export class MBeanNode implements TreeViewDataItem {
       this.icon = Icons.mbean
     }
 
+    if (this.parent) this.parent.id = this.parent.generateId(true)
     this.id = this.generateId(folder)
   }
 

--- a/packages/hawtio/src/plugins/shared/tree/node.ts
+++ b/packages/hawtio/src/plugins/shared/tree/node.ts
@@ -387,6 +387,9 @@ export class MBeanNode implements TreeViewDataItem {
 
     child.parent = this
     this.children.push(child)
+
+    //Refresh ids on adoption
+    this.initId(true)
   }
 
   /**

--- a/packages/hawtio/src/plugins/shared/tree/tree.test.ts
+++ b/packages/hawtio/src/plugins/shared/tree/tree.test.ts
@@ -74,9 +74,8 @@ describe('MBeanTree', () => {
       //Can't access node.idSeparator as is private. And in any case, we should modify this whenever it changes
       const idSeparator = '-'
       const folderDenomination = '-folder'
-      const currentNodeExpectedPartOfId =
-        escapeHtmlId(node.name) +
-        (node.getChildren().length !== 0 && !node.name.includes('XNIO-2') ? folderDenomination : '')
+      const currentNodeExpectedPartOfId = escapeHtmlId(node.name) +
+        (node.getChildren().length !== 0 ? folderDenomination : '')
 
       if (!node.parent) return currentNodeExpectedPartOfId
       return getExpectedIdRecursivelyFromParentNode(node.parent) + idSeparator + currentNodeExpectedPartOfId

--- a/packages/hawtio/src/plugins/shared/tree/tree.test.ts
+++ b/packages/hawtio/src/plugins/shared/tree/tree.test.ts
@@ -74,8 +74,8 @@ describe('MBeanTree', () => {
       //Can't access node.idSeparator as is private. And in any case, we should modify this whenever it changes
       const idSeparator = '-'
       const folderDenomination = '-folder'
-      const currentNodeExpectedPartOfId = escapeHtmlId(node.name) +
-        (node.getChildren().length !== 0 ? folderDenomination : '')
+      const currentNodeExpectedPartOfId =
+        escapeHtmlId(node.name) + (node.getChildren().length !== 0 ? folderDenomination : '')
 
       if (!node.parent) return currentNodeExpectedPartOfId
       return getExpectedIdRecursivelyFromParentNode(node.parent) + idSeparator + currentNodeExpectedPartOfId
@@ -173,16 +173,14 @@ describe('MBeanTree', () => {
   })
 })
 
-function createNode(name: string, objectName: string): MBeanNode {
-  const node = new MBeanNode(null, name, false)
+function createNode(name: string, objectName: string, parent?: MBeanNode): MBeanNode {
+  const node = new MBeanNode(parent ?? null, name, false)
   node.objectName = objectName
-  node.initId(false)
   return node
 }
 
 function createFolder(name: string, children: MBeanNode[]): MBeanNode {
   const folder = new MBeanNode(null, name, true)
   children.forEach(child => folder.adopt(child))
-  folder.initId(true)
   return folder
 }

--- a/packages/hawtio/src/plugins/shared/tree/tree.test.ts
+++ b/packages/hawtio/src/plugins/shared/tree/tree.test.ts
@@ -1,3 +1,4 @@
+import { escapeHtmlId } from '@hawtiosrc/util/jolokia'
 import { workspace } from '../workspace'
 import { MBeanNode } from './node'
 import { treeProcessorRegistry } from './processor-registry'
@@ -60,16 +61,129 @@ describe('MBeanTree', () => {
     wkspTree.forEach(path, _ => (counter = counter + 1))
     expect(counter).toEqual(path.length)
   })
+
+  test('IDs should be concatenation of {parent}[-folder]-({element}[-folder]) on domain tree', async () => {
+    const allNodes: MBeanNode[] = []
+    const recursivelyGetAllNodesOnTree = (tree: MBeanNode[]) => {
+      tree.forEach((node: MBeanNode) => {
+        allNodes.push(node)
+        recursivelyGetAllNodesOnTree(node.getChildren())
+      })
+    }
+    const getExpectedIdRecursivelyFromParentNode = (node: MBeanNode): string => {
+      //Can't access node.idSeparator as is private. And in any case, we should modify this whenever it changes
+      const idSeparator = '-'
+      const folderDenomination = '-folder'
+      const currentNodeExpectedPartOfId =
+        escapeHtmlId(node.name) +
+        (node.getChildren().length !== 0 && !node.name.includes('XNIO-2') ? folderDenomination : '')
+
+      if (!node.parent) return currentNodeExpectedPartOfId
+      return getExpectedIdRecursivelyFromParentNode(node.parent) + idSeparator + currentNodeExpectedPartOfId
+    }
+    recursivelyGetAllNodesOnTree(wkspTree.getTree())
+
+    allNodes.forEach(node => {
+      expect(node.id).toEqual(getExpectedIdRecursivelyFromParentNode(node))
+    })
+  })
+
+  test('IDs should be concatenation of {parent}[-folder]-({element}[-folder]) on mock tree', () => {
+    //The object names are dummys because they are not used for the ids.
+    const treeNodes = [
+      createFolder('mbean1', [
+        createFolder('mbean1-1', [
+          createFolder('mbean1-1-1', [
+            createNode('mbean1-1-1-1', 'objectName1-1-1-1'),
+            createNode('mbean1-1-1-2', 'objectName1-1-1-2'),
+          ]),
+          createNode('mbean1-1-2', 'objectName1-1-2'),
+          createNode('mbean1-1-3', 'objectName1-1-3'),
+        ]),
+        createNode('mbean1-2', 'objectName1-2'),
+        createFolder('mbean1-3', [createNode('mbean1-3-1', 'objectName1-3-1')]),
+      ]),
+      createFolder('mbean2', [createNode('mbean2-1', 'objectName2-1'), createNode('mbean2-2', 'objectName2-2')]),
+      createNode('mbean3', 'objectName3'),
+    ]
+
+    const pathToExpectedIds = [
+      {
+        path: ['mbean1'],
+        expectedId: 'mbean1-folder',
+      },
+      {
+        path: ['mbean1', 'mbean1-1'],
+        expectedId: 'mbean1-folder-mbean1-1-folder',
+      },
+      {
+        path: ['mbean1', 'mbean1-1', 'mbean1-1-1'],
+        expectedId: 'mbean1-folder-mbean1-1-folder-mbean1-1-1-folder',
+      },
+      {
+        path: ['mbean1', 'mbean1-1', 'mbean1-1-1', 'mbean1-1-1-1'],
+        expectedId: 'mbean1-folder-mbean1-1-folder-mbean1-1-1-folder-mbean1-1-1-1',
+      },
+      {
+        path: ['mbean1', 'mbean1-1', 'mbean1-1-1', 'mbean1-1-1-2'],
+        expectedId: 'mbean1-folder-mbean1-1-folder-mbean1-1-1-folder-mbean1-1-1-2',
+      },
+      {
+        path: ['mbean1', 'mbean1-1', 'mbean1-1-2'],
+        expectedId: 'mbean1-folder-mbean1-1-folder-mbean1-1-2',
+      },
+      {
+        path: ['mbean1', 'mbean1-1', 'mbean1-1-3'],
+        expectedId: 'mbean1-folder-mbean1-1-folder-mbean1-1-3',
+      },
+      {
+        path: ['mbean1', 'mbean1-2'],
+        expectedId: 'mbean1-folder-mbean1-2',
+      },
+      {
+        path: ['mbean1', 'mbean1-3'],
+        expectedId: 'mbean1-folder-mbean1-3-folder',
+      },
+      {
+        path: ['mbean1', 'mbean1-3', 'mbean1-3-1'],
+        expectedId: 'mbean1-folder-mbean1-3-folder-mbean1-3-1',
+      },
+      {
+        path: ['mbean2'],
+        expectedId: 'mbean2-folder',
+      },
+      {
+        path: ['mbean2', 'mbean2-1'],
+        expectedId: 'mbean2-folder-mbean2-1',
+      },
+      {
+        path: ['mbean2', 'mbean2-2'],
+        expectedId: 'mbean2-folder-mbean2-2',
+      },
+      {
+        path: ['mbean3'],
+        expectedId: 'mbean3',
+      },
+    ]
+
+    const tree = MBeanTree.createFromNodes('thisIdIsNotUsedForMBeanIds', treeNodes)
+
+    pathToExpectedIds.forEach(({ path, expectedId }) => {
+      expect(tree.navigate(...path)?.id).toEqual(expectedId)
+    })
+  })
 })
 
 function createNode(name: string, objectName: string): MBeanNode {
   const node = new MBeanNode(null, name, false)
   node.objectName = objectName
+  node.initId(false)
   return node
 }
 
 function createFolder(name: string, children: MBeanNode[]): MBeanNode {
   const folder = new MBeanNode(null, name, true)
-  folder.children = children
+  children.forEach(child => folder.adopt(child))
+  folder.initId(true)
   return folder
 }


### PR DESCRIPTION
Tests #258 
Fixes #377 

I saw there were some assertions done by @mmuzikar 3 weeks ago but there was not a fully dedicated tests for the IDs.
On the process I discovered #377 . I created an issue to keep track of it and did two fixes to ensure that the outlier behaviour doesn't repeat. Although I'm not exactly sure if that would still make it exhaustive for all tree constructions, but now that we have a test we can leave it as is and revisit it later if the test starts discovering any issues again.