### PR TITLE
fix(camelContext): expand tree for routes, endpoints & components

### DIFF
--- a/packages/hawtio/src/plugins/camel/context.ts
+++ b/packages/hawtio/src/plugins/camel/context.ts
@@ -58,6 +58,24 @@ export function useCamelTree() {
         path.push(...contextsNode.path())
       }
 
+      const parentContext = rootNode.children[0]?.children
+
+      if(parentContext && parentContext[0]) {
+        // expand the context tree
+        parentContext[0].defaultExpanded = true
+
+        // check whether to expand its children
+        parentContext[0].children?.forEach(childChild => {
+          switch (childChild.name) {
+            case 'routes':
+            case 'endpoints':
+            case 'components':
+              childChild.defaultExpanded = true
+              break
+          }
+        })
+      }
+
       // Expand the nodes to redisplay the path
       rootNode.forEach(path, (node: MBeanNode) => {
         const tvd = node as TreeViewDataItem


### PR DESCRIPTION
## Description
This PR expands the Camel context tree by one level, leaving `MBeans` collapsed. Resolves #665 .

<img width="710" alt="Camel Context Tree" src="https://github.com/hawtio/hawtio-next/assets/3844502/00399f27-f57b-4ef5-9f41-6674d32987fb">

@tadayosi - Apologies for the delay on this issue. There were no lint issues with the `switch` statement. Some questions:
1. Is it a problem that I've done `child.defaultExpanded = true`? This will expand all root children by one (in this case, `SampleCamel`. Or is there a particular property you want me to do a conditional check for?
2. I couldn't see an easy way to test this implementation with unit tests or E2E tests. Please let me know if there's anything you'd like for me to do in this regard for this PR.