### PR TITLE
fix(ui): redirect '/index.html' to root '/'

### DIFF
--- a/packages/hawtio/src/ui/page/HawtioPage.tsx
+++ b/packages/hawtio/src/ui/page/HawtioPage.tsx
@@ -83,6 +83,7 @@ export const HawtioPage: React.FunctionComponent = () => {
             <Route key='help' path='help/*' element={<HawtioHelp />} />
             <Route key='preferences' path='preferences/*' element={<HawtioPreferences />} />
 
+            <Route key='index' path='index.html' element={<Navigate to='/' />} />
             <Route key='root' index element={defaultPage} />
           </Routes>
         </PluginNodeSelectionContext.Provider>


### PR DESCRIPTION
When directly accessing to /index.html, React router doesn't treat it as root '/' so the default page resolution didn't happen. This fix changed the React router routes to explicitly redirect '/index.html' to '/'.

This fix is needed for Spring Boot 3 runtime support.