### PR TITLE
feat(springboot-plugin): Add trace view 

### DIFF
--- a/packages/hawtio/src/plugins/springboot/Health.tsx
+++ b/packages/hawtio/src/plugins/springboot/Health.tsx
@@ -11,8 +11,8 @@ import {
   PageSection,
   Title,
 } from '@patternfly/react-core'
-import { springbootService } from '@hawtiosrc/plugins/springboot/springboot-service'
-import { HealthComponentDetail, HealthData } from '@hawtiosrc/plugins/springboot/types'
+import { springbootService } from './springboot-service'
+import { HealthComponentDetail, HealthData } from './types'
 import { TableComposable, Tbody, Td, Tr } from '@patternfly/react-table'
 import { humanizeLabels } from '@hawtiosrc/util/strings'
 import { ChartDonutUtilization } from '@patternfly/react-charts'

--- a/packages/hawtio/src/plugins/springboot/Health.tsx
+++ b/packages/hawtio/src/plugins/springboot/Health.tsx
@@ -11,7 +11,7 @@ import {
   PageSection,
   Title,
 } from '@patternfly/react-core'
-import { loadHealth } from '@hawtiosrc/plugins/springboot/springboot-service'
+import { springbootService } from '@hawtiosrc/plugins/springboot/springboot-service'
 import { HealthComponentDetail, HealthData } from '@hawtiosrc/plugins/springboot/types'
 import { TableComposable, Tbody, Td, Tr } from '@patternfly/react-table'
 import { humanizeLabels } from '@hawtiosrc/util/strings'
@@ -97,7 +97,7 @@ export const Health: React.FunctionComponent = () => {
   const [healthData, setHealthData] = useState<HealthData>()
 
   useEffect(() => {
-    loadHealth().then(healthData => {
+    springbootService.loadHealth().then(healthData => {
       setHealthData(healthData)
     })
   }, [])
@@ -124,7 +124,7 @@ export const Health: React.FunctionComponent = () => {
               key={component.name}
               mdRowSpan={componentSpanRecord[component.name]![1] as gridSpans}
             >
-              <Card>
+              <Card isFullHeight>
                 <CardHeader>
                   <Title headingLevel='h3'>{humanizeLabels(component.name!)}</Title>
                 </CardHeader>

--- a/packages/hawtio/src/plugins/springboot/Info.tsx
+++ b/packages/hawtio/src/plugins/springboot/Info.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { FormGroup, PageSection } from '@patternfly/react-core'
-import { springbootService } from '@hawtiosrc/plugins/springboot/springboot-service'
+import { springbootService } from './springboot-service'
 import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table'
 
 export const Info: React.FunctionComponent = () => {

--- a/packages/hawtio/src/plugins/springboot/Info.tsx
+++ b/packages/hawtio/src/plugins/springboot/Info.tsx
@@ -1,13 +1,13 @@
 import React, { useEffect, useState } from 'react'
 import { FormGroup, PageSection } from '@patternfly/react-core'
-import { getInfo } from '@hawtiosrc/plugins/springboot/springboot-service'
+import { springbootService } from '@hawtiosrc/plugins/springboot/springboot-service'
 import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table'
 
 export const Info: React.FunctionComponent = () => {
   const [systemProperties, setSystemProperties] = useState<{ key: string; value: string }[]>([])
 
   useEffect(() => {
-    getInfo().then(res => {
+    springbootService.getInfo().then(res => {
       setSystemProperties(res)
     })
   }, [])

--- a/packages/hawtio/src/plugins/springboot/Loggers.tsx
+++ b/packages/hawtio/src/plugins/springboot/Loggers.tsx
@@ -19,7 +19,7 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core'
-import { configureLogLevel, getLoggerConfiguration } from '@hawtiosrc/plugins/springboot/springboot-service'
+import { springbootService } from '@hawtiosrc/plugins/springboot/springboot-service'
 import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table'
 import { SearchIcon } from '@patternfly/react-icons'
 import { Logger } from '@hawtiosrc/plugins/springboot/types'
@@ -36,7 +36,7 @@ const SetLogDropdown: React.FunctionComponent<{
     <DropdownItem
       key={loggerName + '' + level}
       onClick={() => {
-        configureLogLevel(loggerName, level)
+        springbootService.configureLogLevel(loggerName, level)
         reloadLoggers()
       }}
     >
@@ -93,7 +93,7 @@ export const Loggers: React.FunctionComponent = () => {
   const [reloadLoggers, setReloadLoggers] = useState(false)
 
   useEffect(() => {
-    getLoggerConfiguration().then(logConf => {
+    springbootService.getLoggerConfiguration().then(logConf => {
       const sorted = logConf.loggers.sort((logger1, logger2) => {
         if (logger1.name === 'ROOT') return -1
         else if (logger2.name === 'ROOT') return 1

--- a/packages/hawtio/src/plugins/springboot/Loggers.tsx
+++ b/packages/hawtio/src/plugins/springboot/Loggers.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import {
   Bullseye,
   Button,
@@ -19,10 +19,10 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core'
-import { springbootService } from '@hawtiosrc/plugins/springboot/springboot-service'
+import { springbootService } from './springboot-service'
 import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table'
 import { SearchIcon } from '@patternfly/react-icons'
-import { Logger } from '@hawtiosrc/plugins/springboot/types'
+import { Logger } from './types'
 
 const SetLogDropdown: React.FunctionComponent<{
   currentLevel: string
@@ -105,33 +105,16 @@ export const Loggers: React.FunctionComponent = () => {
     })
   }, [reloadLoggers])
 
-  const handleSearch = useCallback(
-    (value: string, logLevel: string, filters: string[]) => {
-      let filtered: Logger[] =
-        loggers.filter(logger => {
-          if (logLevel === 'ALL') {
-            if (value === '') {
-              return true
-            } else {
-              return logger.name.toLowerCase().includes(value.toLowerCase())
-            }
-          }
-          return logger.configuredLevel === logLevel && logger.name.toLowerCase().includes(value.toLowerCase())
-        }) ?? []
-
-      //filter with the rest of the filters
-      filters.forEach(value => {
-        filtered = filtered.filter(prop => prop.name.toLowerCase().includes(value.toLowerCase()))
-      })
-      setFilteredLoggers([...filtered])
-    },
-    [loggers],
-  )
-
   useEffect(() => {
-    handleSearch(searchTerm, logLevel, filters)
+    let filtered: Logger[] = loggers.filter(logger => logLevel === 'ALL' || logger.configuredLevel === logLevel)
+
+    //filter with the rest of the filters
+    ;[...filters, searchTerm].forEach(value => {
+      filtered = filtered.filter(prop => prop.name.toLowerCase().includes(value.toLowerCase()))
+    })
+    setFilteredLoggers([...filtered])
     setPage(1)
-  }, [filters, searchTerm, logLevel, loggers, handleSearch])
+  }, [filters, searchTerm, logLevel, loggers])
 
   const onDeleteFilter = (filter: string) => {
     const newFilters = filters.filter(f => f !== filter)

--- a/packages/hawtio/src/plugins/springboot/SpringBoot.tsx
+++ b/packages/hawtio/src/plugins/springboot/SpringBoot.tsx
@@ -2,11 +2,11 @@ import { Nav, NavItem, NavList, PageGroup, PageNavigation, PageSection, Title } 
 import React, { useEffect, useState } from 'react'
 
 import { Navigate, NavLink, Route, Routes, useLocation } from 'react-router-dom'
-import { Health } from '@hawtiosrc/plugins/springboot/Health'
-import { Info } from '@hawtiosrc/plugins/springboot/Info'
-import { Loggers } from '@hawtiosrc/plugins/springboot/Loggers'
-import { TraceView } from '@hawtiosrc/plugins/springboot/TraceView'
-import { springbootService } from '@hawtiosrc/plugins/springboot/springboot-service'
+import { Health } from './Health'
+import { Info } from './Info'
+import { Loggers } from './Loggers'
+import { TraceView } from './TraceView'
+import { springbootService } from './springboot-service'
 
 type NavItem = {
   id: string
@@ -33,12 +33,12 @@ export const SpringBoot: React.FunctionComponent = () => {
       }
 
       if (await springbootService.hasEndpoint('Httptrace')) {
-        springbootService.setisSb3(false)
+        springbootService.setIsSpringBoot3(false)
         nav.push({ id: 'trace', title: 'Trace', component: <TraceView /> })
       }
 
       if (await springbootService.hasEndpoint('Httpexchanges')) {
-        springbootService.setisSb3(true)
+        springbootService.setIsSpringBoot3(true)
         nav.push({ id: 'trace', title: 'Trace', component: <TraceView /> })
       }
 

--- a/packages/hawtio/src/plugins/springboot/SpringBoot.tsx
+++ b/packages/hawtio/src/plugins/springboot/SpringBoot.tsx
@@ -32,10 +32,13 @@ export const SpringBoot: React.FunctionComponent = () => {
         nav.push({ id: 'loggers', title: 'Loggers', component: <Loggers /> })
       }
 
-      if (
-        (await springbootService.hasEndpoint('Httptrace')) ||
-        (await springbootService.hasEndpoint('Httpexchanges'))
-      ) {
+      if (await springbootService.hasEndpoint('Httptrace')) {
+        springbootService.setisSb3(false)
+        nav.push({ id: 'trace', title: 'Trace', component: <TraceView /> })
+      }
+
+      if (await springbootService.hasEndpoint('Httpexchanges')) {
+        springbootService.setisSb3(true)
         nav.push({ id: 'trace', title: 'Trace', component: <TraceView /> })
       }
 

--- a/packages/hawtio/src/plugins/springboot/SpringBoot.tsx
+++ b/packages/hawtio/src/plugins/springboot/SpringBoot.tsx
@@ -5,8 +5,8 @@ import { Navigate, NavLink, Route, Routes, useLocation } from 'react-router-dom'
 import { Health } from '@hawtiosrc/plugins/springboot/Health'
 import { Info } from '@hawtiosrc/plugins/springboot/Info'
 import { Loggers } from '@hawtiosrc/plugins/springboot/Loggers'
-import { Trace } from '@hawtiosrc/plugins/springboot/Trace'
-import { hasEndpoint } from '@hawtiosrc/plugins/springboot/springboot-service'
+import { TraceView } from '@hawtiosrc/plugins/springboot/TraceView'
+import { springbootService } from '@hawtiosrc/plugins/springboot/springboot-service'
 
 type NavItem = {
   id: string
@@ -20,20 +20,23 @@ export const SpringBoot: React.FunctionComponent = () => {
   useEffect(() => {
     const initNavItems = async () => {
       const nav: NavItem[] = []
-      if (await hasEndpoint('Health')) {
+      if (await springbootService.hasEndpoint('Health')) {
         nav.push({ id: 'health', title: 'Health', component: <Health /> })
       }
 
-      if (await hasEndpoint('Info')) {
+      if (await springbootService.hasEndpoint('Info')) {
         nav.push({ id: 'info', title: 'Info', component: <Info /> })
       }
 
-      if (await hasEndpoint('Loggers')) {
+      if (await springbootService.hasEndpoint('Loggers')) {
         nav.push({ id: 'loggers', title: 'Loggers', component: <Loggers /> })
       }
 
-      if (await hasEndpoint('Trace')) {
-        nav.push({ id: 'trace', title: 'Trace', component: <Trace /> })
+      if (
+        (await springbootService.hasEndpoint('Httptrace')) ||
+        (await springbootService.hasEndpoint('Httpexchanges'))
+      ) {
+        nav.push({ id: 'trace', title: 'Trace', component: <TraceView /> })
       }
 
       setNavItems([...nav])

--- a/packages/hawtio/src/plugins/springboot/Trace.tsx
+++ b/packages/hawtio/src/plugins/springboot/Trace.tsx
@@ -1,4 +1,0 @@
-import React from 'react'
-import { PageSection } from '@patternfly/react-core'
-
-export const Trace: React.FunctionComponent = () => <PageSection variant='light'>Trace - TO BE DONE</PageSection>

--- a/packages/hawtio/src/plugins/springboot/TraceView.tsx
+++ b/packages/hawtio/src/plugins/springboot/TraceView.tsx
@@ -1,0 +1,320 @@
+import React, { useState } from 'react'
+import {
+  Bullseye,
+  Button,
+  Card,
+  Dropdown,
+  DropdownItem,
+  DropdownToggle,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  Flex,
+  FormGroup,
+  Label,
+  PageSection,
+  Pagination,
+  SearchInput,
+  Toolbar,
+  ToolbarContent,
+  ToolbarFilter,
+  ToolbarGroup,
+  ToolbarItem,
+} from '@patternfly/react-core'
+import { TableComposable, Tbody, Td, Th, Thead, ThProps, Tr } from '@patternfly/react-table'
+import { CheckCircleIcon, ExclamationCircleIcon, SearchIcon } from '@patternfly/react-icons'
+import { Trace } from '@hawtiosrc/plugins/springboot/types'
+
+const HttpStatusIcon: React.FunctionComponent<{ code: number }> = ({ code }) => {
+  if (code < 400) return <CheckCircleIcon color={'#3E8635'} />
+  else return <ExclamationCircleIcon color={'#C9190B'} />
+}
+
+const HttpMethodLabel: React.FunctionComponent<{ level: string }> = ({ level }) => {
+  switch (level) {
+    case 'GET':
+    case 'HEAD':
+      return <Label color='blue'>{level}</Label>
+    case 'POST':
+      return <Label color='orange'>{level}</Label>
+    case 'DELETE':
+      return <Label color='red'>{level}</Label>
+    case 'PUT':
+    case 'PATCH':
+      return <Label color='green'>{level}</Label>
+    default:
+      return <Label color='grey'>{level}</Label>
+  }
+}
+export const TraceView: React.FunctionComponent = () => {
+  const [traces, setTraces] = useState<Trace[]>([
+    { timestamp: 1000, httpStatusCode: 200, method: 'GET', path: '/', timeTaken: 123213 },
+    { timestamp: 1000, httpStatusCode: 200, method: 'GET', path: '/', timeTaken: 123213 },
+    { timestamp: 1000, httpStatusCode: 200, method: 'GET', path: '/', timeTaken: 123213 },
+    { timestamp: 1000, httpStatusCode: 200, method: 'GET', path: '/', timeTaken: 123213 },
+    { timestamp: 1000, httpStatusCode: 400, method: 'GET', path: '/', timeTaken: 123213 },
+    { timestamp: 1000, httpStatusCode: 500, method: 'GET', path: '/', timeTaken: 123213 },
+    { timestamp: 1000, httpStatusCode: 500, method: 'GET', path: '/', timeTaken: 123213 },
+    { timestamp: 1000, httpStatusCode: 200, method: 'GET', path: '/', timeTaken: 123213 },
+    { timestamp: 1000, httpStatusCode: 200, method: 'GET', path: '/', timeTaken: 123213 },
+  ])
+  const [filteredTraces, setFilteredTraces] = useState<Trace[]>([
+    { timestamp: 1000, httpStatusCode: 200, method: 'GET', path: '/', timeTaken: 123213 },
+    { timestamp: 1000, httpStatusCode: 200, method: 'GET', path: '/', timeTaken: 123213 },
+    { timestamp: 1000, httpStatusCode: 200, method: 'GET', path: '/', timeTaken: 123213 },
+    { timestamp: 1000, httpStatusCode: 200, method: 'GET', path: '/', timeTaken: 123213 },
+    { timestamp: 1000, httpStatusCode: 400, method: 'GET', path: '/', timeTaken: 123213 },
+    { timestamp: 1000, httpStatusCode: 500, method: 'GET', path: '/', timeTaken: 123213 },
+    { timestamp: 1000, httpStatusCode: 500, method: 'GET', path: '/', timeTaken: 123213 },
+    { timestamp: 1000, httpStatusCode: 200, method: 'GET', path: '/', timeTaken: 123213 },
+    { timestamp: 1000, httpStatusCode: 200, method: 'GET', path: '/', timeTaken: 123213 },
+  ])
+
+  const [httpMethodFilter, setMethodFilter] = useState<string>('ALL')
+  const [page, setPage] = useState(1)
+  const [perPage, setPerPage] = useState(20)
+  const [searchTerm, setSearchTerm] = useState('')
+  const [filters, setFilters] = useState<string[]>([])
+  const [attributeMenuItem, setAttributeMenuItem] = useState('HTTP Method')
+  const [isFilterDropdownOpen, setIsFilterDropdownOpen] = useState(false)
+  const [isHttpMethodFilterDropdownOpen, setIsHttpMethodFilterDropdownOpen] = useState(false)
+  // const [isTraceDetailsOpen, setIsTraceDetailsOpen] = useState(false)
+  //const [currentThread, setCurrentThread] = useState<Thread>()
+
+  const onDeleteFilter = (filter: string) => {
+    const newFilters = filters.filter(f => f !== filter)
+    setFilters(newFilters)
+    handleSearch(searchTerm, attributeMenuItem, newFilters)
+  }
+
+  const addToFilters = () => {
+    setFilters([...filters, `${attributeMenuItem}:${searchTerm}`])
+    setSearchTerm('')
+  }
+
+  const clearFilters = () => {
+    setFilters([])
+    setSearchTerm('')
+    handleSearch('', attributeMenuItem, [])
+  }
+
+  const PropsPagination = () => {
+    return (
+      <Pagination
+        itemCount={filteredTraces.length}
+        page={page}
+        perPage={perPage}
+        onSetPage={(_evt, value) => setPage(value)}
+        onPerPageSelect={(_evt, value) => {
+          setPerPage(value)
+          setPage(1)
+        }}
+        variant='top'
+      />
+    )
+  }
+
+  const getTablePage = (): Trace[] => {
+    const start = (page - 1) * perPage
+    const end = start + perPage
+    return filteredTraces.slice(start, end)
+  }
+
+  const handleSearch = (value: string, key: string, filters: string[]) => {
+    setSearchTerm(value)
+    //filter with findTerm
+    let filtered: Trace[] = []
+
+    if (value === '') {
+      filtered = [...traces]
+    } else {
+      filtered = traces.filter(trace => {
+        return trace.method.toLowerCase().includes(httpMethodFilter.toLowerCase())
+      })
+    }
+
+    //filter with the rest of the filters
+    filters.forEach(value => {
+      const attr = value.split(':')[0] ?? ''
+      const searchTerm = value.split(':')[1] ?? ''
+      switch (attr) {
+        case 'timestamp':
+          filtered = filtered.filter(trace => trace.timestamp === searchTerm)
+          break
+        case 'status':
+          filtered = filtered.filter(trace => parseInt(searchTerm) === trace.httpStatusCode)
+          break
+        case 'path':
+          filtered = filtered.filter(trace => trace.path === searchTerm)
+          break
+        case 'timeTaken':
+          filtered = filtered.filter(trace => parseInt(searchTerm) === trace.timeTaken)
+          break
+      }
+    })
+
+    setSearchTerm(value)
+    setPage(1)
+    setFilteredTraces([...filtered])
+  }
+
+  const tableColumns = [
+    { key: 'timestamp', value: 'Timestamp' },
+    { key: 'httpStatus', value: 'HTTP Status' },
+    { key: 'httpMethod', value: 'HTTP Method' },
+    { key: 'path', value: 'Path' },
+    { key: 'timeTaken', value: 'Time Taken' },
+  ]
+
+  const dropdownItems = tableColumns.map(col => (
+    <DropdownItem
+      onClick={() => {
+        setAttributeMenuItem(col.value)
+        handleSearch(searchTerm, col.value, filters)
+      }}
+      key={col.key}
+    >
+      {col.value}
+    </DropdownItem>
+  ))
+
+  const httpMethodsDropdownItems = ['ALL', 'GET', 'POST', 'DELETE', 'HEAD', 'OPTIONS', 'PATCH', 'PUT', 'TRACE'].map(
+    method => <DropdownItem onClick={() => setMethodFilter(method)} key={'method-' + method}></DropdownItem>,
+  )
+
+  const onShowTraceDetailClick = () => {
+    //  setIsTraceDetailsOpen(true)
+  }
+
+  const TableToolbar: React.FunctionComponent = () => (
+    <Toolbar>
+      <ToolbarContent>
+        <ToolbarItem>
+          <Dropdown
+            data-testid='http-method-select'
+            onSelect={() => setIsHttpMethodFilterDropdownOpen(false)}
+            toggle={
+              <DropdownToggle
+                data-testid='attribute-select-toggle'
+                id='toggle-basic'
+                onToggle={setIsHttpMethodFilterDropdownOpen}
+              >
+                {httpMethodFilter}
+              </DropdownToggle>
+            }
+            isOpen={isHttpMethodFilterDropdownOpen}
+            dropdownItems={httpMethodsDropdownItems}
+          />
+        </ToolbarItem>
+        <ToolbarGroup>
+          <Dropdown
+            data-testid='attribute-select'
+            onSelect={() => setIsFilterDropdownOpen(false)}
+            defaultValue='HTTP Method'
+            toggle={
+              <DropdownToggle
+                data-testid='attribute-select-toggle'
+                id='toggle-basic'
+                onToggle={setIsFilterDropdownOpen}
+              >
+                {tableColumns.find(att => att.value === attributeMenuItem)?.value}
+              </DropdownToggle>
+            }
+            isOpen={isFilterDropdownOpen}
+            dropdownItems={dropdownItems}
+          />
+          <ToolbarFilter
+            chips={filters}
+            deleteChip={(_e, filter) => onDeleteFilter(filter as string)}
+            deleteChipGroup={clearFilters}
+            categoryName='Filters'
+          >
+            <SearchInput
+              type='text'
+              data-testid='filter-input'
+              id='search-input'
+              placeholder='Search...'
+              value={searchTerm}
+              onChange={(_event, value) => handleSearch(value, attributeMenuItem, filters)}
+              aria-label='Search input'
+            />
+          </ToolbarFilter>
+          <ToolbarItem>
+            <Button variant='secondary' onClick={addToFilters} isSmall>
+              Add Filter
+            </Button>
+          </ToolbarItem>
+        </ToolbarGroup>
+
+        <ToolbarItem variant='pagination'>
+          <PropsPagination />
+        </ToolbarItem>
+      </ToolbarContent>
+    </Toolbar>
+  )
+
+  return (
+    <PageSection>
+      <Card isFullHeight>
+        {/*<ThreadsDumpModal isOpen={isThreadsDumpModalOpen} setIsOpen={setIsThreadsDumpModalOpen} />*/}
+        {/*<ThreadInfoModal isOpen={isThreadDetailsOpen} thread={currentThread} setIsOpen={setIsThreadDetailsOpen} />*/}
+        <TableToolbar />
+        {getTablePage().length > 0 && (
+          <FormGroup>
+            <TableComposable aria-label='Message Table' variant='compact' height='80vh' isStriped isStickyHeader>
+              <Thead>
+                <Tr>
+                  {tableColumns.map((att, index) => (
+                    <Th key={'th-key' + index} data-testid={'id-' + att.key}>
+                      {att.value}
+                    </Th>
+                  ))}
+                  <Th> Actions</Th>
+                </Tr>
+              </Thead>
+              <Tbody>
+                {getTablePage().map((trace, index) => {
+                  return (
+                    <Tr key={'row' + index} data-testid={'row' + index}>
+                      <Td key={'col-timestamp'}>{trace.timestamp}</Td>
+                      <Td key={'col-http-status'}>
+                        <Flex>
+                          <HttpStatusIcon code={trace.httpStatusCode} />
+                          <span>{trace.httpStatusCode}</span>
+                        </Flex>
+                      </Td>
+                      <Td key={'col-http=method'}>
+                        <HttpMethodLabel level={trace.method} />
+                      </Td>
+                      <Td key={'col-path'}>{trace.path}</Td>
+                      <Td key={'col-time-taken'}>{trace.timeTaken}</Td>
+                      <Td>
+                        <Button
+                          onClick={_event => {
+                            setIsTraceDetailsOpen(true)
+                            setCurrentThread(trace)
+                          }}
+                          isSmall
+                        >
+                          More
+                        </Button>
+                      </Td>
+                    </Tr>
+                  )
+                })}
+              </Tbody>
+            </TableComposable>
+          </FormGroup>
+        )}
+        {filteredTraces.length === 0 && (
+          <Bullseye>
+            <EmptyState>
+              <EmptyStateIcon icon={SearchIcon} />
+              <EmptyStateBody>No results found.</EmptyStateBody>
+            </EmptyState>
+          </Bullseye>
+        )}
+      </Card>
+    </PageSection>
+  )
+}

--- a/packages/hawtio/src/plugins/springboot/index.ts
+++ b/packages/hawtio/src/plugins/springboot/index.ts
@@ -4,7 +4,7 @@ import { helpRegistry } from '@hawtiosrc/help'
 import { SpringBoot } from '@hawtiosrc/plugins/springboot/SpringBoot'
 import { pluginId, pluginPath } from './globals'
 import help from './help.md'
-import { isActive } from './springboot-service'
+import { springbootService } from './springboot-service'
 
 const order = 17
 
@@ -15,7 +15,7 @@ export const springboot: HawtioPlugin = () => {
     path: pluginPath,
     order,
     component: SpringBoot,
-    isActive,
+    isActive: springbootService.isActive,
   })
   helpRegistry.add(pluginId, 'Spring Boot', help, order)
 }

--- a/packages/hawtio/src/plugins/springboot/index.ts
+++ b/packages/hawtio/src/plugins/springboot/index.ts
@@ -1,7 +1,7 @@
 import { hawtio, HawtioPlugin } from '@hawtiosrc/core'
 
 import { helpRegistry } from '@hawtiosrc/help'
-import { SpringBoot } from '@hawtiosrc/plugins/springboot/SpringBoot'
+import { SpringBoot } from './SpringBoot'
 import { pluginId, pluginPath } from './globals'
 import help from './help.md'
 import { springbootService } from './springboot-service'

--- a/packages/hawtio/src/plugins/springboot/springboot-service.ts
+++ b/packages/hawtio/src/plugins/springboot/springboot-service.ts
@@ -1,90 +1,102 @@
 import { jolokiaService, workspace } from '@hawtiosrc/plugins'
 import { HealthComponent, HealthData, JolokiaHealthData, Logger, LoggerConfiguration } from './types'
 
-export function isActive(): Promise<boolean> {
-  return workspace.treeContainsDomainAndProperties('org.springframework.boot')
-}
+class SpringbootService {
+  isActive(): Promise<boolean> {
+    return workspace.treeContainsDomainAndProperties('org.springframework.boot')
+  }
 
-export async function loadHealth(): Promise<HealthData> {
-  const data = (await jolokiaService.execute(
-    'org.springframework.boot:type=Endpoint,name=Health',
-    'health',
-  )) as JolokiaHealthData
-  let healthComponents: HealthComponent[] = []
+  async loadHealth(): Promise<HealthData> {
+    const data = (await jolokiaService.execute(
+      'org.springframework.boot:type=Endpoint,name=Health',
+      'health',
+    )) as JolokiaHealthData
+    let healthComponents: HealthComponent[] = []
 
-  healthComponents = Object.entries(data.components).map(([componentName, component]) => {
-    let details
+    healthComponents = Object.entries(data.components).map(([componentName, component]) => {
+      let details
 
-    if (component.details) {
-      details = Object.entries(component.details).map(([detailKey, detailValue]) => {
-        const typ = typeof detailValue
-        const value = ['string', 'number', 'boolean'].includes(typ)
-          ? detailValue.toString()
-          : Object.entries(detailValue).map(([key, value]) => ({ key, value }))
+      if (component.details) {
+        details = Object.entries(component.details).map(([detailKey, detailValue]) => {
+          const typ = typeof detailValue
+          const value = ['string', 'number', 'boolean'].includes(typ)
+            ? detailValue.toString()
+            : Object.entries(detailValue).map(([key, value]) => ({ key, value }))
 
-        return {
-          key: detailKey,
-          value: value,
-        }
-      })
-    }
-
-    return {
-      name: componentName,
-      status: component.status,
-      details: component.details ? details : undefined,
-    }
-  })
-
-  return { status: data.status, components: healthComponents }
-}
-
-export async function getInfo() {
-  const res = await jolokiaService.execute('org.springframework.boot:type=Endpoint,name=Info', 'info')
-  const properties: { key: string; value: string }[] = Object.entries(res as object).map(([key, value]) => ({
-    key,
-    value,
-  }))
-  return properties
-}
-
-export async function hasEndpoint(name: string): Promise<boolean> {
-  return await workspace.treeContainsDomainAndProperties('org.springframework.boot', { type: 'Endpoint', name: name })
-}
-
-export async function getLoggerConfiguration() {
-  const data = (await jolokiaService.execute('org.springframework.boot:type=Endpoint,name=Loggers', 'loggers')) as {
-    loggers: {
-      [key: string]: {
-        configuredLevel?: string
-        effectiveLevel: string
+          return {
+            key: detailKey,
+            value: value,
+          }
+        })
       }
-    }
-    levels: string[]
+
+      return {
+        name: componentName,
+        status: component.status,
+        details: component.details ? details : undefined,
+      }
+    })
+
+    return { status: data.status, components: healthComponents }
   }
 
-  const loggers: Logger[] = []
-
-  Object.entries(data.loggers).forEach(([loggerName, loggerInfo]) => {
-    const logger: Logger = {
-      name: loggerName,
-      configuredLevel: loggerInfo['configuredLevel'] == null ? loggerInfo.effectiveLevel : loggerInfo.configuredLevel,
-      effectiveLevel: loggerInfo.effectiveLevel,
-    }
-    loggers.push(logger)
-  })
-
-  const loggerConfiguration: LoggerConfiguration = {
-    levels: data.levels,
-    loggers: loggers,
+  //
+  // export async function getTraces:Promise<Trace[]> () {
+  //   const isSb4 = true
+  //   let data = {trace
+  //   if(isSb4) {
+  //
+  //   }
+  //   const data = await jolokiaService.execute('org.springframework.boot:type=Endpoint,name=Httpexchanges', 'httpExchanges')
+  // }
+  async getInfo() {
+    const res = await jolokiaService.execute('org.springframework.boot:type=Endpoint,name=Info', 'info')
+    const properties: { key: string; value: string }[] = Object.entries(res as object).map(([key, value]) => ({
+      key,
+      value,
+    }))
+    return properties
   }
 
-  return loggerConfiguration
-}
+  hasEndpoint(name: string): Promise<boolean> {
+    return workspace.treeContainsDomainAndProperties('org.springframework.boot', { type: 'Endpoint', name: name })
+  }
 
-export async function configureLogLevel(loggerName: string, loggerLevel: string) {
-  return await jolokiaService.execute('org.springframework.boot:type=Endpoint,name=Loggers', 'configureLogLevel', [
-    loggerName,
-    loggerLevel,
-  ])
+  async getLoggerConfiguration() {
+    const data = (await jolokiaService.execute('org.springframework.boot:type=Endpoint,name=Loggers', 'loggers')) as {
+      loggers: {
+        [key: string]: {
+          configuredLevel?: string
+          effectiveLevel: string
+        }
+      }
+      levels: string[]
+    }
+
+    const loggers: Logger[] = []
+
+    Object.entries(data.loggers).forEach(([loggerName, loggerInfo]) => {
+      const logger: Logger = {
+        name: loggerName,
+        configuredLevel: loggerInfo['configuredLevel'] == null ? loggerInfo.effectiveLevel : loggerInfo.configuredLevel,
+        effectiveLevel: loggerInfo.effectiveLevel,
+      }
+      loggers.push(logger)
+    })
+
+    const loggerConfiguration: LoggerConfiguration = {
+      levels: data.levels,
+      loggers: loggers,
+    }
+
+    return loggerConfiguration
+  }
+
+  async configureLogLevel(loggerName: string, loggerLevel: string) {
+    return await jolokiaService.execute('org.springframework.boot:type=Endpoint,name=Loggers', 'configureLogLevel', [
+      loggerName,
+      loggerLevel,
+    ])
+  }
 }
+export const springbootService = new SpringbootService()

--- a/packages/hawtio/src/plugins/springboot/springboot-service.ts
+++ b/packages/hawtio/src/plugins/springboot/springboot-service.ts
@@ -1,15 +1,15 @@
 import { jolokiaService, workspace } from '@hawtiosrc/plugins'
-import { HealthComponent, HealthData, JmXTrace, JolokiaHealthData, Logger, LoggerConfiguration, Trace } from './types'
+import { HealthComponent, HealthData, JmxTrace, JolokiaHealthData, Logger, LoggerConfiguration, Trace } from './types'
 
-class SpringbootService {
-  isSb3 = true
+class SpringBootService {
+  isSpringBoot3 = true
 
   isActive(): Promise<boolean> {
     return workspace.treeContainsDomainAndProperties('org.springframework.boot')
   }
 
-  setisSb3(is: boolean) {
-    this.isSb3 = is
+  setIsSpringBoot3(is: boolean) {
+    this.isSpringBoot3 = is
   }
 
   async loadHealth(): Promise<HealthData> {
@@ -115,8 +115,8 @@ class SpringbootService {
     const traces: Trace[] = []
     let mbeanName = 'Httpexchanges'
     let mbeanOperation = 'httpExchanges'
-    let jmxTraces: JmXTrace[] = []
-    if (!this.isSb3) {
+    let jmxTraces: JmxTrace[] = []
+    if (!this.isSpringBoot3) {
       mbeanName = 'Httptrace'
       mbeanOperation = 'traces'
     }
@@ -124,10 +124,10 @@ class SpringbootService {
       `org.springframework.boot:type=Endpoint,name=${mbeanName}`,
       mbeanOperation,
     )
-    if (this.isSb3) {
-      jmxTraces = (data as { exchanges: JmXTrace[] }).exchanges
+    if (this.isSpringBoot3) {
+      jmxTraces = (data as { exchanges: JmxTrace[] }).exchanges
     } else {
-      jmxTraces = (data as { traces: JmXTrace[] }).traces
+      jmxTraces = (data as { traces: JmxTrace[] }).traces
     }
 
     jmxTraces
@@ -143,4 +143,4 @@ class SpringbootService {
   }
 }
 
-export const springbootService = new SpringbootService()
+export const springbootService = new SpringBootService()

--- a/packages/hawtio/src/plugins/springboot/types.ts
+++ b/packages/hawtio/src/plugins/springboot/types.ts
@@ -37,3 +37,65 @@ export type Logger = {
   configuredLevel: string
   effectiveLevel: string
 }
+
+export class Trace {
+  timestamp: string
+  method: string = ''
+  path: string = ''
+  httpStatusCode: number = -1
+  timeTaken: string = '-1'
+  info: string = ''
+
+  constructor(traceData: unknown) {
+    const trace = traceData as JmXTrace
+    this.timestamp = trace.timestamp
+
+    if (trace.info) {
+      this.method = trace.info.method
+      this.path = trace.info.path
+      this.info = JSON.stringify(trace.info, null, 2)
+
+      if (trace.info.timeTaken) {
+        this.timeTaken = trace.info.timeTaken
+      }
+
+      if (trace.info.headers?.response) {
+        this.httpStatusCode = parseInt(trace.info.headers.response.status)
+      }
+    } else if (trace.request) {
+      this.method = trace.request.method
+      this.path = new URL(trace.request.uri).pathname
+      this.info = JSON.stringify(trace, null, 2)
+
+      if (trace.timeTaken) {
+        this.timeTaken = trace.timeTaken
+      }
+
+      if (trace.response && trace.response.status) {
+        this.httpStatusCode = parseInt(trace.response.status)
+      }
+    }
+  }
+}
+
+export type JmXTrace = {
+  timestamp: string
+  info?: {
+    method: string
+    path: string
+    timeTaken?: string
+    headers?: {
+      response?: {
+        status: string
+      }
+    }
+  }
+  request?: {
+    method: string
+    uri: string
+  }
+  timeTaken?: string
+  response?: {
+    status?: string
+  }
+}

--- a/packages/hawtio/src/plugins/springboot/types.ts
+++ b/packages/hawtio/src/plugins/springboot/types.ts
@@ -46,8 +46,7 @@ export class Trace {
   timeTaken: string = '-1'
   info: string = ''
 
-  constructor(traceData: unknown) {
-    const trace = traceData as JmXTrace
+  constructor(trace: JmxTrace) {
     this.timestamp = trace.timestamp
 
     if (trace.info) {
@@ -78,7 +77,7 @@ export class Trace {
   }
 }
 
-export type JmXTrace = {
+export type JmxTrace = {
   timestamp: string
   info?: {
     method: string


### PR DESCRIPTION
This PR adds a trace view into the spring-boot plugin: 
<img width="1128" alt="Screenshot 2023-11-22 at 21 31 26" src="https://github.com/hawtio/hawtio-next/assets/6814482/0e29d064-b6bd-4fa4-977a-9603331ecdfb">
<img width="1044" alt="Screenshot 2023-11-22 at 21 31 33" src="https://github.com/hawtio/hawtio-next/assets/6814482/f4519798-bc18-4a4a-b712-2b646f1ebb27">
Also spring-boot service is refactored to the class, for preserving infromation about spring-boot version used.