### PR TITLE
feat(camel): support multi Camel versions v3 & v4

### DIFF
--- a/packages/hawtio/package.json
+++ b/packages/hawtio/package.json
@@ -32,7 +32,8 @@
     "prepack": "yarn build && yarn replace-version"
   },
   "dependencies": {
-    "@hawtio/camel-model": "^3.20.6",
+    "@hawtio/camel-model-v3": "npm:@hawtio/camel-model@^3.21.0",
+    "@hawtio/camel-model-v4": "npm:@hawtio/camel-model@^4.0.0-rc.1",
     "@module-federation/utilities": "^2.0.4",
     "@patternfly/react-charts": "^6.94.19",
     "@patternfly/react-code-editor": "^4.82.113",

--- a/packages/hawtio/src/plugins/camel/camel-service.test.ts
+++ b/packages/hawtio/src/plugins/camel/camel-service.test.ts
@@ -1,3 +1,5 @@
+import * as camel3 from '@hawtio/camel-model-v3'
+import * as camel4 from '@hawtio/camel-model-v4'
 import { MBeanNode } from '@hawtiosrc/plugins/shared/tree'
 import * as camelService from './camel-service'
 import { contextNodeType, endpointNodeType, endpointsType, jmxDomain } from './globals'
@@ -5,7 +7,7 @@ import { contextNodeType, endpointNodeType, endpointsType, jmxDomain } from './g
 jest.mock('@hawtiosrc/plugins/shared/jolokia-service')
 
 describe('camel-service', () => {
-  test('syncChildProperties', async () => {
+  test('setChildProperties', async () => {
     const domainNode = new MBeanNode(null, jmxDomain, true)
     const endpointsNode = domainNode.create(endpointsType, true)
 
@@ -33,6 +35,34 @@ describe('camel-service', () => {
       expect(child.getType()).toBe(endpointNodeType)
       expect(child.getProperty('domain')).toBe(jmxDomain)
     }
+  })
+
+  test('getCamelModel', () => {
+    const camel3Node = new MBeanNode(null, 'test-context-camel3', true)
+    camel3Node.addProperty('domain', jmxDomain)
+    camel3Node.setType(contextNodeType)
+    camel3Node.addProperty('version', '3.21.0')
+    const camel3Model = camelService.getCamelModel(camel3Node)
+    expect(camel3Model).toBeDefined()
+    expect(camel3Model.apacheCamelModelVersion).toBe(camel3.apacheCamelModelVersion)
+    expect(camel3Model.components.components).not.toBeUndefined()
+    expect(camel3Model.dataformats.dataformats).not.toBeUndefined()
+    expect(camel3Model.definitions.definitions).not.toBeUndefined()
+    expect(camel3Model.languages.languages).not.toBeUndefined()
+    expect(camel3Model.rests.rests).not.toBeUndefined()
+
+    const camel4Node = new MBeanNode(null, 'test-context-camel4', true)
+    camel4Node.addProperty('domain', jmxDomain)
+    camel4Node.setType(contextNodeType)
+    camel4Node.addProperty('version', '4.0.0')
+    const camel4Model = camelService.getCamelModel(camel4Node)
+    expect(camel4Model).toBeDefined()
+    expect(camel4Model.apacheCamelModelVersion).toBe(camel4.apacheCamelModelVersion)
+    expect(camel4Model.components.components).not.toBeUndefined()
+    expect(camel4Model.dataformats.dataformats).not.toBeUndefined()
+    expect(camel4Model.definitions.definitions).not.toBeUndefined()
+    expect(camel4Model.languages.languages).not.toBeUndefined()
+    expect(camel4Model.rests.rests).not.toBeUndefined()
   })
 
   test('compareVersions', () => {
@@ -66,60 +96,21 @@ describe('camel-service', () => {
   })
 
   test('isCamelVersionEQGT', () => {
-    const ctxNode = new MBeanNode(null, 'sampleapp', true)
+    const ctxNode = new MBeanNode(null, 'sample app', true)
     camelService.setDomain(ctxNode)
     ctxNode.setType(contextNodeType)
 
-    let versions = [
-      { v: '2.12', r: false },
-      { v: '2.13', r: true },
-      { v: '2.14', r: true },
-      { v: '2.15', r: true },
-      { v: '2.16', r: true },
-      { v: '2.17', r: true },
+    const versions = [
+      { v: '3.21.0', r: false },
+      { v: '3.22.0-Beta1', r: false },
+      { v: '4.0.0-RC1', r: true },
+      { v: '4.0.0', r: true },
+      { v: '4.1.0', r: true },
+      { v: '5.0.0', r: true },
     ]
     for (const version of versions) {
       ctxNode.addProperty('version', version.v)
-      expect(camelService.isCamelVersionEQGT_2_13(ctxNode)).toBe(version.r)
-    }
-
-    versions = [
-      { v: '2.12', r: false },
-      { v: '2.13', r: false },
-      { v: '2.14', r: true },
-      { v: '2.15', r: true },
-      { v: '2.16', r: true },
-      { v: '2.17', r: true },
-    ]
-    for (const version of versions) {
-      ctxNode.addProperty('version', version.v)
-      expect(camelService.isCamelVersionEQGT_2_14(ctxNode)).toBe(version.r)
-    }
-
-    versions = [
-      { v: '2.12', r: false },
-      { v: '2.13', r: false },
-      { v: '2.14', r: false },
-      { v: '2.15', r: true },
-      { v: '2.16', r: true },
-      { v: '2.17', r: true },
-    ]
-    for (const version of versions) {
-      ctxNode.addProperty('version', version.v)
-      expect(camelService.isCamelVersionEQGT_2_15(ctxNode)).toBe(version.r)
-    }
-
-    versions = [
-      { v: '2.12', r: false },
-      { v: '2.13', r: false },
-      { v: '2.14', r: false },
-      { v: '2.15', r: false },
-      { v: '2.16', r: true },
-      { v: '2.17', r: true },
-    ]
-    for (const version of versions) {
-      ctxNode.addProperty('version', version.v)
-      expect(camelService.isCamelVersionEQGT_2_16(ctxNode)).toBe(version.r)
+      expect(camelService.isCamelVersionEQGT(ctxNode, 4, 0)).toBe(version.r)
     }
   })
 })

--- a/packages/hawtio/src/plugins/camel/endpoints/AddEndpointWizard.tsx
+++ b/packages/hawtio/src/plugins/camel/endpoints/AddEndpointWizard.tsx
@@ -31,7 +31,9 @@ export const AddEndpointWizard: React.FunctionComponent = () => {
     if (!selectedNode || !ctx.componentName) return
 
     const schema = es.loadEndpointSchema(selectedNode, ctx.componentName)
-    ctx.setComponentSchema(schema as Record<string, unknown>)
+    if (schema) {
+      ctx.setComponentSchema(schema)
+    }
 
     /*
      * lint reporting that ctx should be a dependency which it really doesn't

--- a/packages/hawtio/src/plugins/camel/endpoints/SendMessage.tsx
+++ b/packages/hawtio/src/plugins/camel/endpoints/SendMessage.tsx
@@ -23,6 +23,7 @@ import xmlFormat from 'xml-formatter'
 import { CamelContext } from '../context'
 import { InputWithSuggestions } from './InputWithSuggestions'
 import { doSendMessage } from './endpoints-service'
+// TODO: Parameterise the version of Camel mode for the exchange headers
 import { headers as exchangeHeaders } from './exchange-headers-camel-model.json'
 
 export const SendMessage: React.FunctionComponent = () => {

--- a/packages/hawtio/src/plugins/camel/endpoints/context.ts
+++ b/packages/hawtio/src/plugins/camel/endpoints/context.ts
@@ -1,4 +1,5 @@
 import { createContext, useState } from 'react'
+import { CamelModelSchema } from '../camel-service'
 
 export function useAddEndpointContext() {
   const [addEndpoint, showAddEndpoint] = useState(false)
@@ -31,7 +32,7 @@ type AddEndpointContext = {
   componentName: string
   setComponentName: (names: string) => void
   componentSchema: Record<string, unknown>
-  setComponentSchema: (componentSchema: Record<string, unknown>) => void
+  setComponentSchema: (componentSchema: CamelModelSchema) => void
   endpointPath: string
   setEndpointPath: (endPointPath: string) => void
   endpointParameters: Record<string, string>

--- a/packages/hawtio/src/plugins/camel/endpoints/endpoints-service.test.ts
+++ b/packages/hawtio/src/plugins/camel/endpoints/endpoints-service.test.ts
@@ -60,8 +60,8 @@ describe('endpoints-service', () => {
 
     const timerSchema = es.loadEndpointSchema(contextNode, 'timer') as Record<string, unknown>
     expect(timerSchema).not.toBeNull()
-    expect(timerSchema['type']).toBe('object')
-    expect(timerSchema['title']).toBe('Timer')
+    expect(timerSchema.type).toBe('object')
+    expect(timerSchema.title).toBe('Timer')
     expect(isObject(timerSchema['properties'])).toBeTruthy()
   })
 })

--- a/packages/hawtio/src/plugins/camel/endpoints/endpoints-service.ts
+++ b/packages/hawtio/src/plugins/camel/endpoints/endpoints-service.ts
@@ -1,7 +1,6 @@
-import * as schema from '@hawtio/camel-model'
 import { eventService, NotificationType } from '@hawtiosrc/core'
 import { jolokiaService, MBeanNode, workspace } from '@hawtiosrc/plugins/shared'
-import { isObject } from '@hawtiosrc/util/objects'
+import { isBlank } from '@hawtiosrc/util/strings'
 import { parseXML } from '@hawtiosrc/util/xml'
 import * as camelService from '../camel-service'
 import { getDefaultRuntimeEndpointRegistry } from '../camel-service'
@@ -148,7 +147,7 @@ export function createEndpointFromData(
   createEndpoint(node, uri)
 }
 
-export function loadEndpointSchema(node: MBeanNode, componentName: string): Record<string, unknown> | null {
+export function loadEndpointSchema(node: MBeanNode, componentName: string): camelService.CamelModelSchema | null {
   const ctxNode = camelService.findContext(node)
   if (!ctxNode) {
     eventService.notify({
@@ -157,15 +156,10 @@ export function loadEndpointSchema(node: MBeanNode, componentName: string): Reco
     })
     return null
   }
+  if (isBlank(componentName)) return null
 
-  if (!componentName) return null
-
-  if (!schema) return null
-
-  if (!isObject(schema.components)) return null
-
-  const compSchema: Record<string, unknown> = schema.components.components
-  return compSchema[componentName] as Record<string, unknown>
+  const camelModel = camelService.getCamelModel(ctxNode)
+  return camelModel.components.components[componentName] ?? null
 }
 
 export async function doSendMessage(

--- a/packages/hawtio/src/plugins/camel/index.ts
+++ b/packages/hawtio/src/plugins/camel/index.ts
@@ -1,9 +1,9 @@
-import { apacheCamelModelVersion } from '@hawtio/camel-model'
 import { hawtio, HawtioPlugin } from '@hawtiosrc/core'
 import { helpRegistry } from '@hawtiosrc/help/registry'
 import { treeProcessorRegistry, workspace } from '@hawtiosrc/plugins/shared'
 import { preferencesRegistry } from '@hawtiosrc/preferences/registry'
 import { Camel } from './Camel'
+import { getCamelVersions } from './camel-service'
 import { CamelPreferences } from './CamelPreferences'
 import { jmxDomain, log, pluginPath } from './globals'
 import help from './help.md'
@@ -24,5 +24,5 @@ export const camel: HawtioPlugin = () => {
   helpRegistry.add('camel', 'Camel', help, 13)
   preferencesRegistry.add('camel', 'Camel', CamelPreferences, 13)
 
-  log.info('Using Camel version:', apacheCamelModelVersion)
+  log.info('Using Camel versions:', getCamelVersions())
 }

--- a/packages/hawtio/src/plugins/camel/properties/Properties.tsx
+++ b/packages/hawtio/src/plugins/camel/properties/Properties.tsx
@@ -41,7 +41,7 @@ export const Properties: React.FunctionComponent = () => {
     const init = async () => {
       const localName: string = selectedNode.getProperty(xmlNodeLocalName)
       const schemaKey = localName ? localName : selectedNode.name
-      const schema = schemaService.getSchema(schemaKey)
+      const schema = schemaService.getSchema(selectedNode, schemaKey)
 
       let newTitle = localName
       let newIcon = selectedNode.icon
@@ -50,7 +50,7 @@ export const Properties: React.FunctionComponent = () => {
 
       if (schema) {
         newTitle = schema['title'] as string
-        newIcon = routesService.getIcon(schema, 24)
+        newIcon = routesService.getIcon(selectedNode, schema, 24)
         newDescription = schema['description'] as string
         const groupStr = schema['group'] as string
         groups = groupStr.split(',')

--- a/packages/hawtio/src/plugins/camel/route-diagram/RouteDiagram.tsx
+++ b/packages/hawtio/src/plugins/camel/route-diagram/RouteDiagram.tsx
@@ -28,12 +28,16 @@ export const RouteDiagram: React.FunctionComponent = () => {
   const nodeTypes = useMemo(() => ({ camel: CamelNode }), [])
 
   useEffect(() => {
-    const xml = selectedNode?.getProperty('xml')
+    if (!selectedNode) {
+      return
+    }
+
+    const xml = selectedNode.getProperty('xml')
     if (!xml) {
       return
     }
 
-    const { camelNodes, edges } = visualizationService.loadRouteXmlNodes(xml)
+    const { camelNodes, edges } = visualizationService.loadRouteXmlNodes(selectedNode, xml)
 
     setGraphNodeData(camelNodes.map(camelNode => camelNode.data))
 

--- a/packages/hawtio/src/plugins/camel/route-diagram/visualization-service.test.ts
+++ b/packages/hawtio/src/plugins/camel/route-diagram/visualization-service.test.ts
@@ -2,6 +2,7 @@ import { visualizationService } from './visualization-service'
 import path from 'path'
 import fs from 'fs'
 import { RouteStats } from '@hawtiosrc/plugins/camel/routes-service'
+import { MBeanNode } from '@hawtiosrc/plugins/shared'
 
 jest.mock('@hawtiosrc/plugins/shared/jolokia-service')
 
@@ -13,7 +14,8 @@ describe('visualization-service', () => {
 
   describe('loadRouteXmlNodes', () => {
     test('nodes and edges were correctly loaded from the file', () => {
-      const { camelNodes, edges } = visualizationService.loadRouteXmlNodes(sampleRoutesXml)
+      const node = new MBeanNode(null, 'test', true)
+      const { camelNodes, edges } = visualizationService.loadRouteXmlNodes(node, sampleRoutesXml)
       expect(camelNodes.length).toBe(11)
       expect(camelNodes[1]?.data.cid).toBe('choice1')
       expect(camelNodes[1]?.data.label).toBe('Choice')
@@ -37,7 +39,8 @@ describe('visualization-service', () => {
   })
   describe('updateStats', () => {
     test('processor stats were updates on the nodes', () => {
-      const { camelNodes } = visualizationService.loadRouteXmlNodes(sampleRoutesXml)
+      const node = new MBeanNode(null, 'test', true)
+      const { camelNodes } = visualizationService.loadRouteXmlNodes(node, sampleRoutesXml)
       const nodesWithStats = visualizationService.updateStats(sampleRoutesStatsXml, camelNodes)
 
       const to2 = nodesWithStats.find(n => n.data.cid === 'to2')
@@ -66,7 +69,8 @@ describe('visualization-service', () => {
       expect(stats?.lastExchangeFailureExchangeId).toEqual('14')
     })
     test('route stats were updates on the from node', () => {
-      const { camelNodes } = visualizationService.loadRouteXmlNodes(sampleRoutesXml)
+      const node = new MBeanNode(null, 'test', true)
+      const { camelNodes } = visualizationService.loadRouteXmlNodes(node, sampleRoutesXml)
       const nodesWithStats = visualizationService.updateStats(sampleRoutesStatsXml, camelNodes)
 
       const from = nodesWithStats.find(n => n.data.type === 'from')

--- a/packages/hawtio/src/plugins/camel/routes-service.ts
+++ b/packages/hawtio/src/plugins/camel/routes-service.ts
@@ -53,13 +53,13 @@ export const ROUTE_OPERATIONS = {
 
 // TODO: This service should be named more properly like RoutesXmlService, RouteStatisticsService, etc.
 class RoutesService {
-  getIcon(nodeSettingsOrXmlNode: Record<string, unknown> | Element, size?: number): ReactNode {
+  getIcon(node: MBeanNode, nodeSettingsOrXmlNode: Record<string, unknown> | Element, size?: number): ReactNode {
     let nodeSettings: Record<string, unknown> | null = null
 
     if (nodeSettingsOrXmlNode instanceof Element) {
       const nodeName = nodeSettingsOrXmlNode.localName
       if (nodeName) {
-        nodeSettings = schemaService.getSchema(nodeName)
+        nodeSettings = schemaService.getSchema(node, nodeName)
       }
     } else {
       nodeSettings = nodeSettingsOrXmlNode
@@ -90,7 +90,7 @@ class RoutesService {
    * Populates a route step node with the given XML.
    */
   private populateStepNode(parent: MBeanNode, stepXml: Element) {
-    const nodeSettings = schemaService.getSchema(stepXml.localName)
+    const nodeSettings = schemaService.getSchema(parent, stepXml.localName)
     if (!nodeSettings) {
       return
     }
@@ -106,14 +106,17 @@ class RoutesService {
     const node = new MBeanNode(null, nodeName, false)
     node.setType(routeXmlNodeType)
     camelService.setDomain(node)
-    node.setIcons(this.getIcon(nodeSettings))
+    node.setIcons(this.getIcon(parent, nodeSettings))
 
     // TODO - tooltips to be implemented
     // updateRouteNodeLabelAndTooltip(node, route, nodeSettings)
 
+    // Adopt child before cascading to grandchildren so that the parent is traceable
+    // from the child
+    parent.adopt(node)
+
     // Cascade XML loading to the child steps
     this.loadStepXml(node, stepXml)
-    parent.adopt(node)
   }
 
   /**

--- a/packages/hawtio/src/plugins/camel/schema-service.test.ts
+++ b/packages/hawtio/src/plugins/camel/schema-service.test.ts
@@ -1,8 +1,9 @@
-import { schemaService } from './schema-service'
-import * as camelSchema from '@hawtio/camel-model'
+import * as camelService from './camel-service'
 import { isObject } from '@hawtiosrc/util/objects'
-import path from 'path'
 import fs from 'fs'
+import path from 'path'
+import { MBeanNode } from '../shared'
+import { schemaService } from './schema-service'
 
 describe('schema-service', () => {
   test('lookupDefinition type extends', () => {
@@ -33,7 +34,9 @@ describe('schema-service', () => {
   })
 
   test('lookupDefinition of routes', () => {
-    const routeDefn: Record<string, unknown> | null = schemaService.lookupDefinition('routes', camelSchema.definitions)
+    const node = new MBeanNode(null, 'test', true)
+    const camelModel = camelService.getCamelModel(node)
+    const routeDefn = schemaService.lookupDefinition('routes', camelModel.definitions)
     expect(routeDefn).not.toBeNull()
     const rd: Record<string, unknown> = routeDefn as Record<string, unknown>
     expect(rd.type).toBe('object')
@@ -43,10 +46,11 @@ describe('schema-service', () => {
   })
 
   test('getSchema nodeId', () => {
-    const routeDefn: Record<string, unknown> | null = schemaService.getSchema('routes')
+    const node = new MBeanNode(null, 'test', true)
+    const routeDefn: Record<string, unknown> | null = schemaService.getSchema(node, 'routes')
     expect(routeDefn).not.toBeNull()
 
-    const rd: Record<string, unknown> = routeDefn as Record<string, unknown>
+    const rd = routeDefn as Record<string, unknown>
     expect(rd.type).toBe('object')
     expect(rd.title).toBe('Routes')
     expect(rd.group).toBe('configuration')
@@ -64,7 +68,8 @@ describe('schema-service', () => {
       acceptOutput: 'false',
     }
 
-    const rd: Record<string, unknown> | null = schemaService.getSchema(routeDefn)
+    const node = new MBeanNode(null, 'test', true)
+    const rd = schemaService.getSchema(node, routeDefn)
     expect(rd).toBe(routeDefn)
   })
 })

--- a/packages/hawtio/src/plugins/camel/schema-service.ts
+++ b/packages/hawtio/src/plugins/camel/schema-service.ts
@@ -1,5 +1,6 @@
-import { definitions } from '@hawtio/camel-model'
-import { cloneObject, isObject } from '@hawtiosrc/util/objects'
+import { cloneObject, isObject, isString } from '@hawtiosrc/util/objects'
+import { MBeanNode } from '../shared'
+import { getCamelModel } from './camel-service'
 
 class SchemaService {
   /**
@@ -47,9 +48,9 @@ class SchemaService {
     return fullSchema
   }
 
-  getSchema(nodeIdOrDefinition: Record<string, unknown> | string): Record<string, unknown> | null {
-    if (typeof nodeIdOrDefinition === 'string' || nodeIdOrDefinition instanceof String) {
-      return this.lookupDefinition(nodeIdOrDefinition as string, definitions)
+  getSchema(node: MBeanNode, nodeIdOrDefinition: Record<string, unknown> | string): Record<string, unknown> | null {
+    if (isString(nodeIdOrDefinition)) {
+      return this.lookupDefinition(nodeIdOrDefinition, getCamelModel(node).definitions)
     } else {
       return nodeIdOrDefinition
     }

--- a/packages/hawtio/src/plugins/camel/tree-processor.test.ts
+++ b/packages/hawtio/src/plugins/camel/tree-processor.test.ts
@@ -27,7 +27,7 @@ const CAMEL_MODEL_VERSION = '3.20.2'
 jest.mock('./camel-service', () => {
   return {
     ...jest.requireActual('./camel-service'),
-    setCamelVersion: jest.fn((contextNode: MBeanNode | null) => {
+    fetchCamelVersion: jest.fn((contextNode: MBeanNode | null) => {
       if (contextNode) contextNode.addProperty('version', CAMEL_MODEL_VERSION)
     }),
   }

--- a/packages/hawtio/src/plugins/camel/tree-processor.ts
+++ b/packages/hawtio/src/plugins/camel/tree-processor.ts
@@ -106,7 +106,7 @@ export const camelTreeProcessor: TreeProcessor = async (tree: MBeanTree) => {
     newCtxNode.setType(contextNodeType)
     camelService.setDomain(newCtxNode)
     // Set the camel version as a property on the context
-    camelService.setCamelVersion(newCtxNode)
+    await camelService.fetchCamelVersion(newCtxNode)
     newCtxNode.setIcons(getIcon(IconNames.CamelIcon))
 
     const endpointsFolderIcon = getIcon(IconNames.EndpointsFolderIcon)

--- a/packages/hawtio/src/plugins/rbac/tree-processor.ts
+++ b/packages/hawtio/src/plugins/rbac/tree-processor.ts
@@ -1,6 +1,7 @@
 import { JolokiaListMethod, MBeanNode, MBeanTree, TreeProcessor, jolokiaService } from '@hawtiosrc/plugins/shared'
 import { operationToString } from '@hawtiosrc/util/jolokia'
-import { isBlank, isString } from '@hawtiosrc/util/strings'
+import { isString } from '@hawtiosrc/util/objects'
+import { isBlank } from '@hawtiosrc/util/strings'
 import { IJmxOperation, IRequest, IResponse } from 'jolokia.js'
 import { log } from './globals'
 import { rbacService } from './rbac-service'

--- a/packages/hawtio/src/plugins/shared/workspace.ts
+++ b/packages/hawtio/src/plugins/shared/workspace.ts
@@ -1,6 +1,6 @@
 import { eventService, Logger } from '@hawtiosrc/core'
 import { jolokiaService } from '@hawtiosrc/plugins/shared/jolokia-service'
-import { isString } from '@hawtiosrc/util/strings'
+import { isString } from '@hawtiosrc/util/objects'
 import { IErrorResponse, IResponse, ISimpleOptions } from 'jolokia.js'
 import { is, object } from 'superstruct'
 import { pluginName } from './globals'

--- a/packages/hawtio/src/util/objects.test.ts
+++ b/packages/hawtio/src/util/objects.test.ts
@@ -15,16 +15,19 @@ describe('objects', () => {
   })
 
   test('isString', () => {
+    expect(isString(undefined)).toBe(false)
     expect(isString(null)).toBe(false)
     expect(isString(1)).toBe(false)
     expect(isString(true)).toBe(false)
     expect(isString(false)).toBe(false)
+    expect(isString({})).toBe(false)
     const obj = { a: 'x', b: 'y', c: 'z' }
     expect(isString(obj)).toBe(false)
     const fn = () => {
       /* no-op */
     }
     expect(isString(fn)).toBe(false)
+    expect(isString('')).toBe(true)
     expect(isString('hello')).toBe(true)
   })
 

--- a/packages/hawtio/src/util/strings.test.ts
+++ b/packages/hawtio/src/util/strings.test.ts
@@ -1,16 +1,6 @@
-import { humanizeLabels, isString, parseBoolean, toString, trimQuotes } from './strings'
+import { humanizeLabels, parseBoolean, toString, trimQuotes } from './strings'
 
 describe('strings', () => {
-  test('isString', () => {
-    expect(isString(undefined)).toBe(false)
-    expect(isString(null)).toBe(false)
-    expect(isString({})).toBe(false)
-    expect(isString(true)).toBe(false)
-    expect(isString(1)).toBe(false)
-    expect(isString('')).toBe(true)
-    expect(isString('hello!')).toBe(true)
-  })
-
   test('toString', () => {
     expect(toString(null)).toEqual('{}')
     expect(toString({})).toEqual('{  }')

--- a/packages/hawtio/src/util/strings.ts
+++ b/packages/hawtio/src/util/strings.ts
@@ -1,10 +1,3 @@
-export function isString(value: unknown): value is string {
-  if (value != null && typeof value.valueOf() === 'string') {
-    return true
-  }
-  return false
-}
-
 /**
  * Return true if the string is either null or empty.
  */

--- a/yarn.lock
+++ b/yarn.lock
@@ -2398,10 +2398,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hawtio/camel-model@npm:^3.20.6":
+"@hawtio/camel-model-v3@npm:@hawtio/camel-model@^3.21.0":
   version: 3.21.0
   resolution: "@hawtio/camel-model@npm:3.21.0"
   checksum: 6e4f02eda269a0e53966fdfc126b6467ed965edb34a56a749c81fcacdb68c28644d1970e45ee0b4df1c912f664c5be99afe4ca7e3d9c7f3758b0c571d55400a2
+  languageName: node
+  linkType: hard
+
+"@hawtio/camel-model-v4@npm:@hawtio/camel-model@^4.0.0-rc.1":
+  version: 4.0.0-rc.1
+  resolution: "@hawtio/camel-model@npm:4.0.0-rc.1"
+  checksum: 8bda5090ef71fb114f0ac7ec079cf7b3b78e213444db0f6db74326052536d64d18de82bb200781c84bba700228a8ee0d5465a45ba866fb516ea11583f41902a3
   languageName: node
   linkType: hard
 
@@ -2426,7 +2433,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@hawtio/react@workspace:packages/hawtio"
   dependencies:
-    "@hawtio/camel-model": ^3.20.6
+    "@hawtio/camel-model-v3": "npm:@hawtio/camel-model@^3.21.0"
+    "@hawtio/camel-model-v4": "npm:@hawtio/camel-model@^4.0.0-rc.1"
     "@module-federation/utilities": ^2.0.4
     "@patternfly/react-charts": ^6.94.19
     "@patternfly/react-code-editor": ^4.82.113


### PR DESCRIPTION
Fix #242

This fix only switches the camel definition model between v3 and v4 based on the `camelVersion` attribute value for the selected context node. That means we can mix up different versions of Camel within a single app if we have multiple contexts. It looks like the Camel plugin implementation is flexible enough that we don't need to copy a different version of the plugin for Camel v4 support.

So from now on, all the code in Camel plugin should fetch the Camel schema model from `camelService.getCamelModel(node: MBeanNode)` and should not directly reference `@hawtio/camel-model-v3` or  `@hawtio/camel-model-v4`. This function should serve as the central point for getting the appropriate Camel model.

Please check if my assumption is not wrong.