### PR TITLE
Migrate Contexts,Exchanges,Attributes to TableComposable 

### DIFF
--- a/packages/hawtio/src/plugins/camel/exchanges/BlockedExchanges.tsx
+++ b/packages/hawtio/src/plugins/camel/exchanges/BlockedExchanges.tsx
@@ -1,7 +1,7 @@
 import { CamelContext } from '@hawtiosrc/plugins/camel/context'
 import { HawtioEmptyCard, HawtioLoadingCard, MBeanNode } from '@hawtiosrc/plugins/shared'
 import { Button, Card, CardBody, CardTitle, Modal, ModalVariant } from '@patternfly/react-core'
-import { Table, TableBody, TableHeader, TableProps, TableText, fitContent, wrappable } from '@patternfly/react-table'
+import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table'
 import React, { useContext, useEffect, useRef, useState } from 'react'
 import * as exs from './exchanges-service'
 
@@ -65,30 +65,9 @@ export const BlockedExchanges: React.FunctionComponent = () => {
   if (isReading) {
     return <HawtioLoadingCard />
   }
-
   if (exchanges.length === 0) {
     return <HawtioEmptyCard title='Blocked Exchanges' message='No blocked exchanges found.' testid='no-exchanges' />
   }
-
-  const columns: TableProps['cells'] = []
-  columns.push({ title: 'Exchange ID', transforms: [wrappable] })
-  columns.push({ title: 'Route ID', transforms: [wrappable] })
-  columns.push({ title: 'Node ID', transforms: [wrappable] })
-  columns.push({ title: 'Duration (ms)', transforms: [wrappable] })
-  columns.push({ title: 'Elapsed (ms)', transforms: [wrappable] })
-  columns.push({ title: '', dataLabel: 'Action', transforms: [fitContent] })
-
-  const rows: TableProps['rows'] = exchanges.map(ex => {
-    const unblockActionButton = (
-      <TableText>
-        <Button variant='secondary' onClick={() => onUnblockClicked(ex)}>
-          Unblock
-        </Button>
-      </TableText>
-    )
-
-    return [ex.exchangeId, ex.routeId, ex.nodeId, ex.duration, ex.elapsed, unblockActionButton]
-  })
 
   const ConfirmUnblockModal = () => (
     <Modal
@@ -115,10 +94,33 @@ export const BlockedExchanges: React.FunctionComponent = () => {
     <Card isFullHeight>
       <CardTitle>Blocked Exchanges</CardTitle>
       <CardBody>
-        <Table data-testid='exchange-table' aria-label='Blocked Exchanges' cells={columns} rows={rows}>
-          <TableHeader />
-          <TableBody />
-        </Table>
+        <TableComposable variant={'compact'} data-testid='exchange-table' aria-label='Blocked Exchanges'>
+          <Thead>
+            <Tr>
+              <Th modifier='wrap'>Exchange ID</Th>
+              <Th modifier='wrap'>Route ID</Th>
+              <Th modifier='wrap'>Node ID</Th>
+              <Th modifier='wrap'>Duration (ms)</Th>
+              <Th modifier='wrap'>Elapsed (ms)</Th>
+              <Th dataLabel='Action' wrap=''></Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {exchanges.map((ex, index) => (
+              <Tr key={ex.exchangeId + '-' + index}>
+                <Td>{ex.exchangeId}</Td>g <Td>{ex.routeId}</Td>
+                <Td>{ex.nodeId}</Td>
+                <Td>{ex.duration}</Td>
+                <Td>{ex.elapsed}</Td>
+                <Td>
+                  <Button variant='link' onClick={() => onUnblockClicked(ex)}>
+                    Unblock
+                  </Button>
+                </Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </TableComposable>
         <ConfirmUnblockModal />
       </CardBody>
     </Card>

--- a/packages/hawtio/src/plugins/camel/exchanges/InflightExchanges.tsx
+++ b/packages/hawtio/src/plugins/camel/exchanges/InflightExchanges.tsx
@@ -1,7 +1,7 @@
 import { CamelContext } from '@hawtiosrc/plugins/camel/context'
 import { HawtioEmptyCard, HawtioLoadingCard } from '@hawtiosrc/plugins/shared'
 import { Card, CardBody, CardTitle } from '@patternfly/react-core'
-import { Table, TableBody, TableHeader, TableProps, wrappable } from '@patternfly/react-table'
+import { TableComposable, Tbody, Th, Td, Thead, Tr } from '@patternfly/react-table'
 import React, { useContext, useEffect, useState } from 'react'
 import * as exs from './exchanges-service'
 
@@ -54,23 +54,32 @@ export const InflightExchanges: React.FunctionComponent = () => {
     return <HawtioEmptyCard title='Inflight Exchanges' message='No inflight exchanges found.' testid='no-exchanges' />
   }
 
-  const columns: TableProps['cells'] = []
-  columns.push({ title: 'Exchange ID', transforms: [wrappable] })
-  columns.push({ title: 'Route ID', transforms: [wrappable] })
-  columns.push({ title: 'Node ID', transforms: [wrappable] })
-  columns.push({ title: 'Duration (ms)', transforms: [wrappable] })
-  columns.push({ title: 'Elapsed (ms)', transforms: [wrappable] })
-
-  const rows: TableProps['rows'] = exchanges.map(ex => [ex.exchangeId, ex.routeId, ex.nodeId, ex.duration, ex.elapsed])
-
   return (
     <Card isFullHeight>
       <CardTitle>Inflight Exchanges</CardTitle>
       <CardBody>
-        <Table data-testid='exchange-table' aria-label='Inflight Exchanges' cells={columns} rows={rows}>
-          <TableHeader />
-          <TableBody />
-        </Table>
+        <TableComposable data-testid='exchange-table' aria-label='Inflight Exchanges' variant='compact'>
+          <Thead>
+            <Tr>
+              <Th modifier='wrap'>Exchange ID</Th>
+              <Th modifier='wrap'>Route ID</Th>
+              <Th modifier='wrap'>Node ID</Th>
+              <Th modifier='wrap'>Duration (ms)</Th>
+              <Th modifier='wrap'>Elapsed (ms)</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {exchanges.map(ex => (
+              <Tr key={ex.exchangeId}>
+                <Td>{ex.exchangeId}</Td>
+                <Td>{ex.routeId}</Td>
+                <Td>{ex.nodeId}</Td>
+                <Td>{ex.duration}</Td>
+                <Td>{ex.elapsed}</Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </TableComposable>
       </CardBody>
     </Card>
   )

--- a/packages/hawtio/src/plugins/shared/attributes/AttributeTable.tsx
+++ b/packages/hawtio/src/plugins/shared/attributes/AttributeTable.tsx
@@ -3,9 +3,9 @@ import { JmxContentMBeans } from '@hawtiosrc/plugins/shared/JmxContentMBeans'
 import { AttributeValues } from '@hawtiosrc/plugins/shared/jolokia-service'
 import { humanizeLabels } from '@hawtiosrc/util/strings'
 import { Card } from '@patternfly/react-core'
-import { Table, TableBody, TableHeader, TableProps } from '@patternfly/react-table'
+import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table'
 import { Response } from 'jolokia.js'
-import { useContext, useEffect, useState } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import { HawtioEmptyCard } from '../HawtioEmptyCard'
 import { HawtioLoadingCard } from '../HawtioLoadingCard'
 import { MBeanNode } from '../tree'
@@ -17,7 +17,7 @@ export const AttributeTable: React.FunctionComponent = () => {
   const [attributesList, setAttributesList] = useState<{ [name: string]: AttributeValues }>({})
   const [isReading, setIsReading] = useState(false)
 
-  const attributesEntries = Object.values(attributesList)
+  const attributesEntries = Object.values(attributesList) ?? []
 
   function checkIfAllMBeansHaveSameAttributes(attributesEntries: AttributeValues[]): boolean {
     if (attributesEntries.length <= 1) {
@@ -28,6 +28,7 @@ export const AttributeTable: React.FunctionComponent = () => {
     if (!firstEntry) {
       return false
     }
+
     const firstAttrsLength = Object.keys(firstEntry).length
     if (attributesEntries.some(attrs => Object.keys(attrs).length !== firstAttrsLength)) {
       return false
@@ -51,9 +52,7 @@ export const AttributeTable: React.FunctionComponent = () => {
 
       for (const node of currentSelection.getChildren()) {
         if (!node || !node?.objectName) continue
-
-        const attrs = await attributeService.read(node.objectName)
-        childrenMbeansAttributes[node.objectName] = attrs
+        childrenMbeansAttributes[node.objectName] = await attributeService.read(node.objectName)
       }
 
       setAttributesList({ ...childrenMbeansAttributes })
@@ -105,17 +104,27 @@ export const AttributeTable: React.FunctionComponent = () => {
   }
 
   const labels = Object.keys(attributesEntries[0] ?? {})
-  const columns: TableProps['cells'] = labels.map(label => humanizeLabels(label))
-  const rows: TableProps['rows'] = attributesEntries.map(attribute =>
-    labels.map(label => JSON.stringify(attribute[label])),
-  )
 
   return (
     <Card isFullHeight>
-      <Table aria-label='MBeans' variant='compact' cells={columns} rows={rows}>
-        <TableHeader className={'attribute-table'} />
-        <TableBody />
-      </Table>
+      <TableComposable aria-label='MBeans' variant='compact'>
+        <Thead>
+          <Tr>
+            {labels.map(label => (
+              <Th key={'header-' + label}>{humanizeLabels(label)}</Th>
+            ))}
+          </Tr>
+        </Thead>
+        <Tbody>
+          {attributesEntries.map((attribute, index) => (
+            <Tr key={'attribute-' + index}>
+              {labels.map((label, index) => (
+                <Td key={'data-' + label + index}>{JSON.stringify(attribute[label])}</Td>
+              ))}
+            </Tr>
+          ))}
+        </Tbody>
+      </TableComposable>
     </Card>
   )
 }


### PR DESCRIPTION
I migrated tables to use TableComposable instead of old PF4 table.
Also fixed #845 by refactoring selected const to use list of strings instead Context objects. 
close #180