### PR TITLE
feat(shared): support different loading options for workspace via hawtconfig.json

### DIFF
--- a/app/public/hawtconfig.json
+++ b/app/public/hawtconfig.json
@@ -20,14 +20,8 @@
     "description": "A Hawtio reimplementation based on TypeScript + React.",
     "imgSrc": "hawtio-logo.svg",
     "productInfo": [
-      {
-        "name": "ABC",
-        "value": "1.2.3"
-      },
-      {
-        "name": "XYZ",
-        "value": "7.8.9"
-      }
+      { "name": "ABC", "value": "1.2.3" },
+      { "name": "XYZ", "value": "7.8.9" }
     ],
     "copyright": "© Hawtio project"
   },

--- a/packages/hawtio/src/core/config-manager.ts
+++ b/packages/hawtio/src/core/config-manager.ts
@@ -7,15 +7,48 @@ const log = Logger.get('hawtio-core-config')
 export const DEFAULT_APP_NAME = 'Hawtio Management Console'
 export const DEFAULT_LOGIN_TITLE = 'Log in to your account'
 
+/**
+ * The single user-customisable entrypoint for the Hawtio console configurations.
+ */
 export type Hawtconfig = {
-  branding?: Branding
-  login?: Login
-  about?: About
+  /**
+   * Configuration for branding & styles.
+   */
+  branding?: BrandingConfig
+
+  /**
+   * Configuration for the built-in login page.
+   */
+  login?: LoginConfig
+
+  /**
+   * Configuration for the About modal.
+   */
+  about?: AboutConfig
+
+  /**
+   * The user can explicitly disable plugins by specifying the plugin route paths.
+   *
+   * This option can be used if some of the built-in plugins are not desirable
+   * for the custom installation of Hawtio console.
+   */
   disabledRoutes?: DisabledRoutes
-  online?: Online
+
+  /**
+   * Configuration for JMX plugin.
+   */
+  jmx?: JmxConfig
+
+  /**
+   * Configuration for Hawtio Online.
+   */
+  online?: OnlineConfig
 }
 
-export type Branding = {
+/**
+ * Branding configuration type.
+ */
+export type BrandingConfig = {
   appName?: string
   showAppName?: boolean
   appLogoUrl?: string
@@ -23,7 +56,10 @@ export type Branding = {
   favicon?: string
 }
 
-export type Login = {
+/**
+ * Login configuration type.
+ */
+export type LoginConfig = {
   title?: string
   description?: string
   links?: LoginLink[]
@@ -34,7 +70,10 @@ export type LoginLink = {
   text: string
 }
 
-export type About = {
+/**
+ * About configuration type.
+ */
+export type AboutConfig = {
   title?: string
   description?: string
   imgSrc?: string
@@ -49,7 +88,33 @@ export type AboutProductInfo = {
 
 export type DisabledRoutes = string[]
 
-export type Online = {
+/**
+ * JMX configuration type.
+ */
+export type JmxConfig = {
+  /**
+   * This option can either disable workspace completely by setting `false`, or
+   * specify an array of MBean paths in the form of
+   * `<domain>/<prop1>=<value1>,<prop2>=<value2>,...`
+   * to fine-tune which MBeans to load into workspace.
+   *
+   * Note that disabling workspace should also deactivate all the plugins that
+   * depend on MBeans provided by workspace.
+   *
+   * @see https://github.com/hawtio/hawtio-next/issues/421
+   */
+  workspace?: boolean | string[]
+}
+
+/**
+ * Hawtio Online configuration type.
+ */
+export type OnlineConfig = {
+  /**
+   * Selector for OpenShift projects or Kubernetes namespaces.
+   *
+   * @see https://github.com/hawtio/hawtio-online/issues/64
+   */
   projectSelector?: string
 }
 

--- a/packages/hawtio/src/plugins/shared/__mocks__/jolokia-service.ts
+++ b/packages/hawtio/src/plugins/shared/__mocks__/jolokia-service.ts
@@ -1,6 +1,7 @@
 import Jolokia, { ListRequestOptions, Request, Response } from 'jolokia.js'
 import { AttributeValues, IJolokiaService, JolokiaListMethod, JolokiaStoredOptions } from '../jolokia-service'
 import jmxCamelResponse from './jmx-camel-tree.json'
+import { OptimisedJmxDomains } from '../tree'
 
 class MockJolokiaService implements IJolokiaService {
   constructor() {
@@ -28,12 +29,12 @@ class MockJolokiaService implements IJolokiaService {
     return ''
   }
 
-  async list(options?: ListRequestOptions): Promise<unknown> {
-    return jmxCamelResponse
+  async list(options?: ListRequestOptions): Promise<OptimisedJmxDomains> {
+    return jmxCamelResponse.domains as unknown as OptimisedJmxDomains
   }
 
-  async sublist(path: string, options?: ListRequestOptions): Promise<unknown> {
-    return jmxCamelResponse
+  async sublist(paths: string | string[], options?: ListRequestOptions): Promise<OptimisedJmxDomains> {
+    return jmxCamelResponse.domains as unknown as OptimisedJmxDomains
   }
 
   async readAttributes(mbean: string): Promise<AttributeValues> {

--- a/packages/hawtio/src/ui/about/context.ts
+++ b/packages/hawtio/src/ui/about/context.ts
@@ -1,11 +1,11 @@
-import { About, configManager } from '@hawtiosrc/core'
+import { AboutConfig, configManager } from '@hawtiosrc/core'
 import { useEffect, useState } from 'react'
 
 /**
  * Custom React hook for using Hawtio About.
  */
 export function useAbout() {
-  const [about, setAbout] = useState<About>({})
+  const [about, setAbout] = useState<AboutConfig>({})
   const [aboutLoaded, setAboutLoaded] = useState(false)
 
   useEffect(() => {


### PR DESCRIPTION
Fix #421

With this fix, now `hawtconfig.json` is enhanced to accept `jmx` option with `workspace` in it like this:

```json
{
  ...
  "jmx": {
    "workspace": ["hawtio", "java.lang/type=Memory", "org.apache.camel", "no.such.domain"]
  },
  ...
}
```

The `workspace` accepts either `boolean` or `string[]` and if it's set to `false` you can disable the workspace completely, which is effectively the zero preload mode requested at #421.