### PR TITLE
fix(core): branding should be applied after loading plugins

### DIFF
--- a/app/src/examples/example2/Example2.tsx
+++ b/app/src/examples/example2/Example2.tsx
@@ -1,11 +1,32 @@
-import { PageSection, PageSectionVariants, Text, TextContent } from '@patternfly/react-core'
+import { CodeBlock, CodeBlockCode, PageSection, PageSectionVariants, Text, TextContent } from '@patternfly/react-core'
 import React from 'react'
 
 export const Example2: React.FunctionComponent = () => (
   <PageSection variant={PageSectionVariants.light}>
     <TextContent>
       <Text component='h1'>Example 2</Text>
-      <Text component='p'>This is another example plugin.</Text>
+      <Text component='p'>
+        This is another example plugin that demonstrates how you can customise <code>hawtconfig.json</code> from an
+        external plugin.
+      </Text>
+      <Text component='p'>
+        See: <code>app/src/examples/example2/index.ts</code>
+      </Text>
+      <CodeBlock>
+        <CodeBlockCode>
+          {`configManager.configure(config => {
+  if (!config.about) {
+    config.about = {}
+  }
+  const description = config.about.description
+  config.about.description = (description ?? '') + ' This text is added by the example 2 plugin.'
+  if (!config.about.productInfo) {
+    config.about.productInfo = []
+  }
+  config.about.productInfo.push({ name: 'Example 2', value: '1.0.0' })
+})`}
+        </CodeBlockCode>
+      </CodeBlock>
     </TextContent>
   </PageSection>
 )

--- a/app/src/examples/example2/index.ts
+++ b/app/src/examples/example2/index.ts
@@ -18,4 +18,8 @@ configManager.configure(config => {
   }
   const description = config.about.description
   config.about.description = (description ?? '') + ' This text is added by the example 2 plugin.'
+  if (!config.about.productInfo) {
+    config.about.productInfo = []
+  }
+  config.about.productInfo.push({ name: 'Example 2', value: '1.0.0' })
 })

--- a/packages/hawtio/src/core/core.ts
+++ b/packages/hawtio/src/core/core.ts
@@ -181,12 +181,13 @@ class HawtioCore {
   async bootstrap() {
     log.info('Bootstrapping Hawtio...')
 
-    // Apply branding
-    const brandingApplied = await configManager.applyBranding()
-    log.info('Branding applied:', brandingApplied)
-
     // Load plugins
     await this.loadPlugins()
+
+    // Apply branding
+    // Branding should be applied after loading plugins as plugins may customise hawtconfig.
+    const brandingApplied = await configManager.applyBranding()
+    log.info('Branding applied:', brandingApplied)
 
     log.info('Bootstrapped Hawtio')
   }


### PR DESCRIPTION
It is because plugins may customise hawtconfig, so otherwise the customisation may be ignored.