### PR TITLE
feat(ForwardMessage): Add typeahead suggestions to forward message input

### DIFF
--- a/packages/hawtio/src/plugins/camel/endpoints/BrowseMessages.test.tsx
+++ b/packages/hawtio/src/plugins/camel/endpoints/BrowseMessages.test.tsx
@@ -24,6 +24,7 @@ function getMockedMessages(): MessageData[] {
 
 jest.mock('@hawtiosrc/plugins/camel/endpoints/endpoints-service', () => ({
   getMessagesFromTheEndpoint: jest.fn().mockResolvedValue(getMockedMessages()),
+  getEndpoints: jest.fn().mockResolvedValue([]),
 }))
 describe('BrowseMessages.tsx', () => {
   const renderWithContext = () => {


### PR DESCRIPTION
Added suggestions to forward message text input as in legacy hawtio: 
<img width="473" alt="Screenshot 2023-06-23 at 15 05 18" src="https://github.com/hawtio/hawtio-next/assets/6814482/228aef22-510d-4ab8-849b-34ce1589f332">
<img width="996" alt="Screenshot 2023-06-23 at 15 05 42" src="https://github.com/hawtio/hawtio-next/assets/6814482/a3c68d97-a9ad-4d40-aa7e-c1e572392db2">
