### PR TITLE
Fix jmx operations error

### DIFF
--- a/packages/hawtio/package.json
+++ b/packages/hawtio/package.json
@@ -50,7 +50,7 @@
     "@types/react-router-dom": "^5.3.3",
     "dagre": "^0.8.5",
     "eventemitter3": "^5.0.1",
-    "jolokia.js": "1.7.2",
+    "jolokia.js": "1.7.3-1",
     "jquery": "^3.7.0",
     "js-logger": "^1.6.1",
     "keycloak-js": "^21.1.2",

--- a/packages/hawtio/src/plugins/camel/camel-content-service.ts
+++ b/packages/hawtio/src/plugins/camel/camel-content-service.ts
@@ -149,7 +149,7 @@ export function canBrowse(node: MBeanNode): boolean {
 }
 
 export function canBrowseMessages(node: MBeanNode): boolean {
-  const browseMessages = node.mbean?.op['browseMessageAsXml']
+  const browseMessages = node.mbean?.op?.['browseMessageAsXml']
   return !!browseMessages
 }
 

--- a/packages/hawtio/src/plugins/shared/attributes/AttributeModal.tsx
+++ b/packages/hawtio/src/plugins/shared/attributes/AttributeModal.tsx
@@ -41,7 +41,7 @@ export const AttributeModal: React.FunctionComponent<AttributeModalProps> = prop
     return null
   }
 
-  const attribute = selectedNode.mbean.attr[name]
+  const attribute = selectedNode.mbean.attr?.[name]
   if (!attribute) {
     return null
   }

--- a/packages/hawtio/src/plugins/shared/operations/Operations.tsx
+++ b/packages/hawtio/src/plugins/shared/operations/Operations.tsx
@@ -17,7 +17,7 @@ export const Operations: React.FunctionComponent = () => {
   const objectName = selectedNode.objectName
   const mbean = selectedNode.mbean
 
-  if (isEmpty(mbean.op)) {
+  if (!mbean.op || isEmpty(mbean.op)) {
     return (
       <Card>
         <CardBody>

--- a/packages/hawtio/src/plugins/shared/tree/node.ts
+++ b/packages/hawtio/src/plugins/shared/tree/node.ts
@@ -33,6 +33,8 @@ export type FilterFn = (node: MBeanNode) => boolean
 
 export type ForEachFn = (node: MBeanNode) => void
 
+const MBEAN_NODE_ID_SEPARATOR = '-'
+
 export class MBeanNode implements TreeViewDataItem {
   /**
    * ID of the tree view item in HTML.
@@ -49,8 +51,6 @@ export class MBeanNode implements TreeViewDataItem {
   // MBean info
   objectName?: string
   mbean?: OptimisedJmxMBean
-
-  private readonly idSeparator = '-'
 
   /**
    * A new node
@@ -77,7 +77,7 @@ export class MBeanNode implements TreeViewDataItem {
   }
 
   private generateId(folder: boolean): string {
-    const idPrefix = this.parent ? this.parent.id + this.idSeparator : ''
+    const idPrefix = this.parent ? this.parent.id + MBEAN_NODE_ID_SEPARATOR : ''
     const idPostFix = folder ? '-folder' : ''
     return idPrefix + escapeHtmlId(this.name) + idPostFix
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2029,7 +2029,7 @@ __metadata:
     jest-environment-jsdom: ^29.5.0
     jest-fetch-mock: ^3.0.3
     jest-watch-typeahead: ^2.2.2
-    jolokia.js: 1.7.2
+    jolokia.js: 1.7.3-1
     jquery: ^3.7.0
     js-logger: ^1.6.1
     keycloak-js: ^21.1.2
@@ -11115,12 +11115,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jolokia.js@npm:1.7.2":
-  version: 1.7.2
-  resolution: "jolokia.js@npm:1.7.2"
+"jolokia.js@npm:1.7.3-1":
+  version: 1.7.3-1
+  resolution: "jolokia.js@npm:1.7.3-1"
   dependencies:
     "@types/jquery": ^3.5.14
-  checksum: 88aafeee1416ee6b02c0d7fd78bc8bf379a928f0047a7cb629c2eff5ddc9403a57b59ebbf58e86a55984649de76a18a93fc7153d7763d916981624f5034477af
+  checksum: 9bc6f6a5d42f8e3105c33fa00da09fbea3252251dec31d263d41876dbdd101da9581508b9c5517b934749958470eb6822fe75ab3a36474d452438417453b513c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Now JMX Operations tab crashes when looking at a mbean that has no operations. jolokia.js should be updated so that we expect `attr` and `op` are indeed optional at type level.