### PR TITLE
fix(HAWNG-514): Change icons for Collapse and Expand to links

### DIFF
--- a/packages/hawtio/src/plugins/shared/PluginTreeViewToolbar.tsx
+++ b/packages/hawtio/src/plugins/shared/PluginTreeViewToolbar.tsx
@@ -8,7 +8,6 @@ import {
   Tooltip,
   TreeViewSearch,
 } from '@patternfly/react-core'
-import { MinusIcon, PlusIcon } from '@patternfly/react-icons'
 
 interface ToolbarProps {
   onSearch: (event: ChangeEvent<HTMLInputElement>) => void
@@ -47,8 +46,8 @@ export const PluginTreeViewToolbar: React.FunctionComponent<ToolbarProps> = (pro
           </ToolbarItem>
           <ToolbarItem variant='expand-all'>
             <Tooltip content={expanded ? 'Collapse all' : 'Expand all'} removeFindDomNode>
-              <Button variant='plain' aria-label='Expand Collapse' onClick={toggleExpanded}>
-                {expanded ? <MinusIcon /> : <PlusIcon />}
+              <Button variant='link' aria-label='Expand Collapse' onClick={toggleExpanded}>
+                {expanded ? 'Collapse all' : 'Expand all'}
               </Button>
             </Tooltip>
           </ToolbarItem>


### PR DESCRIPTION
<img width="536" alt="Screenshot 2024-02-27 at 21 49 21" src="https://github.com/hawtio/hawtio-next/assets/6814482/81e8c404-ef4d-409e-976a-1130fd8c0de8">
