### PR TITLE
Changes to <HawtioLogin> to allow for plugin to provide customisations

### DIFF
--- a/packages/hawtio/src/auth/globals.ts
+++ b/packages/hawtio/src/auth/globals.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@hawtiosrc/core'
+import { Logger } from '@hawtiosrc/core/logging'
 
 export const moduleName = 'hawtio-auth'
 export const log = Logger.get(moduleName)

--- a/packages/hawtio/src/core/config-manager.ts
+++ b/packages/hawtio/src/core/config-manager.ts
@@ -22,6 +22,7 @@ export type Branding = {
 }
 
 export type Login = {
+  title?: string
   description?: string
   links?: LoginLink[]
 }

--- a/packages/hawtio/src/core/core.ts
+++ b/packages/hawtio/src/core/core.ts
@@ -2,6 +2,7 @@ import { importRemote, ImportRemoteOptions } from '@module-federation/utilities'
 import $ from 'jquery'
 import { eventService } from './event-service'
 import { log } from './globals'
+import { userService } from '@hawtiosrc/auth'
 
 /*
  * Components to be added to the header navbar
@@ -226,8 +227,20 @@ class HawtioCore {
    */
   async resolvePlugins(): Promise<Plugin[]> {
     // load plugins sequentially to maintain the order
+    const userLoggedIn = await userService.isLogin()
+
     const resolved: Plugin[] = []
     for (const plugin of this.getPlugins()) {
+      if (plugin.isLogin && (await plugin.isActive())) {
+        // resolve all login-related plugins
+        resolved.push(plugin)
+      }
+      // Only if user is logged in should
+      // other plugins be activated
+      if (!userLoggedIn) {
+        continue
+      }
+      // User logged-in so resolve plugin if active
       if (await plugin.isActive()) {
         resolved.push(plugin)
       }

--- a/packages/hawtio/src/core/core.ts
+++ b/packages/hawtio/src/core/core.ts
@@ -40,6 +40,12 @@ export interface Plugin {
   id: string
   title: string
   path: string
+
+  /**
+   * If this plugin provides a login form component
+   */
+  isLogin?: boolean
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   component: React.ComponentType<any>
 

--- a/packages/hawtio/src/plugins/auth/keycloak/globals.ts
+++ b/packages/hawtio/src/plugins/auth/keycloak/globals.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@hawtiosrc/core'
+import { Logger } from '@hawtiosrc/core/logging'
 
 export const pluginName = 'hawtio-auth-keycloak'
 

--- a/packages/hawtio/src/plugins/camel/CamelTreeView.test.tsx
+++ b/packages/hawtio/src/plugins/camel/CamelTreeView.test.tsx
@@ -1,3 +1,4 @@
+import { userService } from '@hawtiosrc/auth'
 import { camelTreeProcessor } from '@hawtiosrc/plugins/camel/tree-processor'
 import { MBeanNode, MBeanTree, jolokiaService, workspace } from '@hawtiosrc/plugins/shared'
 import { render, screen } from '@testing-library/react'
@@ -44,6 +45,7 @@ describe('CamelTreeView', () => {
   let tree: MBeanTree
 
   beforeAll(async () => {
+    await userService.fetchUser()
     const wkspTree = await workspace.getTree()
     camelTreeProcessor(wkspTree)
     const rootNode = wkspTree.find(node => node.name === jmxDomain)

--- a/packages/hawtio/src/plugins/camel/debug/debug-service.test.ts
+++ b/packages/hawtio/src/plugins/camel/debug/debug-service.test.ts
@@ -1,3 +1,4 @@
+import { userService } from '@hawtiosrc/auth'
 import { camelTreeProcessor } from '@hawtiosrc/plugins/camel/tree-processor'
 import { AttributeValues, MBeanNode, MBeanTree, jolokiaService, workspace } from '@hawtiosrc/plugins/shared'
 import fs from 'fs'
@@ -51,6 +52,7 @@ describe('debug-service', () => {
   let tree: MBeanTree
 
   beforeAll(async () => {
+    await userService.fetchUser()
     tree = await workspace.getTree()
     camelTreeProcessor(tree)
   })

--- a/packages/hawtio/src/plugins/camel/endpoints/endpoints-service.test.ts
+++ b/packages/hawtio/src/plugins/camel/endpoints/endpoints-service.test.ts
@@ -1,3 +1,4 @@
+import { userService } from '@hawtiosrc/auth'
 import { camelTreeProcessor } from '@hawtiosrc/plugins/camel/tree-processor'
 import { AttributeValues, MBeanNode, MBeanTree, jolokiaService, workspace } from '@hawtiosrc/plugins/shared'
 import { isObject } from '@hawtiosrc/util/objects'
@@ -36,6 +37,7 @@ describe('endpoints-service', () => {
   let tree: MBeanTree
 
   beforeAll(async () => {
+    await userService.fetchUser()
     tree = await workspace.getTree()
     camelTreeProcessor(tree)
   })

--- a/packages/hawtio/src/plugins/camel/exchanges/BlockedExchanges.test.tsx
+++ b/packages/hawtio/src/plugins/camel/exchanges/BlockedExchanges.test.tsx
@@ -1,3 +1,4 @@
+import { userService } from '@hawtiosrc/auth'
 import { camelTreeProcessor } from '@hawtiosrc/plugins/camel/tree-processor'
 import { MBeanNode, MBeanTree, jolokiaService, workspace } from '@hawtiosrc/plugins/shared'
 import { fireEvent, render, screen, waitForElementToBeRemoved } from '@testing-library/react'
@@ -48,6 +49,7 @@ describe('BlockedExchanges', () => {
   let tree: MBeanTree
 
   beforeAll(async () => {
+    await userService.fetchUser()
     tree = await workspace.getTree()
     camelTreeProcessor(tree)
   })

--- a/packages/hawtio/src/plugins/camel/exchanges/InflightExchanges.test.tsx
+++ b/packages/hawtio/src/plugins/camel/exchanges/InflightExchanges.test.tsx
@@ -7,6 +7,7 @@ import { CamelContext } from '../context'
 import { jmxDomain } from '../globals'
 import { InflightExchanges } from './InflightExchanges'
 import { Exchange } from './exchanges-service'
+import { userService } from '@hawtiosrc/auth'
 
 const routesXmlPath = path.resolve(__dirname, '..', 'testdata', 'camel-sample-app-routes.xml')
 const sampleRoutesXml = fs.readFileSync(routesXmlPath, { encoding: 'utf8', flag: 'r' })
@@ -49,6 +50,7 @@ describe('InflightExchanges', () => {
   let tree: MBeanTree
 
   beforeAll(async () => {
+    await userService.fetchUser()
     tree = await workspace.getTree()
     camelTreeProcessor(tree)
   })

--- a/packages/hawtio/src/plugins/camel/exchanges/exchanges-service.test.tsx
+++ b/packages/hawtio/src/plugins/camel/exchanges/exchanges-service.test.tsx
@@ -1,3 +1,4 @@
+import { userService } from '@hawtiosrc/auth'
 import { camelTreeProcessor } from '@hawtiosrc/plugins/camel/tree-processor'
 import { MBeanNode, MBeanTree, jolokiaService, workspace } from '@hawtiosrc/plugins/shared'
 import fs from 'fs'
@@ -59,6 +60,7 @@ describe('exchange-service', () => {
   let tree: MBeanTree
 
   beforeAll(async () => {
+    await userService.fetchUser()
     tree = await workspace.getTree()
     camelTreeProcessor(tree)
   })

--- a/packages/hawtio/src/plugins/camel/globals.ts
+++ b/packages/hawtio/src/plugins/camel/globals.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@hawtiosrc/core'
+import { Logger } from '@hawtiosrc/core/logging'
 
 export const jmxDomain = 'org.apache.camel'
 export const pluginPath = '/camel'

--- a/packages/hawtio/src/plugins/camel/tree-processor.test.ts
+++ b/packages/hawtio/src/plugins/camel/tree-processor.test.ts
@@ -15,6 +15,7 @@ import {
   routesType,
 } from './globals'
 import { camelTreeProcessor } from './tree-processor'
+import { userService } from '@hawtiosrc/auth'
 
 jest.mock('@hawtiosrc/plugins/shared/jolokia-service')
 
@@ -54,6 +55,10 @@ describe('tree-processor', () => {
     }
 
     return ''
+  })
+
+  beforeAll(async () => {
+    await userService.fetchUser()
   })
 
   beforeEach(async () => {

--- a/packages/hawtio/src/plugins/camel/type-converters/TypeConvertersStatistics.test.tsx
+++ b/packages/hawtio/src/plugins/camel/type-converters/TypeConvertersStatistics.test.tsx
@@ -9,6 +9,7 @@ import { CamelContext } from '../context'
 import { jmxDomain } from '../globals'
 import { TypeConvertersStatistics } from './TypeConvertersStatistics'
 import { TypeConvertersStats } from './type-converters-service'
+import { userService } from '@hawtiosrc/auth'
 
 const routesXmlPath = path.resolve(__dirname, '..', 'testdata', 'camel-sample-app-routes.xml')
 const sampleRoutesXml = fs.readFileSync(routesXmlPath, { encoding: 'utf8', flag: 'r' })
@@ -56,6 +57,7 @@ describe('TypeConvertersStatistics', () => {
   let tree: MBeanTree
 
   beforeAll(async () => {
+    await userService.fetchUser()
     tree = await workspace.getTree()
     camelTreeProcessor(tree)
   })

--- a/packages/hawtio/src/plugins/camel/type-converters/type-converters-service.test.tsx
+++ b/packages/hawtio/src/plugins/camel/type-converters/type-converters-service.test.tsx
@@ -1,3 +1,4 @@
+import { userService } from '@hawtiosrc/auth'
 import { camelTreeProcessor } from '@hawtiosrc/plugins/camel/tree-processor'
 import { AttributeValues, MBeanNode, MBeanTree, jolokiaService, workspace } from '@hawtiosrc/plugins/shared'
 import fs from 'fs'
@@ -64,6 +65,10 @@ jolokiaService.writeAttribute = jest.fn(async (mbean: string, attr: string, valu
 
 describe('type-converters-service', () => {
   let tree: MBeanTree
+
+  beforeAll(async () => {
+    await userService.fetchUser()
+  })
 
   beforeAll(async () => {
     tree = await workspace.getTree()

--- a/packages/hawtio/src/plugins/connect/globals.ts
+++ b/packages/hawtio/src/plugins/connect/globals.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@hawtiosrc/core'
+import { Logger } from '@hawtiosrc/core/logging'
 
 export const pluginName = 'hawtio-connect'
 export const log = Logger.get(pluginName)

--- a/packages/hawtio/src/plugins/jmx/globals.ts
+++ b/packages/hawtio/src/plugins/jmx/globals.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@hawtiosrc/core'
+import { Logger } from '@hawtiosrc/core/logging'
 
 export const pluginName = 'hawtio-jmx'
 export const pluginPath = '/jmx'

--- a/packages/hawtio/src/plugins/logs/globals.ts
+++ b/packages/hawtio/src/plugins/logs/globals.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@hawtiosrc/core'
+import { Logger } from '@hawtiosrc/core/logging'
 
 export const pluginId = 'logs'
 export const pluginName = 'hawtio-logs'

--- a/packages/hawtio/src/plugins/quartz/globals.ts
+++ b/packages/hawtio/src/plugins/quartz/globals.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@hawtiosrc/core'
+import { Logger } from '@hawtiosrc/core/logging'
 
 export const pluginId = 'quartz'
 export const pluginName = 'hawtio-quartz'

--- a/packages/hawtio/src/plugins/rbac/globals.ts
+++ b/packages/hawtio/src/plugins/rbac/globals.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@hawtiosrc/core'
+import { Logger } from '@hawtiosrc/core/logging'
 
 export const pluginName = 'hawtio-rbac'
 export const log = Logger.get(pluginName)

--- a/packages/hawtio/src/plugins/rbac/rbac-service.test.ts
+++ b/packages/hawtio/src/plugins/rbac/rbac-service.test.ts
@@ -1,9 +1,14 @@
+import { userService } from '@hawtiosrc/auth'
 import { jolokiaService } from '@hawtiosrc/plugins/shared/jolokia-service'
 import { __testing__ } from './rbac-service'
 
 jest.mock('@hawtiosrc/plugins/shared/jolokia-service')
 
 describe('RBACService', () => {
+  beforeAll(async () => {
+    await userService.fetchUser()
+  })
+
   beforeEach(() => {
     jest.resetModules()
   })

--- a/packages/hawtio/src/plugins/runtime/globals.ts
+++ b/packages/hawtio/src/plugins/runtime/globals.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@hawtiosrc/core'
+import { Logger } from '@hawtiosrc/core/logging'
 
 export const pluginId = 'runtime'
 export const pluginName = 'hawtio-runtime'

--- a/packages/hawtio/src/plugins/shared/globals.ts
+++ b/packages/hawtio/src/plugins/shared/globals.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@hawtiosrc/core'
+import { Logger } from '@hawtiosrc/core/logging'
 
 export const pluginName = 'hawtio-shared'
 export const log = Logger.get(pluginName)

--- a/packages/hawtio/src/plugins/shared/jolokia-service.test.ts
+++ b/packages/hawtio/src/plugins/shared/jolokia-service.test.ts
@@ -52,27 +52,36 @@ class ListJolokiaTest extends DummyJolokia {
 }
 
 class JolokiaServiceTest extends JolokiaService {
-  checkListOptimisationTest(jolokia: Jolokia): Promise<void> {
-    return this.checkListOptimisation(jolokia)
+  private delegate: Jolokia
+
+  constructor(delegate: Jolokia) {
+    super()
+    this.delegate = delegate
+  }
+
+  protected async init(): Promise<Jolokia> {
+    return this.delegate
+  }
+
+  checkListOptimisationTest(): Promise<void> {
+    return this.checkListOptimisation(this.delegate)
   }
 }
 
 describe('JolokiaService class', () => {
   test('checkListOptimizationSuccess', async () => {
     const delegate: ListJolokiaTest = new ListJolokiaTest(true)
-    const service: JolokiaServiceTest = new JolokiaServiceTest()
+    const service: JolokiaServiceTest = new JolokiaServiceTest(delegate)
 
-    console.log(service.getListMethod())
-
-    await expect(service.checkListOptimisationTest(delegate)).resolves.not.toThrow()
+    await expect(service.checkListOptimisationTest()).resolves.not.toThrow()
     expect(await service.getListMethod()).toEqual(JolokiaListMethod.OPTIMISED)
   })
 
   test('checkListOptimizationError', async () => {
     const delegate: ListJolokiaTest = new ListJolokiaTest(false)
-    const service: JolokiaServiceTest = new JolokiaServiceTest()
+    const service: JolokiaServiceTest = new JolokiaServiceTest(delegate)
 
-    await expect(service.checkListOptimisationTest(delegate)).resolves.not.toThrow()
+    await expect(service.checkListOptimisationTest()).resolves.not.toThrow()
     expect(await service.getListMethod()).toEqual(JolokiaListMethod.DEFAULT)
   })
 })

--- a/packages/hawtio/src/plugins/shared/jolokia-service.ts
+++ b/packages/hawtio/src/plugins/shared/jolokia-service.ts
@@ -130,7 +130,11 @@ class JolokiaService implements IJolokiaService {
 
   private async initJolokiaUrl(): Promise<string | null> {
     // Wait for resolving user as it may attach credentials to http request headers
-    await userService.isLogin()
+    const loggedIn = await userService.isLogin()
+    if (!loggedIn) {
+      log.debug("Not logged in so no jolokia url should be possible")
+      return null
+    }
 
     // Check remote connection
     const conn = connectService.getCurrentConnectionName()

--- a/packages/hawtio/src/plugins/shared/tree/globals.ts
+++ b/packages/hawtio/src/plugins/shared/tree/globals.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@hawtiosrc/core'
+import { Logger } from '@hawtiosrc/core/logging'
 import { pluginName } from '../globals'
 
 export const log = Logger.get(`${pluginName}-tree`)

--- a/packages/hawtio/src/plugins/shared/tree/node.test.ts
+++ b/packages/hawtio/src/plugins/shared/tree/node.test.ts
@@ -1,3 +1,4 @@
+import { userService } from '@hawtiosrc/auth'
 import { workspace } from '../workspace'
 import { Icons, MBeanNode, PropertyList } from './node'
 import { MBeanTree } from './tree'
@@ -6,6 +7,10 @@ jest.mock('@hawtiosrc/plugins/shared/jolokia-service')
 
 describe('MBeanNode', () => {
   let tree: MBeanTree
+
+  beforeAll(async () => {
+    await userService.fetchUser()
+  })
 
   beforeEach(async () => {
     tree = await workspace.getTree()

--- a/packages/hawtio/src/plugins/shared/tree/tree.test.ts
+++ b/packages/hawtio/src/plugins/shared/tree/tree.test.ts
@@ -1,3 +1,4 @@
+import { userService } from '@hawtiosrc/auth'
 import { escapeHtmlId } from '@hawtiosrc/util/htmls'
 import { workspace } from '../workspace'
 import { MBEAN_NODE_ID_SEPARATOR, MBeanNode } from './node'
@@ -8,6 +9,10 @@ jest.mock('@hawtiosrc/plugins/shared/jolokia-service')
 
 describe('MBeanTree', () => {
   let wkspTree: MBeanTree
+
+  beforeAll(async () => {
+    await userService.fetchUser()
+  })
 
   beforeEach(async () => {
     wkspTree = await workspace.getTree()

--- a/packages/hawtio/src/plugins/shared/workspace.test.ts
+++ b/packages/hawtio/src/plugins/shared/workspace.test.ts
@@ -1,9 +1,14 @@
+import { userService } from '@hawtiosrc/auth'
 import { MBeanTree } from '@hawtiosrc/plugins/shared/tree'
 import { workspace } from './workspace'
 
 jest.mock('@hawtiosrc/plugins/shared/jolokia-service')
 
 describe('workspace', () => {
+  beforeAll(async () => {
+    await userService.fetchUser()
+  })
+
   test('getting the tree', async () => {
     const tree: MBeanTree = await workspace.getTree()
     expect(tree.isEmpty()).toBeFalsy()

--- a/packages/hawtio/src/preferences/globals.ts
+++ b/packages/hawtio/src/preferences/globals.ts
@@ -1,3 +1,3 @@
-import { Logger } from '@hawtiosrc/core'
+import { Logger } from '@hawtiosrc/core/logging'
 
 export const log = Logger.get('hawtio-preferences')

--- a/packages/hawtio/src/ui/about/globals.ts
+++ b/packages/hawtio/src/ui/about/globals.ts
@@ -1,3 +1,3 @@
-import { Logger } from '@hawtiosrc/core'
+import { Logger } from '@hawtiosrc/core/logging'
 
 export const log = Logger.get('hawtio-ui-about')

--- a/packages/hawtio/src/ui/login/HawtioLoginForm.tsx
+++ b/packages/hawtio/src/ui/login/HawtioLoginForm.tsx
@@ -1,0 +1,83 @@
+import { useUser } from '@hawtiosrc/auth/hooks'
+import { LoginForm } from '@patternfly/react-core'
+import { ExclamationCircleIcon } from '@patternfly/react-icons'
+import React, { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { log } from './globals'
+import { loginService } from './login-service'
+
+export const HawtioLoginForm: React.FunctionComponent = () => {
+  const navigate = useNavigate()
+
+  const { isLogin } = useUser()
+  const [username, setUsername] = useState(loginService.getUser())
+  const [isValidUsername, setIsValidUsername] = useState(true)
+  const [password, setPassword] = useState('')
+  const [isValidPassword, setIsValidPassword] = useState(true)
+  const [rememberMe, setRememberMe] = useState(username !== '')
+  const [loginFailed, setLoginFailed] = useState(false)
+
+  log.debug(`Login state: username = ${username}, isLogin = ${isLogin}`)
+
+  const rememberMeLabel = 'Remember username'
+  const loginFailedMessage = 'Invalid login credentials'
+
+  const reset = () => {
+    setIsValidUsername(true)
+    setIsValidPassword(true)
+    setLoginFailed(false)
+  }
+
+  const doLogin = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    event.preventDefault()
+    reset()
+    let invalid = false
+    if (username.trim() === '') {
+      setIsValidUsername(false)
+      setLoginFailed(true)
+      invalid = true
+    }
+    if (password === '') {
+      setIsValidPassword(false)
+      setLoginFailed(true)
+      invalid = true
+    }
+    if (invalid) {
+      return
+    }
+
+    loginService.login(username, password, rememberMe).then(result => {
+      if (result) {
+        navigate('/')
+        // Reload page to force initialising Jolokia service
+        navigate(0)
+        return
+      }
+      // Login failed
+      setLoginFailed(true)
+      setIsValidUsername(false)
+      setIsValidPassword(false)
+    })
+  }
+
+  return (
+    <LoginForm
+      showHelperText={loginFailed}
+      helperText={loginFailedMessage}
+      helperTextIcon={<ExclamationCircleIcon />}
+      usernameLabel='Username'
+      usernameValue={username}
+      onChangeUsername={setUsername}
+      isValidUsername={isValidUsername}
+      passwordLabel='Password'
+      passwordValue={password}
+      onChangePassword={setPassword}
+      isValidPassword={isValidPassword}
+      rememberMeLabel={rememberMeLabel}
+      isRememberMeChecked={rememberMe}
+      onChangeRememberMe={() => setRememberMe(!rememberMe)}
+      onLoginButtonClick={doLogin}
+      loginButtonLabel='Log in'
+    />
+  )
+}

--- a/packages/hawtio/src/ui/login/globals.ts
+++ b/packages/hawtio/src/ui/login/globals.ts
@@ -1,3 +1,3 @@
-import { Logger } from '@hawtiosrc/core'
+import { Logger } from '@hawtiosrc/core/logging'
 
 export const log = Logger.get('hawtio-ui-login')

--- a/packages/hawtio/src/ui/page/HawtioPage.tsx
+++ b/packages/hawtio/src/ui/page/HawtioPage.tsx
@@ -54,7 +54,10 @@ export const HawtioPage: React.FunctionComponent = () => {
     </PageSection>
   )
 
-  const defaultPlugin = plugins[0] ?? null
+  /* Filter out login plugins */
+  const filteredPlugins = plugins.filter(plugin => !plugin.isLogin)
+
+  const defaultPlugin = filteredPlugins[0] ?? null
   let defaultPage
   if (defaultPlugin) {
     defaultPage = <Navigate to={{ pathname: defaultPlugin.path, search }} />
@@ -65,7 +68,7 @@ export const HawtioPage: React.FunctionComponent = () => {
   const showVerticalNavByDefault = preferencesService.isShowVerticalNavByDefault()
 
   return (
-    <PageContext.Provider value={{ username, plugins }}>
+    <PageContext.Provider value={{ username, plugins: filteredPlugins }}>
       <BackgroundImage src={backgroundImages} />
       <Page
         header={<HawtioHeader />}
@@ -77,7 +80,7 @@ export const HawtioPage: React.FunctionComponent = () => {
         <PluginNodeSelectionContext.Provider value={{ selectedNode, setSelectedNode }}>
           <Routes>
             {/* plugins */}
-            {plugins.map(plugin => (
+            {filteredPlugins.map(plugin => (
               <Route key={plugin.id} path={`${plugin.path}/*`} element={React.createElement(plugin.component)} />
             ))}
             <Route key='help' path='help/*' element={<HawtioHelp />} />

--- a/packages/hawtio/src/ui/page/globals.ts
+++ b/packages/hawtio/src/ui/page/globals.ts
@@ -1,3 +1,3 @@
-import { Logger } from '@hawtiosrc/core'
+import { Logger } from '@hawtiosrc/core/logging'
 
 export const log = Logger.get('hawtio-ui-page')

--- a/packages/hawtio/src/util/jolokia.ts
+++ b/packages/hawtio/src/util/jolokia.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@hawtiosrc/core'
+import { Logger } from '@hawtiosrc/core/logging'
 import {
   AttributeRequestOptions,
   BaseRequestOptions,


### PR DESCRIPTION
While most changes concern updating the UI of the `<HawtioLogin/>` to support a customised child login form, a necessary change is also included for the `JolokiaService`. Specifically, the use-case concerns what happens when logging-out occurs.

When the logging-out button is clicked, the app routes back to `/login` but *was* stuck on displaying the waiting symbol.
Analysis showed that because `<HawtioLogin>` is now using the `usePlugins` hook, the component waits on the `pluginsLoaded` flag. This was never returning `true` indicating that the plugins were never completing resolution. Digging in further indicated that despite not being logged-in the `JMX` plugin was, as a result of its `isActive()` plugin function, still trying to list nodes from the `jolokiaService` yet this process was hanging.
This has been resolved by, since the service was already waiting for the `userService.isLogin()` to return, taking the result of `isLogin()` and if `false` then returning a `null` jolokia url. This causes a dummy tree to be created and the `JMX` plugin to resolve satisfactorily.

