### PR TITLE
fix(core): provide API for plugins to customise hawtconfig programmatically

### DIFF
--- a/app/src/examples/example2/index.ts
+++ b/app/src/examples/example2/index.ts
@@ -1,4 +1,4 @@
-import { hawtio, HawtioPlugin } from '@hawtio/react'
+import { configManager, hawtio, HawtioPlugin } from '@hawtio/react'
 import { Example2 } from './Example2'
 
 export const registerExample2: HawtioPlugin = () => {
@@ -10,3 +10,12 @@ export const registerExample2: HawtioPlugin = () => {
     isActive: async () => true,
   })
 }
+
+// Plugin can extend Hawtconfig
+configManager.configure(config => {
+  if (!config.about) {
+    config.about = {}
+  }
+  const description = config.about.description
+  config.about.description = (description ?? '') + ' This text is added by the example 2 plugin.'
+})

--- a/packages/hawtio/src/core/config-manager.test.ts
+++ b/packages/hawtio/src/core/config-manager.test.ts
@@ -1,9 +1,10 @@
 import fetchMock from 'jest-fetch-mock'
-import { configManager, __testing__ } from './config-manager'
+import { configManager } from './config-manager'
 
 describe('ConfigManager', () => {
   beforeEach(() => {
     fetchMock.resetMocks()
+    configManager.reset()
   })
 
   test('configManager exists', () => {
@@ -23,7 +24,6 @@ describe('ConfigManager', () => {
       }),
     )
 
-    const configManager = new __testing__.ConfigManager()
     const config = await configManager.getHawtconfig()
     expect(config.branding?.appName).toEqual('Test App')
     expect(config.online?.projectSelector).toEqual('environment=dev,networkzone=internal')
@@ -46,8 +46,7 @@ describe('ConfigManager', () => {
       }),
     )
 
-    const configManager = new __testing__.ConfigManager()
-    const brandingApplied = await configManager.isBrandingApplied()
+    const brandingApplied = await configManager.applyBranding()
     expect(brandingApplied).toBe(true)
     const head = document.head.innerHTML
     expect(head).toContain('<title>Test App</title>')
@@ -64,8 +63,7 @@ describe('ConfigManager', () => {
     // response for fetching hawtconfig.json
     fetchMock.mockResponse(JSON.stringify({}))
 
-    const configManager = new __testing__.ConfigManager()
-    const brandingApplied = await configManager.isBrandingApplied()
+    const brandingApplied = await configManager.applyBranding()
     expect(brandingApplied).toBe(false)
     const head = document.head.innerHTML
     expect(head).toContain('<title>Hawtio</title>')
@@ -81,7 +79,6 @@ describe('ConfigManager', () => {
       }),
     )
 
-    const configManager = new __testing__.ConfigManager()
     await expect(configManager.isRouteEnabled('route1')).resolves.toBe(false)
     await expect(configManager.isRouteEnabled('route2')).resolves.toBe(true)
   })
@@ -90,7 +87,6 @@ describe('ConfigManager', () => {
     // response for fetching hawtconfig.json
     fetchMock.mockResponse('{}')
 
-    const configManager = new __testing__.ConfigManager()
     const routeEnabled = await configManager.isRouteEnabled('route1')
     expect(routeEnabled).toEqual(true)
   })
@@ -102,7 +98,7 @@ describe('ConfigManager', () => {
         disabledRoutes: ['route1', 'route3'],
       }),
     )
-    const plugins = [...Array(5).keys()].map(i => ({
+    const plugins = Array.from(Array(5).keys()).map(i => ({
       id: `route${i}`,
       title: `Route ${i}`,
       path: `route${i}`,
@@ -110,7 +106,6 @@ describe('ConfigManager', () => {
       isActive: () => Promise.resolve(true),
     }))
 
-    const configManager = new __testing__.ConfigManager()
     const enabledPlugins = await configManager.filterEnabledPlugins(plugins)
     expect(enabledPlugins.map(p => p.path)).toEqual(['route0', 'route2', 'route4'])
   })
@@ -138,7 +133,6 @@ describe('ConfigManager', () => {
       }),
     )
 
-    const configManager = new __testing__.ConfigManager()
     let config = await configManager.getHawtconfig()
     expect(config.about?.title).toEqual('Test App')
     expect(config.about?.description).toEqual('This is a test.')

--- a/packages/hawtio/src/core/config-manager.ts
+++ b/packages/hawtio/src/core/config-manager.ts
@@ -127,6 +127,10 @@ class ConfigManager {
     this.config = undefined
   }
 
+  setHawtconfig(config: Hawtconfig) {
+    this.config = Promise.resolve(config)
+  }
+
   getHawtconfig(): Promise<Hawtconfig> {
     if (this.config) {
       return this.config
@@ -154,6 +158,11 @@ class ConfigManager {
       log.error('Error fetching', HAWTCONFIG_JSON, '-', err)
       return {}
     }
+  }
+
+  async configure(configurer: (config: Hawtconfig) => void) {
+    const config = await this.getHawtconfig()
+    configurer(config)
   }
 
   async applyBranding(): Promise<boolean> {

--- a/packages/hawtio/src/core/core.ts
+++ b/packages/hawtio/src/core/core.ts
@@ -1,6 +1,7 @@
 import { userService } from '@hawtiosrc/auth'
 import { importRemote, ImportRemoteOptions } from '@module-federation/utilities'
 import $ from 'jquery'
+import { configManager } from './config-manager'
 import { eventService } from './event-service'
 import { log } from './globals'
 
@@ -179,7 +180,14 @@ class HawtioCore {
    */
   async bootstrap() {
     log.info('Bootstrapping Hawtio...')
+
+    // Apply branding
+    const brandingApplied = await configManager.applyBranding()
+    log.info('Branding applied:', brandingApplied)
+
+    // Load plugins
     await this.loadPlugins()
+
     log.info('Bootstrapped Hawtio')
   }
 


### PR DESCRIPTION
Changes required to support branding customisation by a WAR plugin such as Artemis plugin.