### PR TITLE
refactor(CLUX-495,496): Use the TableComposable for attributes and primary detail pattern instead of modal

### DIFF
--- a/packages/hawtio/src/plugins/shared/attributes/AttributeModal.tsx
+++ b/packages/hawtio/src/plugins/shared/attributes/AttributeModal.tsx
@@ -75,18 +75,20 @@ export const AttributeModal: React.FunctionComponent<{
 
   const modalTitle = `Attribute: ${attributeName}`
 
-  const modalActions = [
-    <Button key='close' variant='primary' onClick={onClose}>
-      Close
-    </Button>,
-  ]
+  const modalActions = []
+
   if (isWritable) {
     modalActions.push(
       <Button key='update' variant='danger' onClick={updateAttribute}>
-        Update
+        Save
       </Button>,
     )
   }
+  modalActions.push(
+    <Button key='close' variant='link' onClick={onClose}>
+      Cancel
+    </Button>,
+  )
 
   return (
     <Modal variant='medium' title={modalTitle} isOpen={isOpen} onClose={onClose} actions={modalActions}>

--- a/packages/hawtio/src/plugins/shared/attributes/AttributeModal.tsx
+++ b/packages/hawtio/src/plugins/shared/attributes/AttributeModal.tsx
@@ -1,5 +1,18 @@
 import { PluginNodeSelectionContext } from '@hawtiosrc/plugins/context'
-import { Button, ClipboardCopy, Form, FormGroup, Modal, TextArea, TextInput } from '@patternfly/react-core'
+import {
+  Button,
+  ClipboardCopy,
+  DrawerActions,
+  DrawerCloseButton,
+  DrawerHead,
+  DrawerPanelBody,
+  DrawerPanelContent,
+  Form,
+  FormGroup,
+  TextArea,
+  TextInput,
+  Title,
+} from '@patternfly/react-core'
 import React, { useContext, useEffect, useState } from 'react'
 import { attributeService } from './attribute-service'
 import { log } from '../globals'
@@ -84,54 +97,61 @@ export const AttributeModal: React.FunctionComponent<{
       </Button>,
     )
   }
-  modalActions.push(
-    <Button key='close' variant='link' onClick={onClose}>
-      Cancel
-    </Button>,
-  )
 
   return (
-    <Modal variant='medium' title={modalTitle} isOpen={isOpen} onClose={onClose} actions={modalActions}>
-      <Form id='attribute-form' isHorizontal>
-        <FormGroup label='Name' fieldId='attribute-form-name'>
-          <TextInput
-            id='attribute-form-name'
-            name='attribute-form-name'
-            value={attributeName}
-            readOnlyVariant='default'
-          />
-        </FormGroup>
-        <FormGroup label='Description' fieldId='attribute-form-description'>
-          <TextArea
-            id='attribute-form-description'
-            name='attribute-form-description'
-            value={attribute.desc}
-            readOnlyVariant='default'
-          />
-        </FormGroup>
-        <FormGroup label='Type' fieldId='attribute-form-type'>
-          <TextInput
-            id='attribute-form-type'
-            name='attribute-form-type'
-            value={attribute.type}
-            readOnlyVariant='default'
-          />
-        </FormGroup>
-        <FormGroup label='Jolokia URL' fieldId='attribute-form-jolokia-url'>
-          <ClipboardCopy isReadOnly removeFindDomNode>
-            {jolokiaUrl}
-          </ClipboardCopy>
-        </FormGroup>
-        <FormGroup label='Value' fieldId='attribute-form-value'>
-          <TextInput
-            id='attribute-form-value'
-            name='attribute-form-value'
-            value={attributeValue}
-            onChange={value => setAttributeValue(value)}
-            readOnlyVariant={isWritable ? undefined : 'default'}
-          />
-        </FormGroup>
-      </Form>
-    </Modal>
+    <DrawerPanelContent isResizable>
+      <DrawerHead>
+        <Title headingLevel='h2' size='xl'>
+          {modalTitle}
+        </Title>
+        <DrawerActions>
+          <DrawerCloseButton onClick={onClose} />
+        </DrawerActions>
+      </DrawerHead>
+
+      <DrawerPanelBody>
+        <Form id='attribute-form' isHorizontal>
+          <FormGroup label='Name' fieldId='attribute-form-name'>
+            <TextInput
+              id='attribute-form-name'
+              name='attribute-form-name'
+              value={attributeName}
+              readOnlyVariant='default'
+            />
+          </FormGroup>
+          <FormGroup label='Description' fieldId='attribute-form-description'>
+            <TextArea
+              id='attribute-form-description'
+              name='attribute-form-description'
+              value={attribute.desc}
+              readOnlyVariant='default'
+            />
+          </FormGroup>
+          <FormGroup label='Type' fieldId='attribute-form-type'>
+            <TextInput
+              id='attribute-form-type'
+              name='attribute-form-type'
+              value={attribute.type}
+              readOnlyVariant='default'
+            />
+          </FormGroup>
+          <FormGroup label='Jolokia URL' fieldId='attribute-form-jolokia-url'>
+            <ClipboardCopy isReadOnly removeFindDomNode>
+              {jolokiaUrl}
+            </ClipboardCopy>
+          </FormGroup>
+          <FormGroup label='Value' fieldId='attribute-form-value'>
+            <TextInput
+              id='attribute-form-value'
+              name='attribute-form-value'
+              value={attributeValue}
+              onChange={value => setAttributeValue(value)}
+              readOnlyVariant={isWritable ? undefined : 'default'}
+            />
+          </FormGroup>
+          <FormGroup>{modalActions}</FormGroup>
+        </Form>
+      </DrawerPanelBody>
+    </DrawerPanelContent>
   )
 }

--- a/packages/hawtio/src/plugins/shared/attributes/Attributes.tsx
+++ b/packages/hawtio/src/plugins/shared/attributes/Attributes.tsx
@@ -2,8 +2,8 @@ import { PluginNodeSelectionContext } from '@hawtiosrc/plugins/context'
 import { AttributeValues } from '@hawtiosrc/plugins/shared/jolokia-service'
 import { isObject } from '@hawtiosrc/util/objects'
 import { Card } from '@patternfly/react-core'
-import { OnRowClick, Table, TableBody, TableHeader, TableProps } from '@patternfly/react-table'
-import { useContext, useEffect, useState } from 'react'
+import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table'
+import React, { useContext, useEffect, useState } from 'react'
 import { HawtioEmptyCard } from '../HawtioEmptyCard'
 import { HawtioLoadingCard } from '../HawtioLoadingCard'
 import { log } from '../globals'
@@ -61,20 +61,17 @@ export const Attributes: React.FunctionComponent = () => {
     return <HawtioLoadingCard />
   }
 
-  const columns: TableProps['cells'] = ['Attribute', 'Value']
-  const rows: TableProps['rows'] = Object.entries(attributes).map(([name, value]) => [
-    name,
-    isObject(value) ? JSON.stringify(value) : String(value),
-  ])
+  const rows: { name: string; value: string }[] = Object.entries(attributes).map(([name, value]) => ({
+    name: name,
+    value: isObject(value) ? JSON.stringify(value) : String(value),
+  }))
 
   if (rows.length === 0) {
     return <HawtioEmptyCard message='This MBean has no attributes.' />
   }
 
-  const selectAttribute: OnRowClick = (_event, row) => {
-    const name = row[0]
-    const value = row[1]
-    setSelected({ name, value })
+  const selectAttribute = (attribute: { name: string; value: string }) => {
+    setSelected(attribute)
     handleModalToggle()
   }
 
@@ -84,10 +81,28 @@ export const Attributes: React.FunctionComponent = () => {
 
   return (
     <Card isFullHeight>
-      <Table aria-label='Attributes' variant='compact' cells={columns} rows={rows}>
-        <TableHeader />
-        <TableBody onRowClick={selectAttribute} />
-      </Table>
+      {/*<DataListClickableRows />*/}
+      <TableComposable aria-label='Attributes' variant='compact'>
+        <Thead>
+          <Tr>
+            <Th>Attribute</Th>
+            <Th>Value</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {rows.map(att => (
+            <Tr
+              key={att.name}
+              isHoverable
+              isRowSelected={selected.name === att.name}
+              onRowClick={() => selectAttribute(att)}
+            >
+              <Td>{att.name}</Td>
+              <Td>{att.value}</Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </TableComposable>
       <AttributeModal
         isOpen={isModalOpen}
         onClose={handleModalToggle}

--- a/packages/hawtio/src/plugins/shared/attributes/Attributes.tsx
+++ b/packages/hawtio/src/plugins/shared/attributes/Attributes.tsx
@@ -1,7 +1,7 @@
 import { PluginNodeSelectionContext } from '@hawtiosrc/plugins/context'
 import { AttributeValues } from '@hawtiosrc/plugins/shared/jolokia-service'
 import { isObject } from '@hawtiosrc/util/objects'
-import { Card } from '@patternfly/react-core'
+import { Card, Drawer, DrawerContent, DrawerContentBody } from '@patternfly/react-core'
 import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table'
 import React, { useContext, useEffect, useState } from 'react'
 import { HawtioEmptyCard } from '../HawtioEmptyCard'
@@ -72,16 +72,22 @@ export const Attributes: React.FunctionComponent = () => {
 
   const selectAttribute = (attribute: { name: string; value: string }) => {
     setSelected(attribute)
-    handleModalToggle()
+    if (!isModalOpen) {
+      setIsModalOpen(true)
+    }
   }
 
-  const handleModalToggle = () => {
-    setIsModalOpen(!isModalOpen)
-  }
+  const panelContent = (
+    <AttributeModal
+      isOpen={isModalOpen}
+      onClose={() => setIsModalOpen(false)}
+      onUpdate={() => setReload(true)}
+      input={selected}
+    />
+  )
 
-  return (
-    <Card isFullHeight>
-      {/*<DataListClickableRows />*/}
+  const attributesTable = (
+    <div style={{ height: '75vh' }}>
       <TableComposable aria-label='Attributes' variant='compact'>
         <Thead>
           <Tr>
@@ -90,9 +96,9 @@ export const Attributes: React.FunctionComponent = () => {
           </Tr>
         </Thead>
         <Tbody>
-          {rows.map(att => (
+          {rows.map((att, index) => (
             <Tr
-              key={att.name}
+              key={att.name + '-' + index}
               isHoverable
               isRowSelected={selected.name === att.name}
               onRowClick={() => selectAttribute(att)}
@@ -103,12 +109,17 @@ export const Attributes: React.FunctionComponent = () => {
           ))}
         </Tbody>
       </TableComposable>
-      <AttributeModal
-        isOpen={isModalOpen}
-        onClose={handleModalToggle}
-        onUpdate={() => setReload(true)}
-        input={selected}
-      />
-    </Card>
+    </div>
+  )
+  return (
+    <React.Fragment>
+      <Card isFullHeight>
+        <Drawer isExpanded={isModalOpen} className={'pf-m-inline-on-2xl'}>
+          <DrawerContent panelContent={panelContent}>
+            <DrawerContentBody hasPadding> {attributesTable}</DrawerContentBody>
+          </DrawerContent>
+        </Drawer>
+      </Card>
+    </React.Fragment>
   )
 }

--- a/packages/hawtio/src/plugins/shared/operations/OperationForm.tsx
+++ b/packages/hawtio/src/plugins/shared/operations/OperationForm.tsx
@@ -282,7 +282,7 @@ const OperationExecuteForm: React.FunctionComponent<{
       <ActionGroup>
         <Button
           key={`operation-action-execute-${name}`}
-          variant='primary'
+          variant='danger'
           onClick={execute}
           isSmall
           isDisabled={!operation.canInvoke || isExecuting}


### PR DESCRIPTION
- TableComposable for the attributes list 
  - `Update`changed to `Save` 
-  Used primary detail pattern instead of modal: 
  - Make attributes table scrollable so whole page isn't scrolling with the table 
<img width="1773" alt="Screenshot 2024-03-19 at 21 13 26" src="https://github.com/hawtio/hawtio-next/assets/6814482/37709e88-07c4-4542-b788-6ba3c142dec9">


