### PR TITLE
chore(deps): bump @types/react from 18.2.21 to 18.2.23 #576

### DIFF
--- a/packages/hawtio/package.json
+++ b/packages/hawtio/package.json
@@ -47,7 +47,7 @@
     "@types/jest": "^29.5.5",
     "@types/jquery": "^3.5.20",
     "@types/node": "^18.18.1",
-    "@types/react": "^18.2.21",
+    "@types/react": "^18.2.23",
     "@types/react-dom": "^18.2.8",
     "@types/react-router-dom": "^5.3.3",
     "dagre": "^0.8.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2449,7 +2449,7 @@ __metadata:
     "@types/jest": ^29.5.5
     "@types/jquery": ^3.5.20
     "@types/node": ^18.18.1
-    "@types/react": ^18.2.21
+    "@types/react": ^18.2.23
     "@types/react-dom": ^18.2.8
     "@types/react-router-dom": ^5.3.3
     dagre: ^0.8.5
@@ -4695,14 +4695,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:^18.2.21":
-  version: 18.2.21
-  resolution: "@types/react@npm:18.2.21"
+"@types/react@npm:^18.2.23":
+  version: 18.2.24
+  resolution: "@types/react@npm:18.2.24"
   dependencies:
     "@types/prop-types": "*"
     "@types/scheduler": "*"
     csstype: ^3.0.2
-  checksum: ffed203bfe7aad772b8286f7953305c9181ac3a8f27d3f5400fbbc2a8e27ca8e5bbff818ee014f39ca0d19d2b3bb154e5bdbec7e232c6f80b59069375aa78349
+  checksum: ea5d8204e71b1c9c6631f429a93f8e7be0614cdbdb464e92b3181bdccd8a7c45e30ded8b13da726684b6393f651317c36d54832e3d3cdea0da480a3f26268909
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Appears to be compiling correctly.

ref: https://github.com/hawtio/hawtio-next/pull/574

#576 