### PR TITLE
fix:  Mitigate 'findDOMNode is deprecated in StrictMode.' warning in Route/Endpoins tabs by using noWrap

### DIFF
--- a/packages/hawtio/src/plugins/camel/endpoints/EndpointsStats.tsx
+++ b/packages/hawtio/src/plugins/camel/endpoints/EndpointsStats.tsx
@@ -173,7 +173,7 @@ export const EndpointStats: React.FunctionComponent = () => {
       {sortStatistics().length > 0 ? (
         <FormGroup>
           <TableComposable aria-label='Endpoints Table' variant='compact' height='80vh'>
-            <Thead>
+            <Thead noWrap>
               <Tr>
                 <Th data-testid={'url-header'} sort={getSortParams(0)}>
                   URL

--- a/packages/hawtio/src/plugins/camel/routes/CamelRoutes.tsx
+++ b/packages/hawtio/src/plugins/camel/routes/CamelRoutes.tsx
@@ -164,7 +164,7 @@ export const CamelRoutes: React.FunctionComponent = () => {
         aria-label='Camel routes table'
         variant='compact'
       >
-        <Thead>
+        <Thead noWrap>
           <Tr>
             <Th
               select={{


### PR DESCRIPTION
fix #432 