### PR TITLE
build: enable noUncheckedIndexedAccess in tsconfig for better typechecking of records

### DIFF
--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -12,6 +12,7 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,
+    "noUncheckedIndexedAccess": true,
     "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,

--- a/packages/camel-model/tsconfig.json
+++ b/packages/camel-model/tsconfig.json
@@ -11,6 +11,7 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,
+    "noUncheckedIndexedAccess": true,
     "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,

--- a/packages/hawtio/src/core/core.ts
+++ b/packages/hawtio/src/core/core.ts
@@ -163,7 +163,11 @@ class HawtioCore {
           log.debug('Loading remote', remote)
           try {
             const plugin = await importRemote<{ [entry: string]: HawtioPlugin }>(remote)
-            plugin[remote.pluginEntry || DEFAULT_PLUGIN_ENTRY]()
+            const entryFn = plugin[remote.pluginEntry || DEFAULT_PLUGIN_ENTRY]
+            if (!entryFn) {
+              throw new Error(`Plugin entry not found: ${remote.pluginEntry || DEFAULT_PLUGIN_ENTRY}`)
+            }
+            entryFn()
             log.debug('Loaded remote', remote)
           } catch (err) {
             log.error('Error loading remote:', remote, '-', err)

--- a/packages/hawtio/src/core/logging.test.ts
+++ b/packages/hawtio/src/core/logging.test.ts
@@ -7,6 +7,6 @@ describe('Logger', () => {
     Logger.get('hawtio-core-test')
     const availableLoggers = Logger.getAvailableChildLoggers()
     expect(availableLoggers).toHaveLength(1)
-    expect(availableLoggers[0].name).toEqual('hawtio-core-test')
+    expect(availableLoggers[0]?.name).toEqual('hawtio-core-test')
   })
 })

--- a/packages/hawtio/src/core/logging.ts
+++ b/packages/hawtio/src/core/logging.ts
@@ -57,10 +57,11 @@ class LocalStorageHawtioLogger implements HawtioLogger {
   } as const
 
   get(name: string): ILogger {
-    if (this.loggers[name]) {
-      return this.loggers[name]
+    let logger = this.loggers[name]
+    if (logger) {
+      return logger
     }
-    const logger = jsLogger.get(name)
+    logger = jsLogger.get(name)
     this.loggers[name] = logger
     return logger
   }
@@ -92,15 +93,14 @@ class LocalStorageHawtioLogger implements HawtioLogger {
   }
 
   private toLogLevel(level: ILogLevel | string): ILogLevel {
-    let logLevel = this.INFO
-    if (typeof level === 'string') {
-      logLevel = this.LOG_LEVEL_MAP[level]
-      if (!logLevel) {
-        console.error('Unknown log level:', level)
-        return this.INFO
-      }
-    } else {
-      logLevel = level
+    if (typeof level !== 'string') {
+      return level
+    }
+
+    const logLevel = this.LOG_LEVEL_MAP[level]
+    if (!logLevel) {
+      console.error('Unknown log level:', level)
+      return this.INFO
     }
     return logLevel
   }

--- a/packages/hawtio/src/help/registry.test.ts
+++ b/packages/hawtio/src/help/registry.test.ts
@@ -15,9 +15,9 @@ describe('helpRegistry', () => {
     expect(helpRegistry.getHelps()).toEqual([])
     helpRegistry.add('test', 'Test', payload)
     expect(helpRegistry.getHelps()).toHaveLength(1)
-    expect(helpRegistry.getHelps()[0].id).toEqual('test')
-    expect(helpRegistry.getHelps()[0].title).toEqual('Test')
-    expect(helpRegistry.getHelps()[0].content).toEqual(`
+    expect(helpRegistry.getHelps()[0]?.id).toEqual('test')
+    expect(helpRegistry.getHelps()[0]?.title).toEqual('Test')
+    expect(helpRegistry.getHelps()[0]?.content).toEqual(`
       # Help Test
       Test help content.
     `)

--- a/packages/hawtio/src/plugins/camel/CamelContent.tsx
+++ b/packages/hawtio/src/plugins/camel/CamelContent.tsx
@@ -145,7 +145,7 @@ export const CamelContent: React.FunctionComponent = () => {
   /* Filter the nav items to those applicable to the selected node */
   const navItems = allNavItems.filter(nav => nav.isApplicable(selectedNode))
 
-  const camelNav = navItems.length > 0 && (
+  const camelNav = (
     <Nav aria-label='Camel Nav' variant='tertiary'>
       <NavList>
         {navItems.map(nav => (
@@ -165,7 +165,7 @@ export const CamelContent: React.FunctionComponent = () => {
         <PageSection id='camel-content-header' variant={PageSectionVariants.light}>
           {camelService.isContext(selectedNode) && <CamelContentContextToolbar />}
           <Title headingLevel='h1'>{selectedNode.name}</Title>
-          <Text component='small'>{selectedNode.objectName}</Text>
+          {selectedNode.objectName && <Text component='small'>{selectedNode.objectName}</Text>}
         </PageSection>
         {navItems.length > 1 && <PageNavigation>{camelNav}</PageNavigation>}
       </PageGroup>
@@ -174,7 +174,7 @@ export const CamelContent: React.FunctionComponent = () => {
         {navItems.length > 0 && (
           <Routes>
             {camelNavRoutes}
-            <Route key='root' path='/' element={<Navigate to={navItems[0].id} />} />
+            <Route key='root' path='/' element={<Navigate to={navItems[0]?.id ?? ''} />} />
           </Routes>
         )}
         {navItems.length === 0 && !selectedNode.objectName && <JmxContentMBeans />}

--- a/packages/hawtio/src/plugins/camel/CamelTreeView.test.tsx
+++ b/packages/hawtio/src/plugins/camel/CamelTreeView.test.tsx
@@ -51,7 +51,7 @@ describe('CamelTreeView', () => {
 
     if (rootNode) {
       const ctxNode = rootNode.getChildren()[0]
-      tree = MBeanTree.createFromNodes(pluginName, ctxNode.getChildren())
+      tree = MBeanTree.createFromNodes(pluginName, ctxNode?.getChildren() ?? [])
     }
   })
 

--- a/packages/hawtio/src/plugins/camel/camel-service.test.ts
+++ b/packages/hawtio/src/plugins/camel/camel-service.test.ts
@@ -56,7 +56,12 @@ describe('camel-service', () => {
     ]
 
     for (const data of versions) {
-      expect(camelService.compareVersions(data.v, data.ma, data.mi)).toEqual(data.r)
+      expect({
+        v: data.v,
+        ma: data.ma,
+        mi: data.mi,
+        r: camelService.compareVersions(data.v, data.ma, data.mi),
+      }).toEqual(data)
     }
   })
 

--- a/packages/hawtio/src/plugins/camel/camel-service.ts
+++ b/packages/hawtio/src/plugins/camel/camel-service.ts
@@ -295,15 +295,13 @@ export function compareVersions(version: string, major: number, minor: number): 
   const arr = version.split('.')
 
   // parse int or default to 0
-  const vmaj = parseInt(arr[0]) || 0
-  const vmin = parseInt(arr[1]) || 0
+  const vmaj = parseInt(arr[0] ?? '0') || 0
+  const vmin = parseInt(arr[1] ?? '0') || 0
   if (vmaj < major) return -1
-
   if (vmaj > major) return 1
 
-  // maj == major
+  // vmaj == major
   if (vmin < minor) return -1
-
   if (vmin > minor) return 1
 
   // major and minor are the same

--- a/packages/hawtio/src/plugins/camel/context.ts
+++ b/packages/hawtio/src/plugins/camel/context.ts
@@ -29,6 +29,9 @@ export function useCamelTree() {
     const rootNode = wkspTree.findDescendant(node => node.name === jmxDomain)
     if (rootNode && rootNode.children && rootNode.children.length > 0) {
       const contextsNode = rootNode.getChildren()[0]
+      if (!contextsNode) {
+        return
+      }
 
       /*
        * Using the camel domain nodes from the original tree means it is the same

--- a/packages/hawtio/src/plugins/camel/contexts/Contexts.tsx
+++ b/packages/hawtio/src/plugins/camel/contexts/Contexts.tsx
@@ -134,7 +134,9 @@ export const Contexts: React.FunctionComponent = () => {
             selectAllContexts(isSelecting)
           } else {
             const ctx = contexts[rowIndex]
-            onSelectContext(ctx, isSelecting)
+            if (ctx) {
+              onSelectContext(ctx, isSelecting)
+            }
           }
         }}
         canSelectAll={true}

--- a/packages/hawtio/src/plugins/camel/debug/Debug.tsx
+++ b/packages/hawtio/src/plugins/camel/debug/Debug.tsx
@@ -92,10 +92,14 @@ export const Debug: React.FunctionComponent = () => {
         setDebugPanelExpanded(false)
         return
       }
+      const suspendedBreakpoint = suspendedBkps[0]
+      if (!suspendedBreakpoint) {
+        return
+      }
 
-      setGraphSelection(suspendedBkps[0])
+      setGraphSelection(suspendedBreakpoint)
 
-      const msgs = await ds.getTracedMessages(routeNode, suspendedBkps[0])
+      const msgs = await ds.getTracedMessages(routeNode, suspendedBreakpoint)
       log.debug('onMessage ->', msgs)
 
       if (!msgs || msgs.length === 0) {
@@ -343,7 +347,10 @@ export const Debug: React.FunctionComponent = () => {
 
     if (!suspendedBreakpoints || suspendedBreakpoints.length === 0) return
 
-    await ds.stepBreakpoint(selectedNode, suspendedBreakpoints[0])
+    const suspendedBreakpoint = suspendedBreakpoints[0]
+    if (!suspendedBreakpoint) return
+
+    await ds.stepBreakpoint(selectedNode, suspendedBreakpoint)
   }
 
   const onResume = () => {

--- a/packages/hawtio/src/plugins/camel/debug/MessageDrawer.tsx
+++ b/packages/hawtio/src/plugins/camel/debug/MessageDrawer.tsx
@@ -55,6 +55,7 @@ export const MessageDrawer: React.FunctionComponent<MessageDrawerProps> = (props
     if (!props.messages || props.messages.length === 0) return <em key='header-no-messages'>No Messages</em>
 
     const message = props.messages[0]
+    if (!message) return <em key='header-no-messages'>No Messages</em>
 
     return (
       <TableComposable key={'header-' + message.uid} aria-label='Header table' variant='compact'>
@@ -80,6 +81,7 @@ export const MessageDrawer: React.FunctionComponent<MessageDrawerProps> = (props
     if (!props.messages || props.messages.length === 0) return <em key='body-no-messages'>No Messages</em>
 
     const message = props.messages[0]
+    if (!message) return <em key='body-no-messages'>No Messages</em>
     if (message.body === '[Body is null]') return <em key={'body-' + message.uid}>No Body</em>
 
     return <p key={'body-' + message.uid}>{message.body}</p>
@@ -120,7 +122,7 @@ export const MessageDrawer: React.FunctionComponent<MessageDrawerProps> = (props
       <DrawerHead>
         <div tabIndex={props.expanded ? 0 : -1} ref={panelRef}>
           <Text>
-            <em>{props.messages && props.messages.length > 0 ? props.messages[0].uid : ''}</em>
+            <em>{props.messages && props.messages.length > 0 ? props.messages[0]?.uid : ''}</em>
           </Text>
           <Nav
             onSelect={onSelectTab}

--- a/packages/hawtio/src/plugins/camel/debug/debug-service.test.ts
+++ b/packages/hawtio/src/plugins/camel/debug/debug-service.test.ts
@@ -35,7 +35,7 @@ jolokiaService.execute = jest.fn(async (mbean: string, operation: string, args?:
 jolokiaService.readAttributes = jest.fn(async (mbean: string): Promise<AttributeValues> => {
   const values: AttributeValues = {}
 
-  const uri = mbean.split('name=')[1].replace(/"/g, '')
+  const uri = mbean.split('name=')[1]?.replace(/"/g, '')
   values.EndpointUri = uri
   values.state = 'started'
 

--- a/packages/hawtio/src/plugins/camel/endpoints/BrowseMessages.test.tsx
+++ b/packages/hawtio/src/plugins/camel/endpoints/BrowseMessages.test.tsx
@@ -49,9 +49,9 @@ describe('BrowseMessages.tsx', () => {
     await waitFor(() => {
       const messageDetails = screen.getByTestId('message-details')
       expect(messageDetails).toBeInTheDocument()
-      headerKey = within(messageDetails).getByText(message.headers[0].key)
-      headerValue = within(messageDetails).getByText(message.headers[0].value)
-      headerType = within(messageDetails).getByText(message.headers[0].type)
+      headerKey = within(messageDetails).getByText(message.headers[0]?.key as string)
+      headerValue = within(messageDetails).getByText(message.headers[0]?.value as string)
+      headerType = within(messageDetails).getByText(message.headers[0]?.type as string)
     })
 
     expect(headerKey).toBeInTheDocument()
@@ -79,14 +79,14 @@ describe('BrowseMessages.tsx', () => {
     const message = getMockedMessages()[0]
     let element
     await waitFor(() => {
-      element = screen.getByText(message.messageId)
+      element = screen.getByText(message?.messageId as string)
     })
     expect(element).toBeInTheDocument()
     if (element) {
       await userEvent.click(element)
     }
     // Check if the modal is open and the message ID is displayed
-    await testMessageDetails(message)
+    await testMessageDetails(message as MessageData)
   })
 
   test('Messages can be browsed from details modal', async () => {
@@ -94,7 +94,7 @@ describe('BrowseMessages.tsx', () => {
     const messages = getMockedMessages()
     let element
     await waitFor(() => {
-      element = screen.getByText(messages[0].messageId)
+      element = screen.getByText(messages[0]?.messageId as string)
     })
     expect(element).toBeInTheDocument()
     if (element) {
@@ -108,10 +108,10 @@ describe('BrowseMessages.tsx', () => {
       const button = screen.getByTestId(btn)
       expect(button).toBeInTheDocument()
       await userEvent.click(button)
-      await testMessageDetails(messages[messageIndex])
+      await testMessageDetails(messages[messageIndex] as MessageData)
     }
     // Check if the modal is open and the message ID is displayed
-    await testMessageDetails(messages[0])
+    await testMessageDetails(messages[0] as MessageData)
 
     await testButtonActions('next-message-button', 1)
     await testButtonActions('previous-message-button', 0)
@@ -128,7 +128,7 @@ describe('BrowseMessages.tsx', () => {
     expect(element).toBeInTheDocument()
     expect(element).toBeDisabled()
     // Select the first message
-    await userEvent.click(screen.getAllByRole('checkbox')[1])
+    await userEvent.click(screen.getAllByRole('checkbox')[1] as HTMLElement)
     expect(element).not.toBeDisabled()
 
     // Click on the forward button
@@ -146,18 +146,18 @@ describe('BrowseMessages.tsx', () => {
     })
 
     //check select-all and test
-    if (checkBoxes.length > 0) await userEvent.click(checkBoxes[0])
+    if (checkBoxes.length > 0) await userEvent.click(checkBoxes[0] as HTMLElement)
     checkBoxes.forEach(e => {
       expect(e).toBeChecked()
     })
 
-    if (checkBoxes.length > 0) await userEvent.click(checkBoxes[0])
+    if (checkBoxes.length > 0) await userEvent.click(checkBoxes[0] as HTMLElement)
     checkBoxes.forEach(e => {
       expect(e).not.toBeChecked()
     })
     expect(checkBoxes[0]).not.toBeChecked()
     for (let i = 1; i < checkBoxes.length; i++) {
-      await userEvent.click(checkBoxes[i])
+      await userEvent.click(checkBoxes[i] as HTMLElement)
     }
     expect(checkBoxes[0]).toBeChecked()
   })
@@ -174,6 +174,6 @@ describe('BrowseMessages.tsx', () => {
     expect(checkBoxes.length).toBe(2)
 
     expect(screen.getByText('anotherBody')).toBeInTheDocument()
-    expect(screen.queryByText(getMockedMessages()[0].body)).not.toBeInTheDocument()
+    expect(screen.queryByText(getMockedMessages()[0]?.body as string)).not.toBeInTheDocument()
   })
 })

--- a/packages/hawtio/src/plugins/camel/endpoints/BrowseMessages.tsx
+++ b/packages/hawtio/src/plugins/camel/endpoints/BrowseMessages.tsx
@@ -114,8 +114,8 @@ export const BrowseMessages: React.FunctionComponent = () => {
     return filteredMessages.slice(getFromIndex(), getToIndex())
   }
 
-  const handleNextMessage = (index: number): MessageData => {
-    return filteredMessages[index]
+  const handleNextMessage = (index: number): MessageData | null => {
+    return filteredMessages[index] ?? null
   }
 
   const getSubstring = (body: string): string => {
@@ -358,7 +358,7 @@ const MessageDetails: React.FunctionComponent<{
   mid: string
   index: number
   maxValue: number
-  getMessage: (index: number) => MessageData
+  getMessage: (index: number) => MessageData | null
   forwardMessages: (uri: string, message?: MessageData) => void
   endpoints: string[]
 }> = ({ message, mid, index, maxValue, getMessage, forwardMessages, endpoints }) => {
@@ -374,8 +374,10 @@ const MessageDetails: React.FunctionComponent<{
 
   const switchToMessage = (index: number) => {
     const message = getMessage(index)
-    setCurrentMessage(message)
-    setCurrentIndex(index)
+    if (message) {
+      setCurrentMessage(message)
+      setCurrentIndex(index)
+    }
   }
   const MessageHeader = () => {
     return (

--- a/packages/hawtio/src/plugins/camel/endpoints/EndpointParametersForm.tsx
+++ b/packages/hawtio/src/plugins/camel/endpoints/EndpointParametersForm.tsx
@@ -75,26 +75,26 @@ export const EndpointParametersForm: React.FunctionComponent = () => {
   }
 
   const onPlus = (name: string) => {
-    let value = parseInt(ctx.endpointParameters[name])
+    let value = parseInt(ctx.endpointParameters[name] ?? '')
 
     if (Number.isNaN(value)) {
-      value = parseInt(properties[name].defaultValue)
+      value = parseInt(properties[name]?.defaultValue ?? '')
       if (Number.isNaN(value)) value = 0
     } else {
-      value = parseInt(ctx.endpointParameters[name])
+      value = parseInt(ctx.endpointParameters[name] ?? '')
     }
 
     onSetPropValue(name, value + 1)
   }
 
   const onMinus = (name: string) => {
-    let value = parseInt(ctx.endpointParameters[name])
+    let value = parseInt(ctx.endpointParameters[name] ?? '')
 
     if (Number.isNaN(value)) {
-      value = parseInt(properties[name].defaultValue)
+      value = parseInt(properties[name]?.defaultValue ?? '')
       if (Number.isNaN(value)) value = 100
     } else {
-      value = parseInt(ctx.endpointParameters[name])
+      value = parseInt(ctx.endpointParameters[name] ?? '')
     }
 
     onSetPropValue(name, value - 1)
@@ -145,7 +145,7 @@ export const EndpointParametersForm: React.FunctionComponent = () => {
             <NumberInput
               key={index}
               inputName={propertySpec.title}
-              value={numberValue(ctx.endpointParameters[name], propertySpec.defaultValue)}
+              value={numberValue(ctx.endpointParameters[name] ?? '', propertySpec.defaultValue)}
               allowEmptyInput
               onPlus={() => onPlus(name)}
               onMinus={() => onMinus(name)}
@@ -165,7 +165,7 @@ export const EndpointParametersForm: React.FunctionComponent = () => {
             id={name + '-' + index}
             key={index}
             label={propertySpec.title}
-            isChecked={parseBoolean(ctx.endpointParameters[name])}
+            isChecked={parseBoolean(ctx.endpointParameters[name] ?? '')}
             isRequired={propertySpec.required}
             description={propertySpec.description}
             onChange={value => onSetPropValue(name, value)}
@@ -215,9 +215,7 @@ export const EndpointParametersForm: React.FunctionComponent = () => {
 
   return (
     <React.Fragment>
-      {Object.keys(properties).map((name, index) => {
-        return inputControl(name, index, properties[name])
-      })}
+      {Object.entries(properties).map(([key, value], index) => inputControl(key, index, value))}
     </React.Fragment>
   )
 }

--- a/packages/hawtio/src/plugins/camel/endpoints/EndpointStats.test.tsx
+++ b/packages/hawtio/src/plugins/camel/endpoints/EndpointStats.test.tsx
@@ -55,7 +55,7 @@ describe('EndpointStats.tsx', () => {
     renderWithContext()
     const input = within(screen.getByTestId('filter-input')).getByRole('textbox')
 
-    const statistic = getMockedStatistics()[2]
+    const statistic = getMockedStatistics()[2] as EndpointStatistics
     expect(input).toBeInTheDocument()
     await userEvent.type(input, statistic.url)
 
@@ -69,7 +69,7 @@ describe('EndpointStats.tsx', () => {
     // search acording different attribute
     const dropdown = screen.getByTestId('attribute-select-toggle')
     await userEvent.click(dropdown)
-    await userEvent.click(screen.getAllByText('Route ID')[0])
+    await userEvent.click(screen.getAllByText('Route ID')[0] as HTMLElement)
 
     await userEvent.clear(input)
     await userEvent.type(input, statistic.url)

--- a/packages/hawtio/src/plugins/camel/endpoints/EndpointsStats.tsx
+++ b/packages/hawtio/src/plugins/camel/endpoints/EndpointsStats.tsx
@@ -56,16 +56,14 @@ export const EndpointStats: React.FunctionComponent = () => {
     if (value === '') {
       filtered = [...stats]
     } else {
-      filtered = stats.filter(stat => {
-        return (stat[attribute] as string).toLowerCase().includes(value.toLowerCase())
-      })
+      filtered = stats.filter(stat => (stat[attribute] as string).toLowerCase().includes(value.toLowerCase()))
     }
 
     //filter with the rest of the filters
     filters.forEach(value => {
-      const attr = value.split(':')[0]
-      const searchTerm = value.split(':')[1]
-      filtered = filtered.filter(stat => (stat[attr] as string).toLowerCase().includes(searchTerm.toLowerCase()))
+      const attr = value.split(':')[0] ?? ''
+      const searchTerm = value.split(':')[1] ?? ''
+      filtered = filtered.filter(stat => String(stat[attr]).toLowerCase().includes(searchTerm.toLowerCase()))
     })
 
     setSearchTerm(value)

--- a/packages/hawtio/src/plugins/camel/endpoints/SendMessage.tsx
+++ b/packages/hawtio/src/plugins/camel/endpoints/SendMessage.tsx
@@ -75,14 +75,17 @@ export const SendMessage: React.FunctionComponent = () => {
 const MessageHeaders: React.FunctionComponent<{
   onHeadersChange: (headers: { name: string; value: string }[]) => void
 }> = ({ onHeadersChange }) => {
-  const [headers, setHeaders] = useState<Array<{ name: string; value: string }>>([])
+  const [headers, setHeaders] = useState<{ name: string; value: string }[]>([])
   const headersSuggestions = Object.keys(exchangeHeaders as Record<string, { type: string }>)
 
   const handleInputChange = (index: number, newValue: string, headerName: string) => {
     const updatedHeaders = [...headers]
-    updatedHeaders[index] = { ...updatedHeaders[index], [headerName]: newValue }
-    setHeaders(updatedHeaders)
-    onHeadersChange(updatedHeaders)
+    const updatedHeader = updatedHeaders[index]
+    if (updatedHeader) {
+      updatedHeaders[index] = { ...updatedHeader, [headerName]: newValue }
+      setHeaders(updatedHeaders)
+      onHeadersChange(updatedHeaders)
+    }
   }
   const handleAddHeader = () => {
     const updatedHeaders = [...headers, { name: '', value: '' }]

--- a/packages/hawtio/src/plugins/camel/endpoints/endpoints-service.test.ts
+++ b/packages/hawtio/src/plugins/camel/endpoints/endpoints-service.test.ts
@@ -26,7 +26,7 @@ jolokiaService.execute = jest.fn(async (mbean: string, operation: string, args?:
 jolokiaService.readAttributes = jest.fn(async (mbean: string): Promise<AttributeValues> => {
   const values: AttributeValues = {}
 
-  const uri = mbean.split('name=')[1].replace(/"/g, '')
+  const uri = mbean.split('name=')[1]?.replace(/"/g, '')
   values.EndpointUri = uri
   values.state = 'started'
 

--- a/packages/hawtio/src/plugins/camel/endpoints/endpoints-service.ts
+++ b/packages/hawtio/src/plugins/camel/endpoints/endpoints-service.ts
@@ -291,7 +291,7 @@ function parseMessagesFromXml(pDoc: XMLDocument): MessageData[] {
     }
     messagesData.push({
       messageId: message.getAttribute('exchangeId') ?? '',
-      body: message.getElementsByTagName('body')[0].textContent ?? '',
+      body: message.getElementsByTagName('body')[0]?.textContent ?? '',
       headers: headers,
     })
   }

--- a/packages/hawtio/src/plugins/camel/exchanges/BlockedExchanges.test.tsx
+++ b/packages/hawtio/src/plugins/camel/exchanges/BlockedExchanges.test.tsx
@@ -130,11 +130,12 @@ describe('BlockedExchanges', () => {
 
     const data = screen.getAllByRole('cell')
     expect(data.length).toBe(6)
-    expect(data[0]).toHaveTextContent(xchgs[0].exchangeId)
-    expect(data[1]).toHaveTextContent(xchgs[0].routeId)
-    expect(data[2]).toHaveTextContent(xchgs[0].nodeId)
-    expect(data[3]).toHaveTextContent(xchgs[0].duration)
-    expect(data[4]).toHaveTextContent(xchgs[0].elapsed)
+    const xchg = xchgs[0] as Exchange
+    expect(data[0]).toHaveTextContent(xchg.exchangeId)
+    expect(data[1]).toHaveTextContent(xchg.routeId)
+    expect(data[2]).toHaveTextContent(xchg.nodeId)
+    expect(data[3]).toHaveTextContent(xchg.duration)
+    expect(data[4]).toHaveTextContent(xchg.elapsed)
 
     const unblockButton = screen.getByRole('button', { name: /unblock/i })
     expect(unblockButton).toBeInTheDocument()

--- a/packages/hawtio/src/plugins/camel/exchanges/InflightExchanges.test.tsx
+++ b/packages/hawtio/src/plugins/camel/exchanges/InflightExchanges.test.tsx
@@ -136,11 +136,12 @@ describe('InflightExchanges', () => {
 
     const data = screen.getAllByRole('cell')
     expect(data.length).toBe(5)
-    expect(data[0]).toHaveTextContent(xchgs[0].exchangeId)
-    expect(data[1]).toHaveTextContent(xchgs[0].routeId)
-    expect(data[2]).toHaveTextContent(xchgs[0].nodeId)
-    expect(data[3]).toHaveTextContent(xchgs[0].duration)
-    expect(data[4]).toHaveTextContent(xchgs[0].elapsed)
+    const xchg = xchgs[0] as Exchange
+    expect(data[0]).toHaveTextContent(xchg.exchangeId)
+    expect(data[1]).toHaveTextContent(xchg.routeId)
+    expect(data[2]).toHaveTextContent(xchg.nodeId)
+    expect(data[3]).toHaveTextContent(xchg.duration)
+    expect(data[4]).toHaveTextContent(xchg.elapsed)
   })
 
   test('selected node provided with exchanges but browsing disabled', async () => {

--- a/packages/hawtio/src/plugins/camel/exchanges/exchanges-service.test.tsx
+++ b/packages/hawtio/src/plugins/camel/exchanges/exchanges-service.test.tsx
@@ -106,7 +106,7 @@ describe('exchange-service', () => {
     let resXchgs = await exs.getBlockedExchanges(contextNode)
     expect(resXchgs.length).toBe(1)
 
-    await exs.unblockExchange(contextNode, resXchgs[0])
+    await exs.unblockExchange(contextNode, resXchgs[0] as exs.Exchange)
 
     resXchgs = await exs.getBlockedExchanges(contextNode)
     expect(resXchgs.length).toBe(0)

--- a/packages/hawtio/src/plugins/camel/icons/Icons.tsx
+++ b/packages/hawtio/src/plugins/camel/icons/Icons.tsx
@@ -13,7 +13,7 @@ for (const [key, value] of Object.entries(svg)) {
   if (key === 'IconNames') {
     continue // not applicable
   }
-  const iconName = key[0].toUpperCase() + key.substr(1) + 'Icon'
+  const iconName = (key[0]?.toUpperCase() ?? '') + key.substring(1) + 'Icon'
   elementMap.set(iconName, buildIcon(iconName, value, 16))
 }
 
@@ -41,10 +41,8 @@ export function getIcon(name: string, size?: number): JSX.Element {
       // No icon in cache so build the icon then cache it
       const iconKey = name.replace('Icon', '').toLowerCase()
       Object.entries(svg)
-        .filter(([key, value]) => {
-          return iconKey === key
-        })
-        .forEach(([key, value]) => {
+        .filter(([key, _]) => iconKey === key)
+        .forEach(([_, value]) => {
           log.debug("Building custom sized icon '" + name + "' with size '" + size + "'")
           element = buildIcon(customIconName, value, size)
           elementMap.set(customIconName, element)
@@ -52,5 +50,5 @@ export function getIcon(name: string, size?: number): JSX.Element {
     }
   }
 
-  return element ? element : (elementMap.get(IconNames.GenericIcon) as JSX.Element)
+  return element ? element : elementMap.get(IconNames.GenericIcon) ?? svg.generic
 }

--- a/packages/hawtio/src/plugins/camel/properties/properties-service.ts
+++ b/packages/hawtio/src/plugins/camel/properties/properties-service.ts
@@ -34,13 +34,13 @@ export function populateProperties(node: MBeanNode, schemaProperties: Record<str
 export function getDefinedProperties(schemaProperties: Record<string, Record<string, string>>): Property[] {
   return Object.keys(schemaProperties)
     .filter(key => {
-      const obj = schemaProperties[key]
+      const obj = schemaProperties[key] ?? {}
       return Object.keys(obj).includes('value')
     })
     .map(key => {
       const propertySchema = schemaProperties[key]
-      const name = propertySchema['title'] || key
-      return new Property(name, propertySchema['value'], propertySchema['description'])
+      const name = propertySchema?.['title'] ?? key
+      return new Property(name, propertySchema?.['value'] ?? null, propertySchema?.['description'] ?? '')
     })
     .sort(Property.sortByName)
 }
@@ -48,13 +48,13 @@ export function getDefinedProperties(schemaProperties: Record<string, Record<str
 export function getDefaultProperties(schemaProperties: Record<string, Record<string, string>>): Property[] {
   return Object.keys(schemaProperties)
     .filter(key => {
-      const obj = schemaProperties[key]
+      const obj = schemaProperties[key] ?? {}
       return !Object.keys(obj).includes('value') && Object.keys(obj).includes('defaultValue')
     })
     .map(key => {
       const propertySchema = schemaProperties[key]
-      const name = propertySchema['title'] || key
-      return new Property(name, propertySchema['defaultValue'], propertySchema['description'])
+      const name = propertySchema?.['title'] ?? key
+      return new Property(name, propertySchema?.['defaultValue'] ?? null, propertySchema?.['description'] ?? '')
     })
     .sort(Property.sortByName)
 }
@@ -62,13 +62,13 @@ export function getDefaultProperties(schemaProperties: Record<string, Record<str
 export function getUndefinedProperties(schemaProperties: Record<string, Record<string, string>>): Property[] {
   return Object.keys(schemaProperties)
     .filter(key => {
-      const obj = schemaProperties[key]
+      const obj = schemaProperties[key] ?? {}
       return !Object.keys(obj).includes('value') && !Object.keys(obj).includes('defaultValue')
     })
     .map(key => {
       const propertySchema = schemaProperties[key]
-      const name = propertySchema['title'] || key
-      return new Property(name, null, propertySchema['description'])
+      const name = propertySchema?.['title'] ?? key
+      return new Property(name, null, propertySchema?.['description'] ?? '')
     })
     .sort(Property.sortByName)
 }

--- a/packages/hawtio/src/plugins/camel/rest-services/RestServices.tsx
+++ b/packages/hawtio/src/plugins/camel/rest-services/RestServices.tsx
@@ -43,7 +43,7 @@ export const RestServices: React.FunctionComponent = () => {
   // Set of filters created by filter control and displayed as chips
   const [filters, setFilters] = useState<TypeFilter[]>([])
   // The type of filter to be created - chosen by the Select control
-  const [filterType, setFilterType] = useState<string>(headers[0])
+  const [filterType, setFilterType] = useState(headers[0] ?? '')
   // Flag to determine whether the Select control is open or closed
   const [isFilterTypeOpen, setIsFilterTypeOpen] = useState(false)
   // The text value of the filter to be created

--- a/packages/hawtio/src/plugins/camel/route-diagram/visualization-service.test.ts
+++ b/packages/hawtio/src/plugins/camel/route-diagram/visualization-service.test.ts
@@ -15,20 +15,20 @@ describe('visualization-service', () => {
     test('nodes and edges were correctly loaded from the file', () => {
       const { camelNodes, edges } = visualizationService.loadRouteXmlNodes(sampleRoutesXml)
       expect(camelNodes.length).toBe(11)
-      expect(camelNodes[1].data.cid).toBe('choice1')
-      expect(camelNodes[1].data.label).toBe('Choice')
-      expect(camelNodes[1].id).toBe('1')
+      expect(camelNodes[1]?.data.cid).toBe('choice1')
+      expect(camelNodes[1]?.data.label).toBe('Choice')
+      expect(camelNodes[1]?.id).toBe('1')
       //find choice branches:
       const tmpEdges = edges.filter(e => e.source === '1')
       expect(tmpEdges.length).toBe(3)
       //check if otherwise is connected to choice
-      const otherwise = camelNodes.find(n => n.id === tmpEdges[2].target)
+      const otherwise = camelNodes.find(n => n.id === tmpEdges[2]?.target)
       expect(otherwise?.data.label).toBe('Otherwise')
 
-      const when1 = camelNodes.find(n => n.id === tmpEdges[0].target)
+      const when1 = camelNodes.find(n => n.id === tmpEdges[0]?.target)
       expect(when1?.data.cid).toBe('when1')
 
-      const when2 = camelNodes.find(n => n.id === tmpEdges[1].target)
+      const when2 = camelNodes.find(n => n.id === tmpEdges[1]?.target)
       expect(when2?.data.cid).toBe('when2')
 
       // check if label is parsed correctly

--- a/packages/hawtio/src/plugins/camel/routes-service.test.ts
+++ b/packages/hawtio/src/plugins/camel/routes-service.test.ts
@@ -107,9 +107,9 @@ describe('routes-service', () => {
       let childNode: MBeanNode | null = simpleRouteNode.getIndex(i)
       expect(childNode).not.toBeNull()
       childNode = childNode as MBeanNode
-      expect(childNode.id).toBe(expected[i].id)
-      expect(childNode.name).toBe(expected[i].name)
-      expect(childNode.getProperty(xmlNodeLocalName)).toBe(expected[i].localName)
+      expect(childNode.id).toBe(expected[i]?.id)
+      expect(childNode.name).toBe(expected[i]?.name)
+      expect(childNode.getProperty(xmlNodeLocalName)).toBe(expected[i]?.localName)
       expect(childNode.getChildren().length).toBe(0)
       expect(childNode.icon).not.toBeNull()
       render(childNode.icon as React.ReactElement)

--- a/packages/hawtio/src/plugins/camel/routes-service.ts
+++ b/packages/hawtio/src/plugins/camel/routes-service.ts
@@ -90,9 +90,7 @@ class RoutesService {
       iname = iname.replace('-icon', '') // Remove -icon suffix
       iname = iname.replace('icon', '') // Remove remaining icon suffix
       iname = iname.charAt(0).toUpperCase() + iname.slice(1) // Capitalize
-      iname = iname.replace(/-([a-z])/g, (g: string) => {
-        return g[1].toUpperCase()
-      })
+      iname = iname.replace(/-([a-z])/g, s => s[1]?.toUpperCase() ?? s)
       iname = `${iname}Icon`
 
       //

--- a/packages/hawtio/src/plugins/camel/trace/Trace.tsx
+++ b/packages/hawtio/src/plugins/camel/trace/Trace.tsx
@@ -64,6 +64,8 @@ export const Trace: React.FunctionComponent = () => {
     const newMsgs = []
     for (let idx = allMessages.length - 1; idx >= 0; --idx) {
       const message = allMessages[idx]
+      if (!message) continue
+
       const routeId = childText(message, 'routeId')
       if (routeId !== routeNode.name) continue
 
@@ -158,8 +160,9 @@ export const Trace: React.FunctionComponent = () => {
 
   const onRowSelected = (message: MessageData) => {
     let nodeId = message.toNode ? message.toNode : ''
-    if (nodeId === selectedNode?.name) {
-      nodeId = graphNodeData[0].cid
+    const firstData = graphNodeData[0]
+    if (nodeId === selectedNode?.name && firstData) {
+      nodeId = firstData.cid
     }
 
     setMessage(message)

--- a/packages/hawtio/src/plugins/connect/connect-service.ts
+++ b/packages/hawtio/src/plugins/connect/connect-service.ts
@@ -72,7 +72,7 @@ class ConnectService implements IConnectService {
 
   getConnection(name: string): Connection | null {
     const connections = this.loadConnections()
-    return connections[name]
+    return connections[name] ?? null
   }
 
   connectionToUrl(connection: Connection): string {

--- a/packages/hawtio/src/plugins/jmx/JmxContent.tsx
+++ b/packages/hawtio/src/plugins/jmx/JmxContent.tsx
@@ -92,7 +92,7 @@ export const JmxContent: React.FunctionComponent = () => {
         <React.Fragment>
           <Routes>
             {mbeanRoutes}
-            <Route key='root' path='/' element={<Navigate to={navItems[0].id} />} />
+            <Route key='root' path='/' element={<Navigate to={navItems[0]?.id ?? ''} />} />
           </Routes>
         </React.Fragment>
       </PageSection>

--- a/packages/hawtio/src/plugins/rbac/rbac-service.ts
+++ b/packages/hawtio/src/plugins/rbac/rbac-service.ts
@@ -24,9 +24,10 @@ class RBACService implements IRBACService {
       return ''
     }
 
-    if (mbeans.length === 1) {
-      log.info('Use MBean', mbeans[0], 'for client-side RBAC')
-      return mbeans[0]
+    const mbean = mbeans[0]
+    if (mbean && mbeans.length === 1) {
+      log.info('Use MBean', mbean, 'for client-side RBAC')
+      return mbean
     }
 
     // mbeans > 1

--- a/packages/hawtio/src/plugins/shared/chart/Chart.tsx
+++ b/packages/hawtio/src/plugins/shared/chart/Chart.tsx
@@ -71,13 +71,16 @@ export const Chart: React.FunctionComponent = () => {
     if (!chartData[mbeanObjectName]) chartData[mbeanObjectName] = []
 
     // Don't add repeated responses to avoid duplicate points
-    if (!chartData[mbeanObjectName].find(value => value.time === data.time)) chartData[mbeanObjectName]?.push(data)
+    if (!chartData[mbeanObjectName]?.find(value => value.time === data.time)) {
+      chartData[mbeanObjectName]?.push(data)
+    }
 
     if (!attributesToWatch.current[data.name]) {
       attributesToWatch.current[data.name] = {}
     }
 
-    updateNumericAttributesToWatch(attributesToWatch.current[data.name], data.data)
+    const current = attributesToWatch.current[data.name] ?? {}
+    updateNumericAttributesToWatch(current, data.data)
 
     setChartData({ ...chartData })
     attributesToWatch.current = { ...attributesToWatch.current }
@@ -235,19 +238,23 @@ export const Chart: React.FunctionComponent = () => {
                 .filter(([_, isShown]) => isShown)
                 .map(([attributeName, _]) => [name, attributeName]),
             )
-            .map(([name, attributeName]) => (
-              <AttributeChart
-                key={`${name} ${attributeName}`}
-                name={`${name} ${attributeName}`}
-                data={[
-                  ...(chartData[name] ?? []).map(value => ({
-                    name: new Date(value.time * 1000).toLocaleTimeString(),
-                    x: value.time,
-                    y: (value.data[attributeName] as number) ?? 0,
-                  })),
-                ]}
-              />
-            ))}
+            .map(
+              ([name, attributeName]) =>
+                name &&
+                attributeName && (
+                  <AttributeChart
+                    key={`${name} ${attributeName}`}
+                    name={`${name} ${attributeName}`}
+                    data={[
+                      ...(chartData[name] ?? []).map(value => ({
+                        name: new Date(value.time * 1000).toLocaleTimeString(),
+                        x: value.time,
+                        y: (value.data[attributeName] as number) ?? 0,
+                      })),
+                    ]}
+                  />
+                ),
+            )}
         </CardBody>
       </Card>
     </React.Fragment>

--- a/packages/hawtio/src/plugins/shared/tree/node.test.ts
+++ b/packages/hawtio/src/plugins/shared/tree/node.test.ts
@@ -104,7 +104,7 @@ describe('MBeanNode', () => {
     const node2 = new MBeanNode(null, 'test.node', false)
     node2.populateMBean('context=SampleContext,type=context,name="SampleCamel"', mbean)
 
-    const child2 = node2.children?.[0].children?.[0].children?.[0]
+    const child2 = node2.children?.[0]?.children?.[0]?.children?.[0]
     expect(child2?.name).toEqual('SampleCamel')
     expect(child2?.mbean).toBe(mbean)
     expect(child2?.icon).toBe(Icons.locked)

--- a/packages/hawtio/src/plugins/shared/tree/tree.ts
+++ b/packages/hawtio/src/plugins/shared/tree/tree.ts
@@ -1,7 +1,7 @@
 import { escapeTags } from '@hawtiosrc/util/jolokia'
 import { stringSorter } from '@hawtiosrc/util/strings'
 import { log } from '../globals'
-import { FilterFn, ForEachFn, MBeanNode, OptimisedJmxDomain, OptimisedJmxDomains } from './node'
+import { FilterFn, MBeanNode, OptimisedJmxDomain, OptimisedJmxDomains } from './node'
 import { treeProcessorRegistry } from './processor-registry'
 
 /**
@@ -128,7 +128,7 @@ export class MBeanTree {
     return answer
   }
 
-  private descendentByPathEntry(pathEntry: string): MBeanNode | null {
+  private descendByPathEntry(pathEntry: string): MBeanNode | null {
     return this.findDescendant(node => {
       const match = node.name === pathEntry || node.matches({ name: pathEntry })
       return match
@@ -137,7 +137,11 @@ export class MBeanTree {
 
   navigate(...namePath: string[]): MBeanNode | null {
     if (namePath.length === 0) return null // path is empty so return nothing
-    const child: MBeanNode | null = this.descendentByPathEntry(namePath[0])
+
+    const name = namePath[0]
+    if (!name) return null
+
+    const child = this.descendByPathEntry(name)
     return !child ? null : child.navigate(...namePath.slice(1))
   }
 
@@ -145,10 +149,13 @@ export class MBeanTree {
    * Perform a function on each node in the given path
    * where the namePath drills down to descendants of this tree
    */
-  forEach(namePath: string[], eachFn: ForEachFn) {
+  forEach(namePath: string[], eachFn: (node: MBeanNode) => void) {
     if (namePath.length === 0) return // path empty so nothing to do
 
-    const child: MBeanNode | null = this.descendentByPathEntry(namePath[0])
+    const name = namePath[0]
+    if (!name) return
+
+    const child = this.descendByPathEntry(name)
     if (!child) return
 
     eachFn(child)

--- a/packages/hawtio/src/plugins/shared/workspace.test.ts
+++ b/packages/hawtio/src/plugins/shared/workspace.test.ts
@@ -42,26 +42,26 @@ describe('workspace', () => {
 
   test('parseMBean', () => {
     const testdata = [
-      { on: 'jolokia:type=Config', r: { attributes: { type: 'Config' }, domain: 'jolokia' } },
+      { mbean: 'jolokia:type=Config', expected: { attributes: { type: 'Config' }, domain: 'jolokia' } },
       {
-        on: 'jdk.management.jfr:type=FlightRecorder',
-        r: { attributes: { type: 'FlightRecorder' }, domain: 'jdk.management.jfr' },
+        mbean: 'jdk.management.jfr:type=FlightRecorder',
+        expected: { attributes: { type: 'FlightRecorder' }, domain: 'jdk.management.jfr' },
       },
       {
-        on: 'jboss.threads:name="XNIO-1",type=thread-pool',
-        r: { attributes: { name: '"XNIO-1"', type: 'thread-pool' }, domain: 'jboss.threads' },
+        mbean: 'jboss.threads:name="XNIO-1",type=thread-pool',
+        expected: { attributes: { name: '"XNIO-1"', type: 'thread-pool' }, domain: 'jboss.threads' },
       },
       {
-        on: 'org.apache.camel:context=SampleCamelLog4J,type=context,name="SampleCamelLog4J"',
-        r: {
+        mbean: 'org.apache.camel:context=SampleCamelLog4J,type=context,name="SampleCamelLog4J"',
+        expected: {
           attributes: { context: 'SampleCamelLog4J', name: '"SampleCamelLog4J"', type: 'context' },
           domain: 'org.apache.camel',
         },
       },
     ]
 
-    for (const td of testdata) {
-      expect(workspace.parseMBean(td.on)).toEqual(td.r)
+    for (const test of testdata) {
+      expect(workspace.parseMBean(test.mbean)).toEqual(test.expected)
     }
   })
 })

--- a/packages/hawtio/src/plugins/shared/workspace.ts
+++ b/packages/hawtio/src/plugins/shared/workspace.ts
@@ -237,26 +237,23 @@ class Workspace {
     return true
   }
 
-  parseMBean(mbean: string) {
-    const answer: { domain: string; attributes: Record<string, string> } = {
-      domain: '',
-      attributes: {},
-    }
-    let parts: string[] = mbean.split(':')
+  parseMBean(mbean: string): { domain: string; attributes: Record<string, string> } {
+    let domain = ''
+    const attributes: Record<string, string> = {}
+    let parts = mbean.split(':')
     if (parts.length > 1) {
-      answer.domain = parts[0]
-      parts = parts.filter((v: string) => v !== answer.domain)
+      domain = parts[0] ?? ''
+      parts = parts.filter(p => p !== domain)
       const parts2 = parts.join(':')
-      answer.attributes = {}
       const nameValues = parts2.split(',')
-      nameValues.forEach((p: string) => {
-        let nameValue = p.split('=')
-        const name = nameValue[0].trim()
-        nameValue = nameValue.filter((v: string) => v !== name)
-        answer.attributes[name] = nameValue.join('=').trim()
+      nameValues.forEach(nv => {
+        let nameValue = nv.split('=')
+        const name = nameValue[0]?.trim() ?? ''
+        nameValue = nameValue.filter(nv => nv !== name)
+        attributes[name] = nameValue.join('=').trim()
       })
     }
-    return answer
+    return { domain, attributes }
   }
 }
 

--- a/packages/hawtio/src/preferences/LogsPreferences.tsx
+++ b/packages/hawtio/src/preferences/LogsPreferences.tsx
@@ -56,7 +56,10 @@ const LOG_LEVEL_OPTIONS = ['OFF', 'ERROR', 'WARN', 'INFO', 'DEBUG'] as const
 const GlobalForms: React.FunctionComponent = () => {
   const [logLevel, setLogLevel] = useState(Logger.getLevel().name)
 
-  const handleLogLevelChange = (level: string) => {
+  const handleLogLevelChange = (level?: string) => {
+    if (!level) {
+      return
+    }
     setLogLevel(level)
     Logger.setLevel(level)
   }
@@ -129,7 +132,10 @@ const ChildLoggerItem: React.FunctionComponent<ChildLoggerItemProps> = props => 
 
   const name = logger.name
 
-  const onLogLevelChange = (level: string) => {
+  const onLogLevelChange = (level?: string) => {
+    if (!level) {
+      return
+    }
     Logger.updateChildLogger(logger.name, level)
     reloadChildLoggers()
   }

--- a/packages/hawtio/src/preferences/registry.test.tsx
+++ b/packages/hawtio/src/preferences/registry.test.tsx
@@ -9,9 +9,9 @@ describe('preferencesRegistry', () => {
     expect(preferencesRegistry.getPreferences()).toEqual([])
     preferencesRegistry.add('test', 'Test', () => <React.Fragment />)
     expect(preferencesRegistry.getPreferences()).toHaveLength(1)
-    expect(preferencesRegistry.getPreferences()[0].id).toEqual('test')
-    expect(preferencesRegistry.getPreferences()[0].title).toEqual('Test')
-    expect(preferencesRegistry.getPreferences()[0].component).not.toBeNull()
+    expect(preferencesRegistry.getPreferences()[0]?.id).toEqual('test')
+    expect(preferencesRegistry.getPreferences()[0]?.title).toEqual('Test')
+    expect(preferencesRegistry.getPreferences()[0]?.component).not.toBeNull()
 
     // duplicate preferences not allowed
     expect(() => preferencesRegistry.add('test', 'Test', () => <React.Fragment />)).toThrowError(

--- a/packages/hawtio/src/util/cookies.ts
+++ b/packages/hawtio/src/util/cookies.ts
@@ -4,5 +4,5 @@ export function getCookie(name: string): string | null {
   }
   const cookies = document.cookie.split(';')
   const cookie = cookies.map(cookie => cookie.split('=')).find(cookie => cookie.length > 1 && cookie[0] === name)
-  return cookie ? cookie[1] : null
+  return cookie?.[1] ?? null
 }

--- a/packages/hawtio/tsconfig.json
+++ b/packages/hawtio/tsconfig.json
@@ -15,6 +15,7 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,
+    "noUncheckedIndexedAccess": true,
     "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,


### PR DESCRIPTION
Enabling
```
"noUncheckedIndexedAccess": true,
```
at tsconfig.json, which means we should handle cases where `record[key]` might return `undefined` everytime. It should lead us to safer coding.