### PR TITLE
refactor(camel): refactor Camel RouteDiagrams view

### DIFF
--- a/packages/hawtio/src/plugins/camel/CamelContent.tsx
+++ b/packages/hawtio/src/plugins/camel/CamelContent.tsx
@@ -36,15 +36,15 @@ import { Profile } from './profile/Profile'
 import { Properties } from './properties'
 import { RestServices } from './rest-services/RestServices'
 import { RouteDiagram } from './route-diagram/RouteDiagram'
-import { RouteDiagramContext, useRouteDiagramContext } from './route-diagram/route-diagram-context'
 import { CamelRoutes } from './routes/CamelRoutes'
 import { Source } from './routes/Source'
 import { Trace } from './trace'
 import { TypeConverters } from './type-converters'
+import { RouteDiagramContext, useRouteDiagramContext } from './route-diagram/context'
 
 export const CamelContent: React.FunctionComponent = () => {
-  const ctx = useRouteDiagramContext()
-  const { selectedNode } = ctx
+  const { selectedNode } = useContext(CamelContext)
+  const routeDiagramContext = useRouteDiagramContext()
   const { pathname, search } = useLocation()
 
   if (!selectedNode) {
@@ -90,9 +90,8 @@ export const CamelContent: React.FunctionComponent = () => {
     {
       id: 'routeDiagram',
       title: 'Route Diagram',
-      // TODO: The context provider should be applied inside RouteDiagram component
       component: (
-        <RouteDiagramContext.Provider value={ctx}>
+        <RouteDiagramContext.Provider value={routeDiagramContext}>
           <RouteDiagram />
         </RouteDiagramContext.Provider>
       ),

--- a/packages/hawtio/src/plugins/camel/debug/Debug.tsx
+++ b/packages/hawtio/src/plugins/camel/debug/Debug.tsx
@@ -26,11 +26,12 @@ import {
 } from '@patternfly/react-icons'
 import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table'
 import { IResponse } from 'jolokia.js'
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useContext, useEffect, useRef, useState } from 'react'
 import * as camelService from '../camel-service'
+import { CamelContext } from '../context'
 import { log } from '../globals'
 import { RouteDiagram } from '../route-diagram/RouteDiagram'
-import { Annotation, RouteDiagramContext, useRouteDiagramContext } from '../route-diagram/route-diagram-context'
+import { Annotation, RouteDiagramContext, useRouteDiagramContext } from '../route-diagram/context'
 import { CamelNodeData } from '../route-diagram/visualization-service'
 import { ConditionalBreakpointModal } from './ConditionalBreakpointModel'
 import './Debug.css'
@@ -38,8 +39,8 @@ import { MessageDrawer } from './MessageDrawer'
 import { ConditionalBreakpoint, MessageData, debugService as ds } from './debug-service'
 
 export const Debug: React.FunctionComponent = () => {
+  const { selectedNode } = useContext(CamelContext)
   const {
-    selectedNode,
     graphNodeData,
     setGraphNodeData,
     graphSelection,
@@ -523,16 +524,15 @@ export const Debug: React.FunctionComponent = () => {
               <div id='route-diagram-breakpoint-view'>
                 <RouteDiagramContext.Provider
                   value={{
-                    selectedNode: selectedNode,
-                    graphNodeData: graphNodeData,
-                    setGraphNodeData: setGraphNodeData,
-                    graphSelection: graphSelection,
-                    setGraphSelection: setGraphSelection,
-                    setShowStatistics: setShowStatistics,
-                    doubleClickAction: doubleClickAction,
-                    setDoubleClickAction: setDoubleClickAction,
-                    annotations: annotations,
-                    setAnnotations: setAnnotations,
+                    graphNodeData,
+                    setGraphNodeData,
+                    graphSelection,
+                    setGraphSelection,
+                    setShowStatistics,
+                    doubleClickAction,
+                    setDoubleClickAction,
+                    annotations,
+                    setAnnotations,
                   }}
                 >
                   <RouteDiagram />

--- a/packages/hawtio/src/plugins/camel/route-diagram/RouteDiagram.css
+++ b/packages/hawtio/src/plugins/camel/route-diagram/RouteDiagram.css
@@ -63,16 +63,10 @@
   font-size: x-small;
 }
 
-.route-diagram {
+.camel-route-diagram {
   flex-grow: 1;
   position: relative;
   height: 80vh;
-}
-
-.route-diagram-page {
-  height: 90vh;
-  width: 70vw;
-  background-color: white;
 }
 
 .highlighted {

--- a/packages/hawtio/src/plugins/camel/route-diagram/context.ts
+++ b/packages/hawtio/src/plugins/camel/route-diagram/context.ts
@@ -1,6 +1,4 @@
-import { MBeanNode } from '@hawtiosrc/plugins/shared'
-import { createContext, useContext, useState } from 'react'
-import { CamelContext } from '../context'
+import { createContext, useState } from 'react'
 import { CamelNodeData } from './visualization-service'
 
 const noOpAction = (nodeData: CamelNodeData) => {
@@ -8,7 +6,6 @@ const noOpAction = (nodeData: CamelNodeData) => {
 }
 
 export function useRouteDiagramContext() {
-  const { selectedNode, setSelectedNode } = useContext(CamelContext)
   const [graphNodeData, setGraphNodeData] = useState<CamelNodeData[]>([])
   const [graphSelection, setGraphSelection] = useState<string>('')
   const [showStatistics, setShowStatistics] = useState<boolean>(true)
@@ -16,8 +13,6 @@ export function useRouteDiagramContext() {
   const [annotations, setAnnotations] = useState<Annotation[]>([])
 
   return {
-    selectedNode,
-    setSelectedNode,
     graphNodeData,
     setGraphNodeData,
     graphSelection,
@@ -37,7 +32,6 @@ export type Annotation = {
 }
 
 export type RouteDiagramContext = {
-  selectedNode: MBeanNode | null
   graphNodeData?: CamelNodeData[]
   setGraphNodeData: (graphNodeData: CamelNodeData[]) => void
   graphSelection?: string
@@ -51,7 +45,6 @@ export type RouteDiagramContext = {
 }
 
 export const RouteDiagramContext = createContext<RouteDiagramContext>({
-  selectedNode: null,
   graphNodeData: [],
   setGraphNodeData: (graphNodeData: CamelNodeData[]) => {
     /* no-op */

--- a/packages/hawtio/src/plugins/camel/trace/Trace.tsx
+++ b/packages/hawtio/src/plugins/camel/trace/Trace.tsx
@@ -17,21 +17,23 @@ import {
 import { BanIcon, PlayIcon } from '@patternfly/react-icons'
 import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table'
 import { IResponse } from 'jolokia.js'
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useContext, useEffect, useRef, useState } from 'react'
 import * as camelService from '../camel-service'
+import { CamelContext } from '../context'
 import { debugService as ds } from '../debug'
 import { MessageDrawer } from '../debug/MessageDrawer'
 import { MessageData } from '../debug/debug-service'
 import { log } from '../globals'
 import { RouteDiagram } from '../route-diagram/RouteDiagram'
-import { RouteDiagramContext, useRouteDiagramContext } from '../route-diagram/route-diagram-context'
+import { RouteDiagramContext, useRouteDiagramContext } from '../route-diagram/context'
 import './Tracing.css'
 import { tracingService as ts } from './tracing-service'
 
 const MESSAGES_LIMIT = 500
 
 export const Trace: React.FunctionComponent = () => {
-  const { selectedNode, graphNodeData, setGraphNodeData, graphSelection, setGraphSelection, setShowStatistics } =
+  const { selectedNode } = useContext(CamelContext)
+  const { graphNodeData, setGraphNodeData, graphSelection, setGraphSelection, setShowStatistics } =
     useRouteDiagramContext()
   const [isReading, setIsReading] = useState(true)
   const [isTracing, setIsTracing] = useState(false)
@@ -223,12 +225,11 @@ export const Trace: React.FunctionComponent = () => {
                 <PanelMainBody>
                   <RouteDiagramContext.Provider
                     value={{
-                      selectedNode: selectedNode,
-                      graphNodeData: graphNodeData,
-                      setGraphNodeData: setGraphNodeData,
-                      graphSelection: graphSelection,
-                      setGraphSelection: setGraphSelection,
-                      setShowStatistics: setShowStatistics,
+                      graphNodeData,
+                      setGraphNodeData,
+                      graphSelection,
+                      setGraphSelection,
+                      setShowStatistics,
                     }}
                   >
                     <RouteDiagram />


### PR DESCRIPTION
* Removed `selectedNode` from route diagram context; we have been trying to merge the react contexts for each submodule, but I think it's perfectly fine to use multiple react contexts at the same time. React contexts are just a convenient way to use states without passing them as props for cascading sub components. So, ideally we should have normally three contexts for each sub component: the Hawtio context (if any), the root plugin context (camel), and the context specific to a sub component (e.g. route diagram context). Node selection should be provided by the root plugin context.
* Declare return types for the visualization service
* Some other code changes to align with the styles of the other components

Initially I tried to remove the route diagram context and move them to component props, as it seemed to bring tight coupling between RouteDiagram and Debug, Tracer. But now I understand it seems rather necessary (at least for now), so I'll leave it as is.