### PR TITLE
Draft: Setup for improving load times of Hawtio Online

### DIFF
--- a/packages/hawtio/src/index.ts
+++ b/packages/hawtio/src/index.ts
@@ -8,6 +8,7 @@ export * from './core'
 export * from './help'
 export * from './plugins'
 export * from './preferences'
+export * from './ui'
 
 // Register Hawtio React component version
 configManager.addProductInfo('Hawtio React', '__PACKAGE_VERSION_PLACEHOLDER__')

--- a/packages/hawtio/src/ui/index.ts
+++ b/packages/hawtio/src/ui/index.ts
@@ -1,0 +1,5 @@
+export * from './about'
+export * from './icons'
+export * from './login'
+export * from './notification'
+export * from './page'

--- a/packages/hawtio/src/ui/page/index.ts
+++ b/packages/hawtio/src/ui/page/index.ts
@@ -1,1 +1,2 @@
 export * from './HawtioPage'
+export * from './HawtioLoadingPage'


### PR DESCRIPTION
Exposed UI components that could be used for unified look of the app (I will use HawtioLoadingPage in Hawtio Online).
Lazy loading Camel models, the fetch starts on the module load and since the both model packages are not included in the resulting bundle it significantly improves the load times. 