### PR TITLE
feat(camel,rbac): apply RBAC to Camel views (2)

### DIFF
--- a/packages/hawtio/src/plugins/camel/CamelContent.tsx
+++ b/packages/hawtio/src/plugins/camel/CamelContent.tsx
@@ -36,11 +36,19 @@ import { Profile } from './profile/Profile'
 import { Properties } from './properties'
 import { RestServices } from './rest-services/RestServices'
 import { RouteDiagram } from './route-diagram/RouteDiagram'
+import { RouteDiagramContext, useRouteDiagramContext } from './route-diagram/context'
+import { ROUTE_OPERATIONS } from './routes-service'
 import { CamelRoutes } from './routes/CamelRoutes'
 import { Source } from './routes/Source'
 import { Trace } from './trace'
 import { TypeConverters } from './type-converters'
-import { RouteDiagramContext, useRouteDiagramContext } from './route-diagram/context'
+
+type NavItem = {
+  id: string
+  title: string
+  component: JSX.Element
+  isApplicable: (node: MBeanNode) => boolean
+}
 
 export const CamelContent: React.FunctionComponent = () => {
   const { selectedNode } = useContext(CamelContext)
@@ -60,12 +68,7 @@ export const CamelContent: React.FunctionComponent = () => {
     )
   }
 
-  type NavItem = {
-    id: string
-    title: string
-    component: JSX.Element
-    isApplicable: (node: MBeanNode) => boolean
-  }
+  const contextNode = camelService.findContext(selectedNode)
 
   /*
    * Test if nav should contain general mbean tabs
@@ -102,6 +105,8 @@ export const CamelContent: React.FunctionComponent = () => {
       title: 'Source',
       component: <Source />,
       isApplicable: node =>
+        contextNode !== null &&
+        contextNode.hasInvokeRights(ROUTE_OPERATIONS.dumpRoutesAsXml) &&
         !camelService.isEndpointNode(node) &&
         !camelService.isEndpointsFolder(node) &&
         (camelService.isRouteNode(node) || camelService.isRoutesFolder(node)),

--- a/packages/hawtio/src/plugins/camel/CamelContent.tsx
+++ b/packages/hawtio/src/plugins/camel/CamelContent.tsx
@@ -30,6 +30,7 @@ import { Endpoints } from './endpoints'
 import { BrowseMessages } from './endpoints/BrowseMessages'
 import { EndpointStats } from './endpoints/EndpointsStats'
 import { SendMessage } from './endpoints/SendMessage'
+import { ENDPOINT_OPERATIONS } from './endpoints/endpoints-service'
 import { Exchanges } from './exchanges'
 import { log, pluginPath } from './globals'
 import { Profile } from './profile/Profile'
@@ -112,7 +113,15 @@ export const CamelContent: React.FunctionComponent = () => {
         (camelService.isRouteNode(node) || camelService.isRoutesFolder(node)),
     },
     { id: 'properties', title: 'Properties', component: <Properties />, isApplicable: camelService.hasProperties },
-    { id: 'send', title: 'Send', component: <SendMessage />, isApplicable: camelService.isEndpointNode },
+    {
+      id: 'send',
+      title: 'Send',
+      component: <SendMessage />,
+      isApplicable: node =>
+        contextNode !== null &&
+        contextNode.hasInvokeRights(ENDPOINT_OPERATIONS.sendBodyAndHeaders, ENDPOINT_OPERATIONS.sendStringBody) &&
+        camelService.isEndpointNode(node),
+    },
     {
       id: 'browse',
       title: 'Browse',

--- a/packages/hawtio/src/plugins/camel/CamelContent.tsx
+++ b/packages/hawtio/src/plugins/camel/CamelContent.tsx
@@ -126,7 +126,13 @@ export const CamelContent: React.FunctionComponent = () => {
       id: 'browse',
       title: 'Browse',
       component: <BrowseMessages />,
-      isApplicable: node => camelService.isEndpointNode(node) && camelService.canBrowseMessages(node),
+      isApplicable: node =>
+        node.hasInvokeRights(
+          ENDPOINT_OPERATIONS.browseAllMessagesAsXml,
+          ENDPOINT_OPERATIONS.browseRangeMessagesAsXml,
+        ) &&
+        camelService.isEndpointNode(node) &&
+        camelService.canBrowseMessages(node),
     },
     {
       id: 'endpoint-stats',

--- a/packages/hawtio/src/plugins/camel/CamelContent.tsx
+++ b/packages/hawtio/src/plugins/camel/CamelContent.tsx
@@ -30,7 +30,6 @@ import { Endpoints } from './endpoints'
 import { BrowseMessages } from './endpoints/BrowseMessages'
 import { EndpointStats } from './endpoints/EndpointsStats'
 import { SendMessage } from './endpoints/SendMessage'
-import { ENDPOINT_OPERATIONS } from './endpoints/endpoints-service'
 import { Exchanges } from './exchanges'
 import { log, pluginPath } from './globals'
 import { Profile } from './profile/Profile'
@@ -38,7 +37,6 @@ import { Properties } from './properties'
 import { RestServices } from './rest-services/RestServices'
 import { RouteDiagram } from './route-diagram/RouteDiagram'
 import { RouteDiagramContext, useRouteDiagramContext } from './route-diagram/context'
-import { ROUTE_OPERATIONS } from './routes-service'
 import { CamelRoutes } from './routes/CamelRoutes'
 import { Source } from './routes/Source'
 import { Trace } from './trace'
@@ -69,8 +67,6 @@ export const CamelContent: React.FunctionComponent = () => {
     )
   }
 
-  const contextNode = camelService.findContext(selectedNode)
-
   /*
    * Test if nav should contain general mbean tabs
    */
@@ -99,46 +95,32 @@ export const CamelContent: React.FunctionComponent = () => {
           <RouteDiagram />
         </RouteDiagramContext.Provider>
       ),
-      isApplicable: node => camelService.isRouteNode(node) || camelService.isRoutesFolder(node),
+      isApplicable: camelService.canViewRouteDiagram,
     },
     {
       id: 'source',
       title: 'Source',
       component: <Source />,
-      isApplicable: node =>
-        contextNode !== null &&
-        contextNode.hasInvokeRights(ROUTE_OPERATIONS.dumpRoutesAsXml) &&
-        !camelService.isEndpointNode(node) &&
-        !camelService.isEndpointsFolder(node) &&
-        (camelService.isRouteNode(node) || camelService.isRoutesFolder(node)),
+      isApplicable: camelService.canViewSource,
     },
     { id: 'properties', title: 'Properties', component: <Properties />, isApplicable: camelService.hasProperties },
     {
       id: 'send',
       title: 'Send',
       component: <SendMessage />,
-      isApplicable: node =>
-        contextNode !== null &&
-        contextNode.hasInvokeRights(ENDPOINT_OPERATIONS.sendBodyAndHeaders, ENDPOINT_OPERATIONS.sendStringBody) &&
-        camelService.isEndpointNode(node),
+      isApplicable: camelService.canSendMessage,
     },
     {
       id: 'browse',
       title: 'Browse',
       component: <BrowseMessages />,
-      isApplicable: node =>
-        node.hasInvokeRights(
-          ENDPOINT_OPERATIONS.browseAllMessagesAsXml,
-          ENDPOINT_OPERATIONS.browseRangeMessagesAsXml,
-        ) &&
-        camelService.isEndpointNode(node) &&
-        camelService.canBrowseMessages(node),
+      isApplicable: camelService.canBrowseMessages,
     },
     {
       id: 'endpoint-stats',
       title: 'Endpoints (in/out)',
       component: <EndpointStats />,
-      isApplicable: camelService.canSeeEndpointStats,
+      isApplicable: camelService.canViewEndpointStats,
     },
     { id: 'exchanges', title: 'Exchanges', component: <Exchanges />, isApplicable: camelService.hasExchange },
     {

--- a/packages/hawtio/src/plugins/camel/endpoints/SendMessage.tsx
+++ b/packages/hawtio/src/plugins/camel/endpoints/SendMessage.tsx
@@ -1,5 +1,4 @@
 import { NotificationType, eventService } from '@hawtiosrc/core'
-import { doSendMessage } from '@hawtiosrc/plugins/camel/endpoints/endpoints-service'
 import { isBlank } from '@hawtiosrc/util/strings'
 import { CodeEditor, Language } from '@patternfly/react-code-editor'
 import {
@@ -13,16 +12,17 @@ import {
   FormGroup,
   Select,
   SelectOption,
+  SelectOptionObject,
   SelectVariant,
   TextInput,
 } from '@patternfly/react-core'
-import { SelectOptionObject } from '@patternfly/react-core/src/components/Select/SelectOption'
 import { TrashIcon } from '@patternfly/react-icons'
 import * as monacoEditor from 'monaco-editor'
 import React, { FormEvent, useContext, useRef, useState } from 'react'
 import xmlFormat from 'xml-formatter'
 import { CamelContext } from '../context'
 import { InputWithSuggestions } from './InputWithSuggestions'
+import { doSendMessage } from './endpoints-service'
 import { headers as exchangeHeaders } from './exchange-headers-camel-model.json'
 
 export const SendMessage: React.FunctionComponent = () => {

--- a/packages/hawtio/src/plugins/camel/routes-service.ts
+++ b/packages/hawtio/src/plugins/camel/routes-service.ts
@@ -64,6 +64,7 @@ export const ROUTE_OPERATIONS = {
   start: 'start()',
   stop: 'stop()',
   remove: 'remove()',
+  dumpRoutesAsXml: 'dumpRoutesAsXml()',
 } as const
 
 class RoutesService {
@@ -169,7 +170,7 @@ class RoutesService {
 
     let xml = null
     try {
-      xml = await jolokiaService.execute(mbeanName, 'dumpRoutesAsXml()')
+      xml = await jolokiaService.execute(mbeanName, ROUTE_OPERATIONS.dumpRoutesAsXml)
     } catch (error) {
       throw new Error('Failed to dump xml from mbean: ' + mbeanName)
     }

--- a/packages/hawtio/src/plugins/shared/tree/node.ts
+++ b/packages/hawtio/src/plugins/shared/tree/node.ts
@@ -439,6 +439,9 @@ export class MBeanNode implements TreeViewDataItem {
     this.expandedIcon = expandedIcon
   }
 
+  /**
+   * Returns true only if all the given methods can be invoked.
+   */
   hasInvokeRights(...methods: string[]): boolean {
     const mbean = this.mbean
     if (!mbean) return true

--- a/packages/hawtio/src/plugins/shared/tree/node.ts
+++ b/packages/hawtio/src/plugins/shared/tree/node.ts
@@ -440,6 +440,18 @@ export class MBeanNode implements TreeViewDataItem {
   }
 
   /**
+   * Returns true only if all the given operations exist in this MBean node.
+   */
+  hasOperations(...names: string[]): boolean {
+    if (!this.mbean || !this.mbean.op) {
+      return false
+    }
+
+    const operations = this.mbean.op
+    return names.every(name => operations[name] !== undefined)
+  }
+
+  /**
    * Returns true only if all the given methods can be invoked.
    */
   hasInvokeRights(...methods: string[]): boolean {


### PR DESCRIPTION
Applies `hasInvokeRights` check to the rest of the Camel nav items.

Should fix #134.

Over time, we might find more places where we should fine-control visibility of UI components on Hawtio, but we can tackle them later on demand.