### PR TITLE
fix(build): fix tsconfig.json target warning from esbuild

### DIFF
--- a/packages/hawtio/tsconfig.json
+++ b/packages/hawtio/tsconfig.json
@@ -4,7 +4,6 @@
     "paths": {
       "@hawtiosrc/*": ["src/*"]
     },
-    "target": "es2015",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/packages/hawtio/tsup.config.ts
+++ b/packages/hawtio/tsup.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
+  target: 'es2015',
   dts: true,
   sourcemap: true,
   loader: {


### PR DESCRIPTION
Fix #474

@phantomjinx It appears this is enough to fix the warning. Please check.