### PR TITLE
fix(shared): HAWNG-612 jmx tree should keep rendering even in presence of malformed mbeans

### DIFF
--- a/packages/hawtio/src/plugins/shared/tree/node.ts
+++ b/packages/hawtio/src/plugins/shared/tree/node.ts
@@ -125,7 +125,8 @@ export class MBeanNode implements TreeViewDataItem {
       // final mbean node
       const path = paths[0]
       if (!path) {
-        throw new Error('path should not be empty')
+        log.error('Failed to process MBean. Malformed ObjectName:', `"${props.objectName()}"`)
+        return
       }
       const mbeanNode = this.create(path, false)
       mbeanNode.configureMBean(props, mbean)
@@ -134,7 +135,8 @@ export class MBeanNode implements TreeViewDataItem {
 
     const path = paths.shift()
     if (path === undefined) {
-      throw new Error('path should not be empty')
+      log.error('Failed to process MBean. Malformed ObjectName:', `"${props.objectName()}"`)
+      return
     }
     const child = this.getOrCreate(path, true)
     child.createMBeanNode(paths, props, mbean)

--- a/packages/hawtio/src/plugins/shared/workspace.ts
+++ b/packages/hawtio/src/plugins/shared/workspace.ts
@@ -74,8 +74,8 @@ class Workspace implements IWorkspace {
       this.maybeMonitorTree()
 
       return tree
-    } catch (response) {
-      log.error('A request to list the JMX tree failed: ' + response)
+    } catch (error) {
+      log.error('A request to list the JMX tree failed:', error)
       return MBeanTree.createEmpty(pluginName)
     }
   }


### PR DESCRIPTION
https://issues.redhat.com/browse/HAWNG-612