### PR TITLE
fix(api): expose each builtin plugin's entry point to the public API

### DIFF
--- a/app/src/bootstrap.tsx
+++ b/app/src/bootstrap.tsx
@@ -13,6 +13,12 @@ configure()
 
 // Bootstrap Hawtio
 registerPlugins()
+
+// You can also select which builtin plugins to load
+//connect()
+//jmx()
+//camel()
+
 registerExamples()
 hawtio.bootstrap()
 

--- a/packages/hawtio/src/plugins/index.ts
+++ b/packages/hawtio/src/plugins/index.ts
@@ -1,4 +1,4 @@
-import { HawtioPlugin } from '@hawtiosrc/core'
+import type { HawtioPlugin } from '@hawtiosrc/core'
 import { keycloak } from './auth/keycloak'
 import { camel } from './camel'
 import { connect } from './connect'
@@ -28,6 +28,10 @@ export const registerPlugins: HawtioPlugin = () => {
   springboot()
 }
 
+// Export each plugin's entry point so that a custom console assembler can select which to bundle
+export { camel, connect, jmx, keycloak, logs, quartz, rbac, runtime, springboot }
+
+// Common plugin API
 export * from './connect'
 export * from './context'
 export * from './shared'


### PR DESCRIPTION
This allows you to assemble a custom console with a selected set of builtin plugins rather than all or nothing with registerPlugins().

This provides a downstream project with a more flexibility to use the @hawtio/react component.

Fix #788