### PR TITLE
Feat: Add  suggestion's for a header name input

### DIFF
--- a/packages/hawtio/src/plugins/camel/endpoints/BrowseMessages.tsx
+++ b/packages/hawtio/src/plugins/camel/endpoints/BrowseMessages.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useRef, useState } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import { CamelContext } from '@hawtiosrc/plugins/camel/context'
 import {
   Bullseye,
@@ -11,16 +11,11 @@ import {
   Flex,
   FlexItem,
   FormGroup,
-  Menu,
-  MenuContent,
-  MenuItem,
-  MenuList,
   Modal,
   ModalVariant,
   PageSection,
   Pagination,
   SearchInput,
-  Text,
   TextInput,
   Title,
   Toolbar,
@@ -40,81 +35,19 @@ import {
 import { eventService, NotificationType } from '@hawtiosrc/core'
 import { Position } from 'reactflow'
 import { MBeanNode } from '@hawtiosrc/plugins'
-
+import { InputWithSuggestions } from './InputWithSuggestions'
 const ForwardMessagesComponent: React.FunctionComponent<{
   onForwardMessages: (uri: string, message?: MessageData) => void
   currentMessage?: MessageData
   endpoints: string[]
 }> = ({ onForwardMessages, currentMessage, endpoints }) => {
   const [uri, setUri] = useState('')
-  const [menuIsOpen, setMenuIsOpen] = React.useState(false)
-  const suggestionsRef = useRef(null)
-
-  const handleOutsideClick = (event: MouseEvent) => {
-    if (suggestionsRef.current && !(suggestionsRef.current as HTMLElement).contains(event.target as Node)) {
-      setMenuIsOpen(false)
-    }
-  }
-
-  useEffect(() => {
-    document.addEventListener('mousedown', handleOutsideClick)
-    return () => {
-      document.removeEventListener('mousedown', handleOutsideClick)
-    }
-  }, [])
-
-  const onSelect = (event: React.MouseEvent<Element, MouseEvent> | undefined, itemId: string | number | undefined) => {
-    const selectedText = (event?.target as HTMLElement).innerText
-    setUri(selectedText)
-    setMenuIsOpen(false)
-    event?.stopPropagation()
-  }
-
-  const suggestionsList = endpoints
-    ?.filter(e => e.includes(uri))
-    .map((e, index) => {
-      const suggestion =
-        uri !== ''
-          ? e
-              .split(new RegExp(`(${uri})`, 'gi'))
-              .map((part, i) =>
-                part.toLowerCase() === uri.toLowerCase() ? <strong key={part + i}>{part}</strong> : part,
-              )
-          : e
-
-      return (
-        <MenuItem key={e} itemId={index}>
-          <Text>{suggestion}</Text>
-        </MenuItem>
-      )
-    })
-
-  const suggestions = (
-    <div ref={suggestionsRef}>
-      <Menu
-        style={{ position: 'absolute', top: '100%', zIndex: '999' }}
-        onSelect={onSelect}
-        onBlur={() => setMenuIsOpen(false)}
-      >
-        <MenuContent>
-          <MenuList data-testid='suggestions-menu-list'>{suggestionsList}</MenuList>
-        </MenuContent>
-      </Menu>
-    </div>
-  )
 
   return (
     <FormGroup label='URI:'>
       <Flex>
-        <FlexItem flex={{ default: 'flexNone', md: 'flex_3' }} style={{ position: 'relative' }}>
-          <TextInput
-            value={uri}
-            onChange={setUri}
-            onFocus={() => setMenuIsOpen(true)}
-            placeholder='uri'
-            aria-label='Search input'
-          />
-          {suggestionsList.length > 0 && menuIsOpen && suggestions}
+        <FlexItem flex={{ default: 'flexNone', md: 'flex_3' }}>
+          <InputWithSuggestions suggestions={endpoints} value={uri} onChange={setUri} />
         </FlexItem>
         <FlexItem flex={{ default: 'flexNone', md: 'flex_1' }}>
           <Button key='confirm' variant='primary' onClick={() => onForwardMessages(uri, currentMessage)}>
@@ -151,6 +84,7 @@ const ForwardMessagesModal: React.FunctionComponent<{
         title={'Forward Messages'}
         isOpen={isModalOpen}
         onClose={handleModalToggle}
+        style={{ overflow: 'visible' }}
       >
         <ForwardMessagesComponent endpoints={endpoints} onForwardMessages={onForwardMessages} />
       </Modal>

--- a/packages/hawtio/src/plugins/camel/endpoints/InputWithSuggestions.tsx
+++ b/packages/hawtio/src/plugins/camel/endpoints/InputWithSuggestions.tsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useRef } from 'react'
+import { Menu, MenuContent, MenuItem, MenuList, Text, TextInput } from '@patternfly/react-core'
+
+export const InputWithSuggestions: React.FunctionComponent<{
+  suggestions: string[]
+  value: string
+  onChange: (value: string) => void
+}> = ({ suggestions, value, onChange }) => {
+  const [menuIsOpen, setMenuIsOpen] = React.useState(false)
+  const suggestionsRef = useRef(null)
+
+  const handleOutsideClick = (event: MouseEvent) => {
+    if (suggestionsRef.current && !(suggestionsRef.current as HTMLElement).contains(event.target as Node)) {
+      setMenuIsOpen(false)
+    }
+  }
+
+  useEffect(() => {
+    document.addEventListener('mousedown', handleOutsideClick)
+    return () => {
+      document.removeEventListener('mousedown', handleOutsideClick)
+    }
+  }, [])
+
+  const onSelect = (event: React.MouseEvent<Element, MouseEvent> | undefined, itemId: string | number | undefined) => {
+    const selectedText = (event?.target as HTMLElement).innerText
+    onChange(selectedText)
+    setMenuIsOpen(false)
+    event?.stopPropagation()
+  }
+
+  const suggestionsList = suggestions
+    ?.filter(e => e.includes(value))
+    .map((e, index) => {
+      const suggestion =
+        value !== ''
+          ? e
+              .split(new RegExp(`(${value})`, 'gi'))
+              .map((part, i) =>
+                part.toLowerCase() === value.toLowerCase() ? <strong key={part + i}>{part}</strong> : part,
+              )
+          : e
+
+      return (
+        <MenuItem key={e} itemId={index}>
+          <Text>{suggestion}</Text>
+        </MenuItem>
+      )
+    })
+
+  const suggestionsElement = (
+    <div ref={suggestionsRef}>
+      <Menu
+        style={{ position: 'absolute', top: '100%', zIndex: '999' }}
+        onSelect={onSelect}
+        onBlur={() => setMenuIsOpen(false)}
+        isScrollable
+      >
+        <MenuContent menuHeight='250px'>
+          <MenuList data-testid='suggestions-menu-list'>{suggestionsList}</MenuList>
+        </MenuContent>
+      </Menu>
+    </div>
+  )
+
+  return (
+    <div style={{ position: 'relative' }}>
+      <TextInput
+        value={value}
+        onChange={onChange}
+        onFocus={() => setMenuIsOpen(true)}
+        placeholder=''
+        aria-label='Search input'
+      />
+      {suggestionsList.length > 0 && menuIsOpen && suggestionsElement}
+    </div>
+  )
+}

--- a/packages/hawtio/src/plugins/camel/endpoints/SendMessage.tsx
+++ b/packages/hawtio/src/plugins/camel/endpoints/SendMessage.tsx
@@ -21,6 +21,8 @@ import { CodeEditor, Language } from '@patternfly/react-code-editor'
 import { doSendMessage } from '@hawtiosrc/plugins/camel/endpoints/endpoints-service'
 import { eventService, NotificationType } from '@hawtiosrc/core'
 import { SelectOptionObject } from '@patternfly/react-core/src/components/Select/SelectOption'
+import { headers as exchangeHeaders } from './exchange-headers-camel-model.json'
+import { InputWithSuggestions } from './InputWithSuggestions'
 
 type SendBodyMessageProps = {
   onBodyChange: (body: string) => void
@@ -104,10 +106,11 @@ type MessageHeadersProps = {
 }
 const MessageHeaders: React.FunctionComponent<MessageHeadersProps> = props => {
   const [headers, setHeaders] = useState<Array<{ name: string; value: string }>>([])
+  const headersSuggestions = Object.keys(exchangeHeaders as Record<string, { type: string }>)
 
-  const handleInputChange = (index: number, newValue: string, event: React.FormEvent<HTMLInputElement>) => {
+  const handleInputChange = (index: number, newValue: string, headerName: string) => {
     const updatedHeaders = [...headers]
-    updatedHeaders[index] = { ...updatedHeaders[index], [event.currentTarget.name]: newValue }
+    updatedHeaders[index] = { ...updatedHeaders[index], [headerName]: newValue }
     setHeaders(updatedHeaders)
     props.onHeadersChange(updatedHeaders)
   }
@@ -145,12 +148,11 @@ const MessageHeaders: React.FunctionComponent<MessageHeadersProps> = props => {
           headers.map((header, index) => (
             <Flex key={index}>
               <FlexItem flex={{ default: 'flexNone', md: 'flex_2' }}>
-                <TextInput
-                  type='text'
+                <InputWithSuggestions
                   aria-label={'name-input-' + index}
-                  name='name'
+                  suggestions={headersSuggestions}
                   value={header.name}
-                  onChange={(newValue, event) => handleInputChange(index, newValue, event)}
+                  onChange={newValue => handleInputChange(index, newValue, 'name')}
                 />
               </FlexItem>
               <FlexItem flex={{ default: 'flexNone', md: 'flex_2' }}>
@@ -159,7 +161,7 @@ const MessageHeaders: React.FunctionComponent<MessageHeadersProps> = props => {
                   name='value'
                   aria-label={'value-input-' + index}
                   value={header.value}
-                  onChange={(newValue, event) => handleInputChange(index, newValue, event)}
+                  onChange={(newValue, event) => handleInputChange(index, newValue, 'value')}
                 />
               </FlexItem>
               <FlexItem flex={{ default: 'flexNone', md: 'flex_1' }} span={4}>

--- a/packages/hawtio/src/plugins/camel/endpoints/exchange-headers-camel-model.json
+++ b/packages/hawtio/src/plugins/camel/endpoints/exchange-headers-camel-model.json
@@ -1,0 +1,466 @@
+{
+  "headers": {
+    "CamelAuthenticationFailurePolicyId": {
+      "type": "java.lang.String"
+    },
+    "CamelAcceptContentType": {
+      "type": "java.lang.String"
+    },
+    "CamelAggregatedSize": {
+      "type": "java.lang.String"
+    },
+    "CamelAggregatedTimeout": {
+      "type": "java.lang.String"
+    },
+    "CamelAggregatedCompletedBy": {
+      "type": "java.lang.String"
+    },
+    "CamelAggregatedCorrelationKey": {
+      "type": "java.lang.String"
+    },
+    "CamelAggregatedCollectionGuard": {
+      "type": "java.lang.String"
+    },
+    "CamelAggregationStrategy": {
+      "type": "java.lang.String"
+    },
+    "CamelAggregationCompleteCurrentGroup": {
+      "type": "java.lang.String"
+    },
+    "CamelAggregationCompleteAllGroups": {
+      "type": "java.lang.String"
+    },
+    "CamelAggregationCompleteAllGroupsInclusive": {
+      "type": "java.lang.String"
+    },
+    "CamelAsyncWait": {
+      "type": "java.lang.String"
+    },
+    "CamelBatchIndex": {
+      "type": "java.lang.String"
+    },
+    "CamelBatchSize": {
+      "type": "java.lang.String"
+    },
+    "CamelBatchComplete": {
+      "type": "java.lang.String"
+    },
+    "CamelBeanMethodName": {
+      "type": "java.lang.String"
+    },
+    "CamelBinding": {
+      "type": "java.lang.String"
+    },
+    "breadcrumbId": {
+      "type": "java.lang.String"
+    },
+    "CamelCharsetName": {
+      "type": "java.lang.String"
+    },
+    "CamelCircuitBreakerState": {
+      "type": "java.lang.String"
+    },
+    "CamelCreatedTimestamp": {
+      "type": "java.lang.String"
+    },
+    "CamelClaimCheckRepository": {
+      "type": "java.lang.String"
+    },
+    "Content-Encoding": {
+      "type": "java.lang.String"
+    },
+    "Content-Length": {
+      "type": "java.lang.String"
+    },
+    "Content-Type": {
+      "type": "java.lang.String"
+    },
+    "CamelCookieHandler": {
+      "type": "java.lang.String"
+    },
+    "CamelCorrelationId": {
+      "type": "java.lang.String"
+    },
+    "CamelContentSchema": {
+      "type": "java.lang.String"
+    },
+    "CamelContentSchemaType": {
+      "type": "java.lang.String"
+    },
+    "CamelDataSetIndex": {
+      "type": "java.lang.String"
+    },
+    "org.apache.camel.default.charset": {
+      "type": "java.lang.String"
+    },
+    "CamelDestinationOverrideUrl": {
+      "type": "java.lang.String"
+    },
+    "CamelDisableHttpStreamCache": {
+      "type": "java.lang.String"
+    },
+    "CamelDuplicateMessage": {
+      "type": "java.lang.String"
+    },
+    "CamelDocumentBuilderFactory": {
+      "type": "java.lang.String"
+    },
+    "CamelExceptionCaught": {
+      "type": "java.lang.String"
+    },
+    "CamelExceptionHandled": {
+      "type": "java.lang.String"
+    },
+    "CamelEvaluateExpressionResult": {
+      "type": "java.lang.String"
+    },
+    "CamelErrorHandlerBridge": {
+      "type": "java.lang.String"
+    },
+    "CamelErrorHandlerCircuitDetected": {
+      "type": "java.lang.String"
+    },
+    "CamelErrorHandlerHandled": {
+      "type": "java.lang.String"
+    },
+    "CamelExternalRedelivered": {
+      "type": "java.lang.String"
+    },
+    "CamelFailureHandled": {
+      "type": "java.lang.String"
+    },
+    "CamelFailureEndpoint": {
+      "type": "java.lang.String"
+    },
+    "CamelFailureRouteId": {
+      "type": "java.lang.String"
+    },
+    "CamelFatalFallbackErrorHandler": {
+      "type": "java.lang.String"
+    },
+    "CamelFileContentType": {
+      "type": "java.lang.String"
+    },
+    "CamelFileLocalWorkPath": {
+      "type": "java.lang.String"
+    },
+    "CamelFileName": {
+      "type": "java.lang.String"
+    },
+    "CamelFileNameOnly": {
+      "type": "java.lang.String"
+    },
+    "CamelFileNameProduced": {
+      "type": "java.lang.String"
+    },
+    "CamelFileNameConsumed": {
+      "type": "java.lang.String"
+    },
+    "CamelFilePath": {
+      "type": "java.lang.String"
+    },
+    "CamelFileParent": {
+      "type": "java.lang.String"
+    },
+    "CamelFileLastModified": {
+      "type": "java.lang.String"
+    },
+    "CamelFileLength": {
+      "type": "java.lang.String"
+    },
+    "CamelFileLockFileAcquired": {
+      "type": "java.lang.String"
+    },
+    "CamelFileLockFileName": {
+      "type": "java.lang.String"
+    },
+    "CamelFileLockExclusiveLock": {
+      "type": "java.lang.String"
+    },
+    "CamelFileLockRandomAccessFile": {
+      "type": "java.lang.String"
+    },
+    "CamelFileLockChannelFile": {
+      "type": "java.lang.String"
+    },
+    "CamelFilterMatched": {
+      "type": "java.lang.String"
+    },
+    "CamelFilterNonXmlChars": {
+      "type": "java.lang.String"
+    },
+    "CamelGroupedExchange": {
+      "type": "java.lang.String"
+    },
+    "CamelHttpScheme": {
+      "type": "java.lang.String"
+    },
+    "CamelHttpHost": {
+      "type": "java.lang.String"
+    },
+    "CamelHttpPort": {
+      "type": "java.lang.String"
+    },
+    "CamelHttpBaseUri": {
+      "type": "java.lang.String"
+    },
+    "CamelHttpCharacterEncoding": {
+      "type": "java.lang.String"
+    },
+    "CamelHttpMethod": {
+      "type": "java.lang.String"
+    },
+    "CamelHttpPath": {
+      "type": "java.lang.String"
+    },
+    "CamelHttpProtocolVersion": {
+      "type": "java.lang.String"
+    },
+    "CamelHttpQuery": {
+      "type": "java.lang.String"
+    },
+    "CamelHttpRawQuery": {
+      "type": "java.lang.String"
+    },
+    "CamelHttpResponseCode": {
+      "type": "java.lang.String"
+    },
+    "CamelHttpResponseText": {
+      "type": "java.lang.String"
+    },
+    "CamelHttpUri": {
+      "type": "java.lang.String"
+    },
+    "CamelHttpUrl": {
+      "type": "java.lang.String"
+    },
+    "CamelHttpChunked": {
+      "type": "java.lang.String"
+    },
+    "CamelHttpServletRequest": {
+      "type": "java.lang.String"
+    },
+    "CamelHttpServletResponse": {
+      "type": "java.lang.String"
+    },
+    "CamelInterceptedEndpoint": {
+      "type": "java.lang.String"
+    },
+    "CamelInterceptSendToEndpointWhenMatched": {
+      "type": "java.lang.String"
+    },
+    "CamelInterrupted": {
+      "type": "java.lang.String"
+    },
+    "CamelLanguageScript": {
+      "type": "java.lang.String"
+    },
+    "CamelLogDebugBodyMaxChars": {
+      "type": "java.lang.String"
+    },
+    "CamelLogDebugStreams": {
+      "type": "java.lang.String"
+    },
+    "CamelLogEipName": {
+      "type": "java.lang.String"
+    },
+    "CamelLoopIndex": {
+      "type": "java.lang.String"
+    },
+    "CamelLoopSize": {
+      "type": "java.lang.String"
+    },
+    "Long-Running-Action": {
+      "type": "java.lang.String"
+    },
+    "CamelMaximumCachePoolSize": {
+      "type": "java.lang.String"
+    },
+    "CamelMaximumEndpointCacheSize": {
+      "type": "java.lang.String"
+    },
+    "CamelMaximumSimpleCacheSize": {
+      "type": "java.lang.String"
+    },
+    "CamelMaximumTransformerCacheSize": {
+      "type": "java.lang.String"
+    },
+    "CamelMaximumValidatorCacheSize": {
+      "type": "java.lang.String"
+    },
+    "CamelMessageHistory": {
+      "type": "java.lang.String"
+    },
+    "CamelMessageHistoryHeaderFormat": {
+      "type": "java.lang.String"
+    },
+    "CamelMessageHistoryOutputFormat": {
+      "type": "java.lang.String"
+    },
+    "CamelMessageTimestamp": {
+      "type": "java.lang.String"
+    },
+    "CamelMulticastIndex": {
+      "type": "java.lang.String"
+    },
+    "CamelMulticastComplete": {
+      "type": "java.lang.String"
+    },
+    "CamelNotifyEvent": {
+      "type": "java.lang.String"
+    },
+    "CamelOnCompletion": {
+      "type": "java.lang.String"
+    },
+    "CamelOnCompletionRouteIds": {
+      "type": "java.lang.String"
+    },
+    "CamelOffset": {
+      "type": "java.lang.String"
+    },
+    "CamelOverruleFileName": {
+      "type": "java.lang.String"
+    },
+    "CamelParentUnitOfWork": {
+      "type": "java.lang.String"
+    },
+    "CamelStreamCacheUnitOfWork": {
+      "type": "java.lang.String"
+    },
+    "CamelRecipientListEndpoint": {
+      "type": "java.lang.String"
+    },
+    "CamelReceivedTimestamp": {
+      "type": "java.lang.String"
+    },
+    "CamelRedelivered": {
+      "type": "java.lang.String"
+    },
+    "CamelRedeliveryCounter": {
+      "type": "java.lang.String"
+    },
+    "CamelRedeliveryMaxCounter": {
+      "type": "java.lang.String"
+    },
+    "CamelRedeliveryExhausted": {
+      "type": "java.lang.String"
+    },
+    "CamelRedeliveryDelay": {
+      "type": "java.lang.String"
+    },
+    "CamelRestHttpUri": {
+      "type": "java.lang.String"
+    },
+    "CamelRestHttpQuery": {
+      "type": "java.lang.String"
+    },
+    "CamelRollbackOnly": {
+      "type": "java.lang.String"
+    },
+    "CamelRollbackOnlyLast": {
+      "type": "java.lang.String"
+    },
+    "CamelRouteStop": {
+      "type": "java.lang.String"
+    },
+    "CamelReuseScripteEngine": {
+      "type": "java.lang.String"
+    },
+    "CamelCompileScript": {
+      "type": "java.lang.String"
+    },
+    "CamelSAXParserFactory": {
+      "type": "java.lang.String"
+    },
+    "CamelSchedulerPolledMessages": {
+      "type": "java.lang.String"
+    },
+    "CamelSoapAction": {
+      "type": "java.lang.String"
+    },
+    "CamelSkipGzipEncoding": {
+      "type": "java.lang.String"
+    },
+    "CamelSkipWwwFormUrlEncoding": {
+      "type": "java.lang.String"
+    },
+    "CamelSlipEndpoint": {
+      "type": "java.lang.String"
+    },
+    "CamelSlipProducer": {
+      "type": "java.lang.String"
+    },
+    "CamelSplitIndex": {
+      "type": "java.lang.String"
+    },
+    "CamelSplitComplete": {
+      "type": "java.lang.String"
+    },
+    "CamelSplitSize": {
+      "type": "java.lang.String"
+    },
+    "CamelStepId": {
+      "type": "java.lang.String"
+    },
+    "CamelTimerCounter": {
+      "type": "java.lang.String"
+    },
+    "CamelTimerFiredTime": {
+      "type": "java.lang.String"
+    },
+    "CamelTimerName": {
+      "type": "java.lang.String"
+    },
+    "CamelTimerPeriod": {
+      "type": "java.lang.String"
+    },
+    "CamelTimerTime": {
+      "type": "java.lang.String"
+    },
+    "CamelToEndpoint": {
+      "type": "java.lang.String"
+    },
+    "CamelTraceEvent": {
+      "type": "java.lang.String"
+    },
+    "CamelTraceEventNodeId": {
+      "type": "java.lang.String"
+    },
+    "CamelTraceEventTimestamp": {
+      "type": "java.lang.String"
+    },
+    "CamelTraceEventExchange": {
+      "type": "java.lang.String"
+    },
+    "CamelTracingHeaderFormat": {
+      "type": "java.lang.String"
+    },
+    "CamelTracingOutputFormat": {
+      "type": "java.lang.String"
+    },
+    "CamelTransactionContextData": {
+      "type": "java.lang.String"
+    },
+    "TryRouteBlock": {
+      "type": "java.lang.String"
+    },
+    "Transfer-Encoding": {
+      "type": "java.lang.String"
+    },
+    "CamelUnitOfWorkExhausted": {
+      "type": "java.lang.String"
+    },
+    "CamelXsltFileName": {
+      "type": "java.lang.String"
+    },
+    "CamelXsltError": {
+      "type": "java.lang.String"
+    },
+    "CamelXsltFatalError": {
+      "type": "java.lang.String"
+    },
+    "CamelXsltWarning": {
+      "type": "java.lang.String"
+    }
+  }
+}


### PR DESCRIPTION

![Screenshot 2023-06-28 at 08 59 35](https://github.com/hawtio/hawtio-next/assets/6814482/1295dc27-a2a7-441b-b3fa-3bbc4353ee42)
also: 
- manually created exchange headers definitions into the `camel-model` 
- reused input with suggestions from the `BrowseMessages` component