### PR TITLE
fix(ui): HAWNG-11 custom brand logo must not be greater than height=50px

### DIFF
--- a/packages/hawtio/src/ui/page/HawtioHeader.css
+++ b/packages/hawtio/src/ui/page/HawtioHeader.css
@@ -1,3 +1,7 @@
+#hawtio-header-brand .pf-c-brand {
+  max-height: 50px;
+}
+
 #hawtio-header-toolbar .pf-c-toolbar__content-section {
   justify-content: end;
 }

--- a/packages/hawtio/src/ui/page/HawtioHeader.tsx
+++ b/packages/hawtio/src/ui/page/HawtioHeader.tsx
@@ -32,27 +32,25 @@ export const HawtioHeader: React.FunctionComponent = () => {
   const onNavToggle = () => setNavOpen(!navOpen)
 
   return (
-    <React.Fragment>
-      <Masthead display={{ default: 'inline' }}>
-        <MastheadToggle>
-          <PageToggleButton
-            variant='plain'
-            aria-label='Global navigation'
-            isNavOpen={navOpen}
-            onNavToggle={onNavToggle}
-            id='vertical-nav-toggle'
-          >
-            <BarsIcon />
-          </PageToggleButton>
-        </MastheadToggle>
-        <MastheadMain>
-          <HawtioBrand />
-        </MastheadMain>
-        <MastheadContent>
-          <HawtioHeaderToolbar />
-        </MastheadContent>
-      </Masthead>
-    </React.Fragment>
+    <Masthead id='hawtio-header' display={{ default: 'inline' }}>
+      <MastheadToggle>
+        <PageToggleButton
+          variant='plain'
+          aria-label='Global navigation'
+          isNavOpen={navOpen}
+          onNavToggle={onNavToggle}
+          id='vertical-nav-toggle'
+        >
+          <BarsIcon />
+        </PageToggleButton>
+      </MastheadToggle>
+      <MastheadMain>
+        <HawtioBrand />
+      </MastheadMain>
+      <MastheadContent>
+        <HawtioHeaderToolbar />
+      </MastheadContent>
+    </Masthead>
   )
 }
 
@@ -67,7 +65,7 @@ const HawtioBrand: React.FunctionComponent = () => {
   const appName = hawtconfig.branding?.appName || DEFAULT_APP_NAME
 
   return (
-    <MastheadBrand component={props => <Link to='/' {...props} />}>
+    <MastheadBrand id='hawtio-header-brand' component={props => <Link to='/' {...props} />}>
       <Brand src={appLogo} alt={appName} />
     </MastheadBrand>
   )


### PR DESCRIPTION
Right now, when a custom brand logo with a big size is provided via `hawtconfig.json`, it's rendered full size in the header and consumes a lot of space on the console.