### PR TITLE
Fix E2E workflow & improve login form UX

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         node: ['18', '20']
-        java: ['11', '17']
+        java: ['17', '21']
         runtime: ['springboot', 'quarkus']
         browser: ['firefox'] # 'chrome' tests are unstable: https://github.com/hawtio/hawtio-next/issues/478
     env:

--- a/packages/hawtio/src/plugins/connect/login/ConnectLogin.tsx
+++ b/packages/hawtio/src/plugins/connect/login/ConnectLogin.tsx
@@ -44,7 +44,7 @@ export const ConnectLogin: React.FunctionComponent = () => {
 
   return (
     <Modal variant='small' title={title} isOpen={isOpen} onClose={handleClose} actions={actions}>
-      <Form id='connect-login-form' isHorizontal>
+      <Form id='connect-login-form' isHorizontal onKeyUp={e => e.key === 'Enter' && handleLogin()}>
         {loginFailed && (
           <FormAlert>
             <Alert variant='danger' title='Incorrect username or password' isInline />
@@ -57,6 +57,7 @@ export const ConnectLogin: React.FunctionComponent = () => {
             name='connect-login-form-username'
             value={username}
             onChange={value => setUsername(value)}
+            autoFocus={true}
           />
         </FormGroup>
         <FormGroup label='Password' isRequired fieldId='connect-login-form-password'>


### PR DESCRIPTION
With Hawtio 4.x we have app images only for Java 21 and 17, so 11 was removed from the testing matrix. 
Also the login form when connecting now is autofocused so user can login just from their keyboard + use Enter as submit. 
(Enter as submit should work automatically in forms, but the way modals are implemented the submit button is outside the form element so it doesn't trigger the submit event)