### PR TITLE
fix(shared): jolokia instance is created every time getJolokia() is invoked

### DIFF
--- a/packages/hawtio/src/plugins/rbac/rbac-service.ts
+++ b/packages/hawtio/src/plugins/rbac/rbac-service.ts
@@ -17,7 +17,7 @@ class RBACService implements IRBACService {
     this.aclMBean = undefined
   }
 
-  async getACLMBean(): Promise<string> {
+  getACLMBean(): Promise<string> {
     if (this.aclMBean) {
       return this.aclMBean
     }

--- a/packages/hawtio/src/plugins/shared/workspace.ts
+++ b/packages/hawtio/src/plugins/shared/workspace.ts
@@ -36,7 +36,7 @@ class Workspace implements IWorkspace {
     eventService.refresh()
   }
 
-  async getTree(): Promise<MBeanTree> {
+  getTree(): Promise<MBeanTree> {
     if (this.tree) {
       return this.tree
     }


### PR DESCRIPTION
Basically, lazy-init methods that return Promise should not use async/await as otherwise we would be screwed up with subtle concurrency issues.