### PR TITLE
feat(camel): upgrade Camel models to 4.0.4 and 4.4.0

### DIFF
--- a/packages/hawtio/package.json
+++ b/packages/hawtio/package.json
@@ -33,8 +33,8 @@
     "prepack": "yarn build && yarn replace-version"
   },
   "dependencies": {
-    "@hawtio/camel-model-v3": "npm:@hawtio/camel-model@^3.21.2",
-    "@hawtio/camel-model-v4": "npm:@hawtio/camel-model@~4.0.3",
+    "@hawtio/camel-model-v4_0": "npm:@hawtio/camel-model@~4.0.4",
+    "@hawtio/camel-model-v4_4": "npm:@hawtio/camel-model@~4.4.0",
     "@module-federation/utilities": "^3.0.5",
     "@patternfly/react-charts": "~6.94.21",
     "@patternfly/react-code-editor": "~4.82.122",

--- a/packages/hawtio/src/plugins/camel/camel-service.test.ts
+++ b/packages/hawtio/src/plugins/camel/camel-service.test.ts
@@ -1,5 +1,5 @@
-import * as camel3 from '@hawtio/camel-model-v3'
-import * as camel4 from '@hawtio/camel-model-v4'
+import * as camel4_0 from '@hawtio/camel-model-v4_0'
+import * as camel4_4 from '@hawtio/camel-model-v4_4'
 import { MBeanNode } from '@hawtiosrc/plugins/shared/tree'
 import * as camelService from './camel-service'
 import { contextNodeType, endpointNodeType, endpointsType, jmxDomain } from './globals'
@@ -44,25 +44,51 @@ describe('camel-service', () => {
     camel3Node.addMetadata('version', '3.21.0')
     const camel3Model = camelService.getCamelModel(camel3Node)
     expect(camel3Model).toBeDefined()
-    expect(camel3Model.apacheCamelModelVersion).toBe(camel3.apacheCamelModelVersion)
+    expect(camel3Model.apacheCamelModelVersion).toBe(camel4_0.apacheCamelModelVersion)
     expect(camel3Model.components).not.toBeUndefined()
     expect(camel3Model.dataformats).not.toBeUndefined()
     expect(camel3Model.definitions).not.toBeUndefined()
     expect(camel3Model.languages).not.toBeUndefined()
     expect(camel3Model.rests).not.toBeUndefined()
 
-    const camel4Node = new MBeanNode(null, 'test-context-camel4', true)
-    camel4Node.addMetadata('domain', jmxDomain)
-    camel4Node.setType(contextNodeType)
-    camel4Node.addMetadata('version', '4.0.0')
-    const camel4Model = camelService.getCamelModel(camel4Node)
+    const camel40Node = new MBeanNode(null, 'test-context-camel4_0', true)
+    camel40Node.addMetadata('domain', jmxDomain)
+    camel40Node.setType(contextNodeType)
+    camel40Node.addMetadata('version', '4.0.4')
+    const camel4Model = camelService.getCamelModel(camel40Node)
     expect(camel4Model).toBeDefined()
-    expect(camel4Model.apacheCamelModelVersion).toBe(camel4.apacheCamelModelVersion)
+    expect(camel4Model.apacheCamelModelVersion).toBe(camel4_0.apacheCamelModelVersion)
     expect(camel4Model.components).not.toBeUndefined()
     expect(camel4Model.dataformats).not.toBeUndefined()
     expect(camel4Model.definitions).not.toBeUndefined()
     expect(camel4Model.languages).not.toBeUndefined()
     expect(camel4Model.rests).not.toBeUndefined()
+
+    const camel41Node = new MBeanNode(null, 'test-context-camel4_1', true)
+    camel41Node.addMetadata('domain', jmxDomain)
+    camel41Node.setType(contextNodeType)
+    camel41Node.addMetadata('version', '4.1.0')
+    const camel41Model = camelService.getCamelModel(camel41Node)
+    expect(camel41Model).toBeDefined()
+    expect(camel41Model.apacheCamelModelVersion).toBe(camel4_0.apacheCamelModelVersion)
+    expect(camel41Model.components).not.toBeUndefined()
+    expect(camel41Model.dataformats).not.toBeUndefined()
+    expect(camel41Model.definitions).not.toBeUndefined()
+    expect(camel41Model.languages).not.toBeUndefined()
+    expect(camel41Model.rests).not.toBeUndefined()
+
+    const camel44Node = new MBeanNode(null, 'test-context-camel4_4', true)
+    camel44Node.addMetadata('domain', jmxDomain)
+    camel44Node.setType(contextNodeType)
+    camel44Node.addMetadata('version', '4.4.0')
+    const camel44Model = camelService.getCamelModel(camel44Node)
+    expect(camel44Model).toBeDefined()
+    expect(camel44Model.apacheCamelModelVersion).toBe(camel4_4.apacheCamelModelVersion)
+    expect(camel44Model.components).not.toBeUndefined()
+    expect(camel44Model.dataformats).not.toBeUndefined()
+    expect(camel44Model.definitions).not.toBeUndefined()
+    expect(camel44Model.languages).not.toBeUndefined()
+    expect(camel44Model.rests).not.toBeUndefined()
   })
 
   test('compareVersions', () => {

--- a/packages/hawtio/src/plugins/camel/camel-service.ts
+++ b/packages/hawtio/src/plugins/camel/camel-service.ts
@@ -1,5 +1,5 @@
-import * as camel3 from '@hawtio/camel-model-v3'
-import * as camel4 from '@hawtio/camel-model-v4'
+import * as camel4_0 from '@hawtio/camel-model-v4_0'
+import * as camel4_4 from '@hawtio/camel-model-v4_4'
 import { eventService } from '@hawtiosrc/core'
 import { MBeanNode } from '@hawtiosrc/plugins/shared'
 import { jolokiaService } from '@hawtiosrc/plugins/shared/jolokia-service'
@@ -325,18 +325,24 @@ export function hasProperties(node: MBeanNode): boolean {
 }
 
 export function getCamelVersions(): string[] {
-  return [camel3.apacheCamelModelVersion, camel4.apacheCamelModelVersion]
+  return [camel4_0.apacheCamelModelVersion, camel4_4.apacheCamelModelVersion]
 }
 
 /**
  * Returns the corresponding version of Camel model based on the Camel version of
- * the given node. Currently, it supports Camel v3 and v4.
+ * the given node.
  */
 export function getCamelModel(node: MBeanNode): CamelModel {
-  if (isCamelVersionEQGT(node, 4, 0)) {
-    return camel4 as unknown as CamelModel
+  // 4.4 ~     => 4.4.x
+  // 4.0 ~ 4.3 => 4.0.x
+  if (isCamelVersionEQGT(node, 4, 4)) {
+    return camel4_4 as unknown as CamelModel
   }
-  return camel3 as unknown as CamelModel
+  if (isCamelVersionEQGT(node, 4, 0)) {
+    return camel4_0 as unknown as CamelModel
+  }
+  // Fallback to 4.0.x model
+  return camel4_0 as unknown as CamelModel
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2177,17 +2177,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hawtio/camel-model-v3@npm:@hawtio/camel-model@^3.21.2":
-  version: 3.21.2
-  resolution: "@hawtio/camel-model@npm:3.21.2"
-  checksum: 10/feebd08f32479336191e5df8e859d1dcfc32c0d05b307a5d05ce7a2a2730b9de110951fc6787664c43a2ddb1146bcbe2bfa441a467320f2d2c492d1335c840cc
+"@hawtio/camel-model-v4_0@npm:@hawtio/camel-model@~4.0.4":
+  version: 4.0.4
+  resolution: "@hawtio/camel-model@npm:4.0.4"
+  checksum: 10/c4c92f7dc07216205adb84e544b52d0d1c7d7271cc42925ac9dc290cf3abd74cce4fc7910f8a65d409a4e7df53d5f9db84e5223ffb3d0ee5bbd9e0a81679ddb4
   languageName: node
   linkType: hard
 
-"@hawtio/camel-model-v4@npm:@hawtio/camel-model@~4.0.3":
-  version: 4.0.3
-  resolution: "@hawtio/camel-model@npm:4.0.3"
-  checksum: 10/0270c632bdeea39fdc1febd0380d862eeb1059cbd9c6627a41fa02fdba175a6d67a089cbf953db32a62f402de546b5a212e3d0745bcbc9a4518002cb928dae1c
+"@hawtio/camel-model-v4_4@npm:@hawtio/camel-model@~4.4.0":
+  version: 4.4.0
+  resolution: "@hawtio/camel-model@npm:4.4.0"
+  checksum: 10/895dbe3988e552842ab6443574631b185145fe6c97123cc24d43eef074815bdac5bd0c06a648e795dd366d12fafb280a30fe76f81a7f79e32884c01a49af3fa2
   languageName: node
   linkType: hard
 
@@ -2213,8 +2213,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@hawtio/react@workspace:packages/hawtio"
   dependencies:
-    "@hawtio/camel-model-v3": "npm:@hawtio/camel-model@^3.21.2"
-    "@hawtio/camel-model-v4": "npm:@hawtio/camel-model@~4.0.3"
+    "@hawtio/camel-model-v4_0": "npm:@hawtio/camel-model@~4.0.4"
+    "@hawtio/camel-model-v4_4": "npm:@hawtio/camel-model@~4.4.0"
     "@module-federation/utilities": "npm:^3.0.5"
     "@patternfly/react-charts": "npm:~6.94.21"
     "@patternfly/react-code-editor": "npm:~4.82.122"


### PR DESCRIPTION
Drop support for Camel model 3.x as the 3.x versions are EOL'ed upstream.

Fix #800