### PR TITLE
refactor(shared): rename 'properties' to 'metadata' on MBeanNode

### DIFF
--- a/packages/hawtio/src/plugins/camel/camel-service.test.ts
+++ b/packages/hawtio/src/plugins/camel/camel-service.test.ts
@@ -30,18 +30,18 @@ describe('camel-service', () => {
     camelService.setChildProperties(endpointsNode, endpointNodeType)
 
     expect(endpointsNode.getType()).toBe(endpointsType)
-    expect(endpointsNode.getProperty('domain')).toBe(jmxDomain)
+    expect(endpointsNode.getMetadata('domain')).toBe(jmxDomain)
     for (const child of endpointsNode.getChildren()) {
       expect(child.getType()).toBe(endpointNodeType)
-      expect(child.getProperty('domain')).toBe(jmxDomain)
+      expect(child.getMetadata('domain')).toBe(jmxDomain)
     }
   })
 
   test('getCamelModel', () => {
     const camel3Node = new MBeanNode(null, 'test-context-camel3', true)
-    camel3Node.addProperty('domain', jmxDomain)
+    camel3Node.addMetadata('domain', jmxDomain)
     camel3Node.setType(contextNodeType)
-    camel3Node.addProperty('version', '3.21.0')
+    camel3Node.addMetadata('version', '3.21.0')
     const camel3Model = camelService.getCamelModel(camel3Node)
     expect(camel3Model).toBeDefined()
     expect(camel3Model.apacheCamelModelVersion).toBe(camel3.apacheCamelModelVersion)
@@ -52,9 +52,9 @@ describe('camel-service', () => {
     expect(camel3Model.rests.rests).not.toBeUndefined()
 
     const camel4Node = new MBeanNode(null, 'test-context-camel4', true)
-    camel4Node.addProperty('domain', jmxDomain)
+    camel4Node.addMetadata('domain', jmxDomain)
     camel4Node.setType(contextNodeType)
-    camel4Node.addProperty('version', '4.0.0')
+    camel4Node.addMetadata('version', '4.0.0')
     const camel4Model = camelService.getCamelModel(camel4Node)
     expect(camel4Model).toBeDefined()
     expect(camel4Model.apacheCamelModelVersion).toBe(camel4.apacheCamelModelVersion)
@@ -109,7 +109,7 @@ describe('camel-service', () => {
       { v: '5.0.0', r: true },
     ]
     for (const version of versions) {
-      ctxNode.addProperty('version', version.v)
+      ctxNode.addMetadata('version', version.v)
       expect(camelService.isCamelVersionEQGT(ctxNode, 4, 0)).toBe(version.r)
     }
   })

--- a/packages/hawtio/src/plugins/camel/camel-service.ts
+++ b/packages/hawtio/src/plugins/camel/camel-service.ts
@@ -82,11 +82,11 @@ export function setChildProperties(parent: MBeanNode | null, childType: string) 
 }
 
 export function setDomain(node: MBeanNode) {
-  node.addProperty('domain', jmxDomain)
+  node.addMetadata('domain', jmxDomain)
 }
 
 export function hasDomain(node: MBeanNode): boolean {
-  return node && jmxDomain === node.getProperty('domain')
+  return node && jmxDomain === node.getMetadata('domain')
 }
 
 export function hasMBean(node: MBeanNode): boolean {
@@ -318,7 +318,7 @@ export function getCamelModel(node: MBeanNode): CamelModel {
  * elsewhere.
  */
 export async function fetchCamelVersion(contextNode: MBeanNode) {
-  const version = contextNode.getProperty('version')
+  const version = contextNode.getMetadata('version')
   if (!isBlank(version)) {
     // Already retrieved
     return
@@ -330,14 +330,14 @@ export async function fetchCamelVersion(contextNode: MBeanNode) {
   }
 
   const camelVersion = (await jolokiaService.readAttribute(contextNode.objectName, 'CamelVersion')) as string
-  contextNode.addProperty('version', camelVersion)
+  contextNode.addMetadata('version', camelVersion)
 }
 
 export function getCamelVersion(node: MBeanNode): string | null {
   const ctxNode = findContext(node)
   if (!ctxNode) return null
 
-  return ctxNode.getProperty('version')
+  return ctxNode.getMetadata('version') ?? null
 }
 
 export function compareVersions(version: string, major: number, minor: number): number {

--- a/packages/hawtio/src/plugins/camel/camel-service.ts
+++ b/packages/hawtio/src/plugins/camel/camel-service.ts
@@ -86,31 +86,27 @@ export function setDomain(node: MBeanNode) {
 }
 
 export function hasDomain(node: MBeanNode): boolean {
-  return node && jmxDomain === node.getMetadata('domain')
+  return jmxDomain === node.getMetadata('domain')
 }
 
 export function hasMBean(node: MBeanNode): boolean {
-  return node && node.objectName !== undefined && isObject(node.mbean)
-}
-
-export function hasType(node: MBeanNode, type: string): boolean {
-  return node && type === node.getType()
+  return node.objectName !== undefined && isObject(node.mbean)
 }
 
 export function isDomainNode(node: MBeanNode): boolean {
-  return node && hasType(node, domainNodeType)
+  return node.getType() === domainNodeType
 }
 
 export function isContextsFolder(node: MBeanNode): boolean {
-  return node && hasDomain(node) && hasType(node, contextsType)
+  return hasDomain(node) && node.getType() === contextsType
 }
 
 export function isContext(node: MBeanNode): boolean {
-  return node && hasDomain(node) && hasType(node, contextNodeType)
+  return hasDomain(node) && node.getType() === contextNodeType
 }
 
 export function findContext(node: MBeanNode): MBeanNode | null {
-  if (!node || !hasDomain(node)) return null
+  if (!hasDomain(node)) return null
 
   if (isDomainNode(node)) {
     // The camel domain node so traverse to context folder & recurse
@@ -133,31 +129,31 @@ export function findContext(node: MBeanNode): MBeanNode | null {
 }
 
 export function isRoutesFolder(node: MBeanNode): boolean {
-  return node && hasDomain(node) && !hasMBean(node) && hasType(node, routesType)
+  return hasDomain(node) && !hasMBean(node) && node.getType() === routesType
 }
 
 export function isRouteNode(node: MBeanNode): boolean {
-  return node && hasDomain(node) && hasType(node, routeNodeType)
+  return hasDomain(node) && node.getType() === routeNodeType
 }
 
 export function isRouteXmlNode(node: MBeanNode): boolean {
-  return node && hasDomain(node) && hasType(node, routeXmlNodeType)
+  return hasDomain(node) && node.getType() === routeXmlNodeType
 }
 
 export function isEndpointsFolder(node: MBeanNode): boolean {
-  return node && hasDomain(node) && !hasMBean(node) && hasType(node, endpointsType)
+  return hasDomain(node) && !hasMBean(node) && node.getType() === endpointsType
 }
 
 export function isEndpointNode(node: MBeanNode): boolean {
-  return node && hasDomain(node) && hasType(node, endpointNodeType)
+  return hasDomain(node) && node.getType() === endpointNodeType
 }
 
 export function isComponentsFolder(node: MBeanNode): boolean {
-  return node && hasDomain(node) && !hasMBean(node) && hasType(node, componentsType)
+  return hasDomain(node) && !hasMBean(node) && node.getType() === componentsType
 }
 
 export function isComponentNode(node: MBeanNode): boolean {
-  return node && hasDomain(node) && hasType(node, componentNodeType)
+  return hasDomain(node) && node.getType() === componentNodeType
 }
 
 function findMBean(node: MBeanNode, folder: string, id: string): MBeanNode | null {
@@ -222,7 +218,6 @@ export function getDefaultRuntimeEndpointRegistry(node: MBeanNode): MBeanNode | 
 
 export function hasExchange(node: MBeanNode): boolean {
   return (
-    node &&
     !isEndpointsFolder(node) &&
     !isEndpointNode(node) &&
     !isComponentsFolder(node) &&
@@ -243,7 +238,6 @@ export function canListTypeConverters(node: MBeanNode): boolean {
 
 export function hasTypeConverter(node: MBeanNode): boolean {
   return (
-    node &&
     !isRouteNode(node) &&
     !isRouteXmlNode(node) &&
     !isEndpointsFolder(node) &&

--- a/packages/hawtio/src/plugins/camel/endpoints/endpoints-service.ts
+++ b/packages/hawtio/src/plugins/camel/endpoints/endpoints-service.ts
@@ -178,7 +178,7 @@ export async function doSendMessage(
     }
   })
 
-  const context = mbean.parent?.getProperty(contextNodeType)
+  const context = mbean.parent?.getMetadata(contextNodeType)
   const uri = mbean.name
   if (context && uri) {
     let ok = true
@@ -218,7 +218,7 @@ export async function forwardMessagesToEndpoint(
   messages: MessageData[],
   notify: (type: NotificationType, message: string) => void,
 ) {
-  const context = mBean.parent?.getProperty(contextNodeType)
+  const context = mBean.parent?.getMetadata(contextNodeType)
 
   if (context && uri && messages && messages.length) {
     try {
@@ -253,7 +253,7 @@ export async function forwardMessagesToEndpoint(
 }
 export async function getMessagesFromTheEndpoint(mbean: MBeanNode, from: number, to: number): Promise<MessageData[]> {
   let messageData: MessageData[] = []
-  const context = mbean.parent?.getProperty(contextNodeType)
+  const context = mbean.parent?.getMetadata(contextNodeType)
   const browseAll = to === -1
   if (context) {
     let reply

--- a/packages/hawtio/src/plugins/camel/exchanges/exchanges-service.ts
+++ b/packages/hawtio/src/plugins/camel/exchanges/exchanges-service.ts
@@ -1,6 +1,6 @@
 import { jolokiaService } from '@hawtiosrc/plugins/shared'
 import { MBeanNode } from '@hawtiosrc/plugins/shared/tree'
-import { findContext, hasType } from '../camel-service'
+import { findContext } from '../camel-service'
 import { mbeansType, routeNodeType } from '../globals'
 
 export type Exchange = {
@@ -32,7 +32,7 @@ export async function getExchanges(node: MBeanNode, serviceName: string): Promis
 
   const response = await jolokiaService.execute(service.objectName as string, 'browse()')
   let exchanges = Object.values(response as object) as Exchange[]
-  if (hasType(node, routeNodeType)) {
+  if (node.getType() === routeNodeType) {
     exchanges = exchanges.filter(ex => ex.routeId === node.name)
   }
 

--- a/packages/hawtio/src/plugins/camel/properties/Properties.tsx
+++ b/packages/hawtio/src/plugins/camel/properties/Properties.tsx
@@ -39,7 +39,7 @@ export const Properties: React.FunctionComponent = () => {
     setIsReading(true)
 
     const init = async () => {
-      const localName: string = selectedNode.getProperty(xmlNodeLocalName)
+      const localName = selectedNode.getMetadata(xmlNodeLocalName) ?? ''
       const schemaKey = localName ? localName : selectedNode.name
       const schema = schemaService.getSchema(selectedNode, schemaKey)
 

--- a/packages/hawtio/src/plugins/camel/properties/properties-service.ts
+++ b/packages/hawtio/src/plugins/camel/properties/properties-service.ts
@@ -5,11 +5,11 @@ import { Property } from './property'
 
 export function populateProperties(node: MBeanNode, schemaProperties: Record<string, Record<string, string>>) {
   // Extract the xml fragment from the node's property stash
-  const xml = node.getProperty('xml')
+  const xml = node.getMetadata('xml')
   if (!xml) return
 
   // Extract the xml tag name from the node's property stash
-  const localName = node.getProperty(xmlNodeLocalName)
+  const localName = node.getMetadata(xmlNodeLocalName)
   if (!localName) return
 
   // Parse the xml and find the root element using the localname

--- a/packages/hawtio/src/plugins/camel/route-diagram/RouteDiagram.tsx
+++ b/packages/hawtio/src/plugins/camel/route-diagram/RouteDiagram.tsx
@@ -32,7 +32,7 @@ export const RouteDiagram: React.FunctionComponent = () => {
       return
     }
 
-    const xml = selectedNode.getProperty('xml')
+    const xml = selectedNode.getMetadata('xml')
     if (!xml) {
       return
     }

--- a/packages/hawtio/src/plugins/camel/routes-service.test.ts
+++ b/packages/hawtio/src/plugins/camel/routes-service.test.ts
@@ -39,7 +39,7 @@ describe('routes-service', () => {
     contextNode.objectName = 'org.apache.camel:context=SampleCamel,type=context,name="SampleCamel"'
 
     routesNode = new MBeanNode(null, 'routes-2', true)
-    routesNode.addProperty('type', 'routes')
+    routesNode.addMetadata('type', 'routes')
 
     simpleRouteNode = new MBeanNode(null, testRouteId, false)
 
@@ -76,7 +76,7 @@ describe('routes-service', () => {
 
   test('loadRouteXml', async () => {
     routesService.loadRouteXml(simpleRouteNode, simpleRouteXml)
-    expect(simpleRouteNode.getProperty('xml')).toBe('    ' + simpleRouteXml.outerHTML)
+    expect(simpleRouteNode.getMetadata('xml')).toBe('    ' + simpleRouteXml.outerHTML)
     expect(simpleRouteNode.childCount()).toBe(4)
 
     type MBeanAttr = {
@@ -103,7 +103,7 @@ describe('routes-service', () => {
       childNode = childNode as MBeanNode
       expect(childNode.id).toBe(expected[i]?.id)
       expect(childNode.name).toBe(expected[i]?.name)
-      expect(childNode.getProperty(xmlNodeLocalName)).toBe(expected[i]?.localName)
+      expect(childNode.getMetadata(xmlNodeLocalName)).toBe(expected[i]?.localName)
       expect(childNode.getChildren().length).toBe(0)
       expect(childNode.icon).not.toBeNull()
       render(childNode.icon as React.ReactElement)

--- a/packages/hawtio/src/plugins/camel/routes-service.ts
+++ b/packages/hawtio/src/plugins/camel/routes-service.ts
@@ -124,9 +124,9 @@ class RoutesService {
    * inner steps of the XML.
    */
   private loadStepXml(stepNode: MBeanNode, stepXml: Element) {
-    stepNode.addProperty('xml', stepXml.outerHTML)
+    stepNode.addMetadata('xml', stepXml.outerHTML)
     // Preserve the xml local name for use by views
-    stepNode.addProperty(xmlNodeLocalName, stepXml.localName)
+    stepNode.addMetadata(xmlNodeLocalName, stepXml.localName)
 
     // Populate child nodes
     for (const childXml of stepXml.children) {
@@ -139,13 +139,13 @@ class RoutesService {
    * route steps of the XML.
    */
   loadRouteXml(routeNode: MBeanNode, routeXml: Element) {
-    routeNode.addProperty('xml', '    ' + routeXml.outerHTML) // Indent route XML for better readability
+    routeNode.addMetadata('xml', '    ' + routeXml.outerHTML) // Indent route XML for better readability
     // Preserve the xml local name for use by views
-    routeNode.addProperty(xmlNodeLocalName, routeXml.localName)
+    routeNode.addMetadata(xmlNodeLocalName, routeXml.localName)
 
     // If route is grouped with the 'group' attribute, add it to the node.
     const routeGroup = routeXml.getAttribute('group')
-    if (routeGroup) routeNode.addProperty('group', routeGroup)
+    if (routeGroup) routeNode.addMetadata('group', routeGroup)
 
     // Populate child nodes
     for (const stepXml of routeXml.children) {
@@ -192,7 +192,7 @@ class RoutesService {
 
     try {
       const xml = await this.fetchRoutesXml(contextNode)
-      routesNode.addProperty('xml', xml)
+      routesNode.addMetadata('xml', xml)
       routesNode.getChildren().forEach(routeNode => {
         try {
           const routeXml = this.processRouteXml(xml, routeNode)
@@ -211,7 +211,7 @@ class RoutesService {
     const routeNodeOperation = 'dumpRouteStatsAsXml'
     const routesFolderOperation = 'dumpRoutesStatsAsXml'
 
-    const mbeanName = routesNode.getProperty(contextNodeType)
+    const mbeanName = routesNode.getMetadata(contextNodeType)
     const operationForMBean = mbeanName ? routesFolderOperation : routeNodeOperation
     const mbeanToQuery = mbeanName ? mbeanName : routesNode.objectName ?? ''
 
@@ -236,7 +236,7 @@ class RoutesService {
     return routesStats
   }
 
-  createProcessorStats(routeid: string, pDoc: Element): ProcessorStats {
+  createProcessorStats(routeId: string, pDoc: Element): ProcessorStats {
     let res: ProcessorStats = {
       id: '',
       index: '',

--- a/packages/hawtio/src/plugins/camel/routes/Source.tsx
+++ b/packages/hawtio/src/plugins/camel/routes/Source.tsx
@@ -8,7 +8,7 @@ export const Source: React.FunctionComponent = () => {
   const [xmlSource, setXmlSource] = useState('')
 
   useEffect(() => {
-    const xml = selectedNode?.getProperty('xml')
+    const xml = selectedNode?.getMetadata('xml')
     if (xml) {
       setXmlSource(xml)
     } else {

--- a/packages/hawtio/src/plugins/camel/routes/routes-service.ts
+++ b/packages/hawtio/src/plugins/camel/routes/routes-service.ts
@@ -1,6 +1,5 @@
 import { jolokiaService } from '@hawtiosrc/plugins/shared/jolokia-service'
 import { MBeanNode } from '@hawtiosrc/plugins/shared/tree'
-import * as camelService from '../camel-service'
 import { routeGroupsType, routeNodeType } from '../globals'
 import { CamelRoute } from './route'
 
@@ -31,11 +30,11 @@ class RoutesService implements IRoutesService {
      */
     const routes: CamelRoute[] = []
     for (const child of children) {
-      if (camelService.hasType(child, routeNodeType)) {
+      if (child.getType() === routeNodeType) {
         // read attributes of route
         const camelRoute = await this.readRouteAttributes(child)
         if (camelRoute) routes.push(camelRoute)
-      } else if (camelService.hasType(child, routeGroupsType)) {
+      } else if (child.getType() === routeGroupsType) {
         // recurse into route group
         const camelRoutes = await this.getRoutesAttributes(child)
         routes.push(...camelRoutes)

--- a/packages/hawtio/src/plugins/camel/tree-processor.test.ts
+++ b/packages/hawtio/src/plugins/camel/tree-processor.test.ts
@@ -28,7 +28,7 @@ jest.mock('./camel-service', () => {
   return {
     ...jest.requireActual('./camel-service'),
     fetchCamelVersion: jest.fn((contextNode: MBeanNode | null) => {
-      if (contextNode) contextNode.addProperty('version', CAMEL_MODEL_VERSION)
+      if (contextNode) contextNode.addMetadata('version', CAMEL_MODEL_VERSION)
     }),
   }
 })

--- a/packages/hawtio/src/plugins/camel/tree-processor.test.ts
+++ b/packages/hawtio/src/plugins/camel/tree-processor.test.ts
@@ -74,14 +74,14 @@ describe('tree-processor', () => {
     const contextsNode = domainNode.getIndex(0) as MBeanNode
     expect(contextsNode).not.toBeNull()
     expect(camelService.hasDomain(contextsNode)).toBeTruthy()
-    expect(camelService.hasType(contextsNode, contextsType)).toBeTruthy()
+    expect(contextsNode.getType()).toBe(contextsType)
     expect(contextsNode.id).toBe('org.apache.camel-folder-CamelContexts-folder')
     expect(contextsNode.name).toBe(camelContexts)
     expect(contextsNode.childCount()).toBe(1)
 
     const contextNode = contextsNode.getIndex(0) as MBeanNode
     expect(camelService.hasDomain(contextNode)).toBeTruthy()
-    expect(camelService.hasType(contextNode, contextNodeType)).toBeTruthy()
+    expect(contextNode.getType()).toBe(contextNodeType)
     expect(contextNode.id).toBe('org.apache.camel-folder-CamelContexts-folder-SampleCamel-folder')
     expect(contextNode.name).toBe('SampleCamel')
     expect(camelService.getCamelVersion(contextNode)).toBe(CAMEL_MODEL_VERSION)
@@ -92,7 +92,7 @@ describe('tree-processor', () => {
       const node = contextNode.get(type, true) as MBeanNode
       expect(node).toBeDefined()
       expect(camelService.hasDomain(node)).toBeTruthy()
-      expect(camelService.hasType(node, type)).toBeTruthy()
+      expect(node.getType()).toBe(type)
       expect(node.id).toEqual(`org.apache.camel-folder-CamelContexts-folder-SampleCamel-folder-${type}-folder`)
       expect(node.name).toBe(type)
       expect(camelService.getCamelVersion(node)).toBe(CAMEL_MODEL_VERSION)
@@ -103,7 +103,7 @@ describe('tree-processor', () => {
     for (const child of routesNode.getChildren()) {
       expect(child).toBeDefined()
       expect(camelService.hasDomain(child)).toBeTruthy()
-      expect(camelService.hasType(child, routeNodeType)).toBeTruthy()
+      expect(child.getType()).toBe(routeNodeType)
     }
   })
 

--- a/packages/hawtio/src/plugins/camel/tree-processor.ts
+++ b/packages/hawtio/src/plugins/camel/tree-processor.ts
@@ -25,7 +25,7 @@ function adoptChild(parent: MBeanNode, child: MBeanNode, type: string, childIcon
   parent.adopt(child)
   child.setIcons(childIcon)
   if (camelService.isContext(parent)) {
-    child.addProperty(contextNodeType, parent.objectName ?? '')
+    child.addMetadata(contextNodeType, parent.objectName ?? '')
   }
   child.setType(type)
   camelService.setDomain(child)
@@ -40,7 +40,7 @@ function setChildIcon(node: MBeanNode, childIcon: ReactNode) {
 function groupRoutes(routesNode: MBeanNode) {
   let haveGroups = false
   for (const routeNode of routesNode.getChildren()) {
-    const groupId = routeNode.getProperty('group')
+    const groupId = routeNode.getMetadata('group')
     if (groupId) {
       haveGroups = true
       break
@@ -55,7 +55,7 @@ function groupRoutes(routesNode: MBeanNode) {
   for (const routeNode of routeNodes) {
     if (routeNode.getType() === routeGroupsType) continue
 
-    const groupId = routeNode.getProperty('group')
+    const groupId = routeNode.getMetadata('group')
     let groupNode: MBeanNode
     if (groupId) {
       groupNode = routesNode.getOrCreate(groupId, true)
@@ -88,9 +88,9 @@ export const camelTreeProcessor: TreeProcessor = async (tree: MBeanTree) => {
   // Create the initial contexts group node
   const groupCtxsNode = camelDomain.getOrCreate(camelContexts, true)
   groupCtxsNode.setIcons(getIcon(IconNames.CamelIcon))
-  groupCtxsNode.addProperty('class', 'org-apache-camel-context-folder')
-  groupCtxsNode.addProperty('key', camelContexts)
-  groupCtxsNode.addProperty('name', camelContexts)
+  groupCtxsNode.addMetadata('class', 'org-apache-camel-context-folder')
+  groupCtxsNode.addMetadata('key', camelContexts)
+  groupCtxsNode.addMetadata('name', camelContexts)
   groupCtxsNode.setType(contextsType)
   camelService.setDomain(groupCtxsNode)
 
@@ -118,7 +118,7 @@ export const camelTreeProcessor: TreeProcessor = async (tree: MBeanTree) => {
       adoptChild(newCtxNode, routesNode, routesType, endpointsFolderIcon)
       setChildIcon(routesNode, routeIcon)
       camelService.setChildProperties(routesNode, routeNodeType)
-      routesNode.addProperty(contextNodeType, newCtxNode.objectName ?? '')
+      routesNode.addMetadata(contextNodeType, newCtxNode.objectName ?? '')
 
       await routesService.loadRoutesXml(newCtxNode, routesNode)
 

--- a/packages/hawtio/src/plugins/shared/tree/node.test.ts
+++ b/packages/hawtio/src/plugins/shared/tree/node.test.ts
@@ -148,8 +148,8 @@ describe('MBeanNode', () => {
   test('matches', async () => {
     const domainNode = tree.get('org.apache.camel') as MBeanNode
     expect(domainNode).not.toBeNull()
-    domainNode.addProperty('type', domainNodeType)
-    domainNode.addProperty('domain', domainNode.name)
+    domainNode.addMetadata('type', domainNodeType)
+    domainNode.addMetadata('domain', domainNode.name)
 
     expect(domainNode.matches({})).toBeFalsy()
     expect(domainNode.matches({ name: '' })).toBeFalsy()

--- a/packages/hawtio/src/plugins/shared/tree/node.ts
+++ b/packages/hawtio/src/plugins/shared/tree/node.ts
@@ -39,7 +39,11 @@ export class MBeanNode implements TreeViewDataItem {
   icon: React.ReactNode
   expandedIcon?: React.ReactNode
   children?: MBeanNode[]
-  properties?: Record<string, string>
+
+  /**
+   * Various metadata that can be attached to the node for processing it in the MBean tree.
+   */
+  private metadata: Record<string, string> = {}
 
   // MBean info
   objectName?: string
@@ -142,12 +146,12 @@ export class MBeanNode implements TreeViewDataItem {
     }
   }
 
-  getType(): string {
-    return this.getProperty('type')
+  getType(): string | undefined {
+    return this.getMetadata('type')
   }
 
   setType(type: string) {
-    this.addProperty('type', type)
+    this.addMetadata('type', type)
   }
 
   /**
@@ -206,7 +210,7 @@ export class MBeanNode implements TreeViewDataItem {
           nodeValue = this.name
           break
         default:
-          nodeValue = this.getProperty(key)
+          nodeValue = this.getMetadata(key)
           if (!nodeValue) return false // this node lacks this property
           break
       }
@@ -274,16 +278,12 @@ export class MBeanNode implements TreeViewDataItem {
     return this.children ? this.children.length : 0
   }
 
-  getProperty(key: string): string {
-    return this.properties?.[key] ?? ''
+  getMetadata(key: string): string | undefined {
+    return this.metadata[key]
   }
 
-  addProperty(key: string, value: string) {
-    if (!this.properties) {
-      this.properties = {}
-    }
-
-    this.properties[key] = value
+  addMetadata(key: string, value: string) {
+    this.metadata[key] = value
   }
 
   static sorter(a: MBeanNode, b: MBeanNode): number {


### PR DESCRIPTION
Fix #453 