### PR TITLE
fix: Adds noconsole rule to guard against casual console.log msgs #625

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint', 'import'],
   rules: {
+    'no-console': 'error',
     semi: ['error', 'never'],
     '@typescript-eslint/explicit-member-accessibility': [
       'warn',

--- a/packages/hawtio/scripts/generate-camel-svg-index.js
+++ b/packages/hawtio/scripts/generate-camel-svg-index.js
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable no-console */
 /* jshint node: true */
 const fs = require('fs')
 const path = require('path')

--- a/packages/hawtio/src/core/logging.ts
+++ b/packages/hawtio/src/core/logging.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { stringSorter } from '@hawtiosrc/util/strings'
 import jsLogger, { GlobalLogger, ILogger, ILogLevel } from 'js-logger'
 import { is, object, type } from 'superstruct'

--- a/packages/hawtio/src/plugins/camel/endpoints/endpoints-service.ts
+++ b/packages/hawtio/src/plugins/camel/endpoints/endpoints-service.ts
@@ -128,9 +128,9 @@ export function createEndpointFromData(
   endPointPath: string,
   parameters: Record<string, string>,
 ) {
-  if (!componentName) console.error('createEndpointFromData: component name must be defined')
+  if (!componentName) log.error('createEndpointFromData: component name must be defined')
 
-  if (!endPointPath) console.error('createEndpointFromData: endpoint path must be defined')
+  if (!endPointPath) log.error('createEndpointFromData: endpoint path must be defined')
 
   log.debug('Have endpoint data ' + JSON.stringify(parameters))
 

--- a/packages/hawtio/src/plugins/camel/exchanges/InflightExchanges.test.tsx
+++ b/packages/hawtio/src/plugins/camel/exchanges/InflightExchanges.test.tsx
@@ -37,7 +37,6 @@ let canDisplayInflightExchanges = false
 jest.mock('./exchanges-service', () => {
   return {
     getInflightExchanges: jest.fn(async () => {
-      console.log('using mocked getInflightExchanges()')
       return Promise.resolve(xchgs)
     }),
     canBrowseInflightExchanges: jest.fn(async (node: MBeanNode): Promise<boolean> => {

--- a/packages/hawtio/src/plugins/shared/__mocks__/connect-service.ts
+++ b/packages/hawtio/src/plugins/shared/__mocks__/connect-service.ts
@@ -2,6 +2,7 @@ import { Connection, ConnectionTestResult, Connections, IConnectService } from '
 
 class MockConnectService implements IConnectService {
   constructor() {
+    // eslint-disable-next-line no-console
     console.log('Using mock connect service')
   }
 

--- a/packages/hawtio/src/plugins/shared/__mocks__/jolokia-service.ts
+++ b/packages/hawtio/src/plugins/shared/__mocks__/jolokia-service.ts
@@ -4,6 +4,7 @@ import jmxCamelResponse from './jmx-camel-tree.json'
 
 class MockJolokiaService implements IJolokiaService {
   constructor() {
+    // eslint-disable-next-line no-console
     console.log('Using mock jolokia service')
   }
 

--- a/packages/hawtio/src/setupTests.ts
+++ b/packages/hawtio/src/setupTests.ts
@@ -10,6 +10,7 @@ fetchMock.enableMocks()
 
 // Default mock response for every usage of fetch
 fetchMock.mockResponse(req => {
+  // eslint-disable-next-line no-console
   console.log('Mock fetch:', req.url)
   let res = '{}'
   switch (req.url) {


### PR DESCRIPTION
* Uses eslint-disable-next-line to keep those instances where it makes sense to use console.[log|error]

issue #625