### PR TITLE
chore: exports the auth module for use with external clients

### DIFF
--- a/packages/hawtio/src/index.ts
+++ b/packages/hawtio/src/index.ts
@@ -3,6 +3,7 @@ import { configManager } from './core'
 // Hawtio React component
 export * from './Hawtio'
 // Hawtio API
+export * from './auth'
 export * from './core'
 export * from './help'
 export * from './plugins'


### PR DESCRIPTION
This is required for hawtio-online since we need to connect the osAuthService to the userService