### PR TITLE
refactor(plugins): polish the look and feel of the rest of the plugins 

### DIFF
--- a/packages/hawtio/src/plugins/camel/CamelContent.tsx
+++ b/packages/hawtio/src/plugins/camel/CamelContent.tsx
@@ -175,6 +175,7 @@ export const CamelContent: React.FunctionComponent = () => {
       <PageSection
         id='camel-content-main'
         variant={pathname.includes('chart') ? PageSectionVariants.default : PageSectionVariants.light}
+        padding={{ default: pathname.includes('chart') ? 'padding' : 'noPadding' }}
         hasOverflowScroll
       >
         {navItems.length > 0 && (

--- a/packages/hawtio/src/plugins/camel/debug/Debug.css
+++ b/packages/hawtio/src/plugins/camel/debug/Debug.css
@@ -2,6 +2,11 @@
   overflow: auto;
   margin-top: 1.5em;
 }
+#debug-header-container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
 
 .react-flow {
   background-color: white !important;

--- a/packages/hawtio/src/plugins/camel/debug/Debug.tsx
+++ b/packages/hawtio/src/plugins/camel/debug/Debug.tsx
@@ -4,9 +4,7 @@ import { isBlank } from '@hawtiosrc/util/strings'
 import { childText, parseXML } from '@hawtiosrc/util/xml'
 import {
   Button,
-  CardActions,
   PanelMainBody,
-  CardTitle,
   Text,
   Toolbar,
   ToolbarContent,
@@ -484,21 +482,17 @@ export const Debug: React.FunctionComponent = () => {
 
   return (
     <Panel>
-      <PanelHeader>
-        <CardTitle>
-          <Title headingLevel='h3'>Debug</Title>
-        </CardTitle>
-        <CardActions>
-          <Button
-            variant='primary'
-            isSmall
-            icon={!isDebugging ? React.createElement(PlayIcon) : React.createElement(BanIcon)}
-            onClick={onDebugging}
-            isDisabled={!camelService.canGetBreakpoints(selectedNode)}
-          >
-            {!isDebugging ? 'Start Debugging' : 'Stop Debugging'}
-          </Button>
-        </CardActions>
+      <PanelHeader id='debug-header-container'>
+        <Title headingLevel='h3'>Debug</Title>
+        <Button
+          variant='primary'
+          isSmall
+          icon={!isDebugging ? React.createElement(PlayIcon) : React.createElement(BanIcon)}
+          onClick={onDebugging}
+          isDisabled={!camelService.canGetBreakpoints(selectedNode)}
+        >
+          {!isDebugging ? 'Start Debugging' : 'Stop Debugging'}
+        </Button>
       </PanelHeader>
       <PanelMain>
         <PanelMainBody>

--- a/packages/hawtio/src/plugins/jmx/JmxContent.tsx
+++ b/packages/hawtio/src/plugins/jmx/JmxContent.tsx
@@ -2,6 +2,7 @@ import { Chart, JmxContentMBeans, MBeanNode } from '@hawtiosrc/plugins/shared'
 import { AttributeTable, Attributes } from '@hawtiosrc/plugins/shared/attributes'
 import { Operations } from '@hawtiosrc/plugins/shared/operations'
 import {
+  Divider,
   EmptyState,
   EmptyStateIcon,
   EmptyStateVariant,
@@ -9,7 +10,6 @@ import {
   NavItem,
   NavList,
   PageGroup,
-  PageNavigation,
   PageSection,
   PageSectionVariants,
   Text,
@@ -86,9 +86,17 @@ export const JmxContent: React.FunctionComponent = () => {
           <Title headingLevel='h1'>{selectedNode.name}</Title>
           <Text component='small'>{selectedNode.objectName}</Text>
         </PageSection>
-        <PageNavigation>{mbeanNav}</PageNavigation>
+        <Divider />
+        <PageSection type='tabs' variant={PageSectionVariants.light} hasShadowBottom>
+          {mbeanNav}
+        </PageSection>
+        <Divider />
       </PageGroup>
-      <PageSection id='jmx-content-main'>
+      <PageSection
+        id='jmx-content-main'
+        variant={pathname.includes('chart') ? PageSectionVariants.default : PageSectionVariants.light}
+        hasOverflowScroll
+      >
         <Routes>
           {mbeanRoutes}
           <Route key='root' path='/' element={<Navigate to={navItems[0]?.id ?? ''} />} />

--- a/packages/hawtio/src/plugins/jmx/JmxContent.tsx
+++ b/packages/hawtio/src/plugins/jmx/JmxContent.tsx
@@ -95,6 +95,7 @@ export const JmxContent: React.FunctionComponent = () => {
       <PageSection
         id='jmx-content-main'
         variant={pathname.includes('chart') ? PageSectionVariants.default : PageSectionVariants.light}
+        padding={{ default: pathname.includes('chart') ? 'padding' : 'noPadding' }}
         hasOverflowScroll
       >
         <Routes>

--- a/packages/hawtio/src/plugins/logs/Logs.tsx
+++ b/packages/hawtio/src/plugins/logs/Logs.tsx
@@ -10,6 +10,7 @@ import {
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
+  Divider,
   EmptyState,
   EmptyStateBody,
   EmptyStateIcon,
@@ -18,6 +19,7 @@ import {
   PageSection,
   Pagination,
   PaginationProps,
+  Panel,
   SearchInput,
   Select,
   SelectOption,
@@ -40,10 +42,11 @@ import { LOGS_UPDATE_INTERVAL, logsService } from './logs-service'
 export const Logs: React.FunctionComponent = () => {
   return (
     <React.Fragment>
-      <PageSection id='logs-header' variant='light'>
+      <PageSection id='logs-header' hasShadowBottom variant='light'>
         <Title headingLevel='h1'>Logs</Title>
       </PageSection>
-      <PageSection id='logs-table' isFilled>
+      <Divider />
+      <PageSection id='logs-table' variant='light' isFilled>
         <LogsTable />
       </PageSection>
     </React.Fragment>
@@ -272,7 +275,7 @@ const LogsTable: React.FunctionComponent = () => {
   }
 
   return (
-    <Card>
+    <Panel>
       {tableToolbar}
       <TableComposable variant='compact' aria-label='Logs Table' isStriped isStickyHeader>
         <Thead>
@@ -316,7 +319,7 @@ const LogsTable: React.FunctionComponent = () => {
       </TableComposable>
       {renderPagination('bottom', false)}
       <LogModal isOpen={isModalOpen} onClose={handleModalToggle} log={selected} />
-    </Card>
+    </Panel>
   )
 }
 

--- a/packages/hawtio/src/plugins/quartz/QuartzContent.tsx
+++ b/packages/hawtio/src/plugins/quartz/QuartzContent.tsx
@@ -1,5 +1,6 @@
 import { Attributes, Operations } from '@hawtiosrc/plugins/shared'
 import {
+  Divider,
   EmptyState,
   EmptyStateBody,
   EmptyStateIcon,
@@ -7,7 +8,6 @@ import {
   NavItem,
   NavList,
   PageGroup,
-  PageNavigation,
   PageSection,
   PageSectionVariants,
   Text,
@@ -87,9 +87,13 @@ export const QuartzContent: React.FunctionComponent = () => {
           <Title headingLevel='h1'>{selectedNode.name}</Title>
           <Text component='small'>{selectedNode.objectName}</Text>
         </PageSection>
-        <PageNavigation>{nav}</PageNavigation>
+        <Divider />
+        <PageSection type='tabs' hasShadowBottom>
+          {nav}
+        </PageSection>
+        <Divider />
       </PageGroup>
-      <PageSection id='quartz-content-main'>
+      <PageSection variant='light' id='quartz-content-main' padding={{ default: 'noPadding' }}>
         <Routes>
           {routes}
           <Route key='root' path='/' element={<Navigate to={navItems[0]?.id ?? ''} />} />

--- a/packages/hawtio/src/plugins/quartz/jobs/Jobs.tsx
+++ b/packages/hawtio/src/plugins/quartz/jobs/Jobs.tsx
@@ -2,10 +2,12 @@ import { HawtioLoadingCard } from '@hawtiosrc/plugins/shared'
 import {
   Bullseye,
   Button,
-  Card,
   EmptyState,
   EmptyStateBody,
   EmptyStateIcon,
+  Panel,
+  PanelMain,
+  PanelMainBody,
   SearchInput,
   Select,
   SelectOption,
@@ -176,30 +178,34 @@ export const Jobs: React.FunctionComponent = () => {
   )
 
   return (
-    <Card isFullHeight>
-      {tableToolbar}
-      <TableComposable id='quartz-jobs-table' variant='compact' aria-label='Jobs Table' isStriped isStickyHeader>
-        <Thead noWrap>
-          <Tr>
-            <Th>Group</Th>
-            <Th>Name</Th>
-            <Th>Durable</Th>
-            <Th>Recover</Th>
-            <Th>Job Class Name</Th>
-            <Th>Description</Th>
-          </Tr>
-        </Thead>
-        <Tbody>
-          {filteredJobs.map((job, index) => (
-            <JobsTableRow key={index} job={job} />
-          ))}
-          {filteredJobs.length === 0 && (
-            <Tr>
-              <Td colSpan={6}>{emptyResult}</Td>
-            </Tr>
-          )}
-        </Tbody>
-      </TableComposable>
-    </Card>
+    <Panel>
+      <PanelMain>
+        <PanelMainBody>
+          {tableToolbar}
+          <TableComposable id='quartz-jobs-table' variant='compact' aria-label='Jobs Table' isStriped isStickyHeader>
+            <Thead noWrap>
+              <Tr>
+                <Th>Group</Th>
+                <Th>Name</Th>
+                <Th>Durable</Th>
+                <Th>Recover</Th>
+                <Th>Job Class Name</Th>
+                <Th>Description</Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {filteredJobs.map((job, index) => (
+                <JobsTableRow key={index} job={job} />
+              ))}
+              {filteredJobs.length === 0 && (
+                <Tr>
+                  <Td colSpan={6}>{emptyResult}</Td>
+                </Tr>
+              )}
+            </Tbody>
+          </TableComposable>
+        </PanelMainBody>
+      </PanelMain>
+    </Panel>
   )
 }

--- a/packages/hawtio/src/plugins/quartz/triggers/Triggers.tsx
+++ b/packages/hawtio/src/plugins/quartz/triggers/Triggers.tsx
@@ -2,10 +2,12 @@ import { HawtioLoadingCard } from '@hawtiosrc/plugins/shared'
 import {
   Bullseye,
   Button,
-  Card,
   EmptyState,
   EmptyStateBody,
   EmptyStateIcon,
+  Panel,
+  PanelMain,
+  PanelMainBody,
   SearchInput,
   Select,
   SelectOption,
@@ -172,40 +174,45 @@ export const Triggers: React.FunctionComponent = () => {
   )
 
   return (
-    <Card isFullHeight>
-      {tableToolbar}
-      <TableComposable
-        id='quartz-triggers-table'
-        variant='compact'
-        aria-label='Triggers Table'
-        isStriped
-        isStickyHeader
-      >
-        <Thead noWrap>
-          <Tr>
-            <Th>State</Th>
-            <Th>Group</Th>
-            <Th>Name</Th>
-            <Th>Type</Th>
-            <Th>Expression</Th>
-            <Th>Misfire Instruction</Th>
-            <Th>Previous Fire</Th>
-            <Th>Next Fire</Th>
-            <Th>Final Fire</Th>
-            <Th colSpan={2}>Actions</Th>
-          </Tr>
-        </Thead>
-        <Tbody>
-          {filteredTriggers.map((trigger, index) => (
-            <TriggersTableRow key={index} trigger={trigger} reload={() => setReload(true)} />
-          ))}
-          {filteredTriggers.length === 0 && (
-            <Tr>
-              <Td colSpan={11}>{emptyResult}</Td>
-            </Tr>
-          )}
-        </Tbody>
-      </TableComposable>
-    </Card>
+    <Panel>
+      {' '}
+      <PanelMain>
+        <PanelMainBody>
+          {tableToolbar}
+          <TableComposable
+            id='quartz-triggers-table'
+            variant='compact'
+            aria-label='Triggers Table'
+            isStriped
+            isStickyHeader
+          >
+            <Thead noWrap>
+              <Tr>
+                <Th>State</Th>
+                <Th>Group</Th>
+                <Th>Name</Th>
+                <Th>Type</Th>
+                <Th>Expression</Th>
+                <Th>Misfire Instruction</Th>
+                <Th>Previous Fire</Th>
+                <Th>Next Fire</Th>
+                <Th>Final Fire</Th>
+                <Th colSpan={2}>Actions</Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {filteredTriggers.map((trigger, index) => (
+                <TriggersTableRow key={index} trigger={trigger} reload={() => setReload(true)} />
+              ))}
+              {filteredTriggers.length === 0 && (
+                <Tr>
+                  <Td colSpan={11}>{emptyResult}</Td>
+                </Tr>
+              )}
+            </Tbody>
+          </TableComposable>
+        </PanelMainBody>
+      </PanelMain>
+    </Panel>
   )
 }

--- a/packages/hawtio/src/plugins/quartz/triggers/Triggers.tsx
+++ b/packages/hawtio/src/plugins/quartz/triggers/Triggers.tsx
@@ -175,7 +175,6 @@ export const Triggers: React.FunctionComponent = () => {
 
   return (
     <Panel>
-      {' '}
       <PanelMain>
         <PanelMainBody>
           {tableToolbar}

--- a/packages/hawtio/src/plugins/runtime/Runtime.tsx
+++ b/packages/hawtio/src/plugins/runtime/Runtime.tsx
@@ -1,4 +1,4 @@
-import { Nav, NavItem, NavList, PageGroup, PageNavigation, PageSection, Title } from '@patternfly/react-core'
+import { Divider, Nav, NavItem, NavList, PageGroup, PageSection, Title } from '@patternfly/react-core'
 import React from 'react'
 
 import { Navigate, NavLink, Route, Routes, useLocation } from 'react-router-dom'
@@ -26,7 +26,8 @@ export const Runtime: React.FunctionComponent = () => {
         <Title headingLevel='h1'>Runtime</Title>
       </PageSection>
       <PageGroup>
-        <PageNavigation>
+        <Divider />
+        <PageSection type='tabs' hasShadowBottom>
           <Nav aria-label='Runtime Nav' variant='tertiary'>
             <NavList>
               {navItems.map(navItem => (
@@ -36,9 +37,10 @@ export const Runtime: React.FunctionComponent = () => {
               ))}
             </NavList>
           </Nav>
-        </PageNavigation>
+        </PageSection>
       </PageGroup>
-      <PageSection>
+      <Divider />
+      <PageSection variant={location.pathname.includes('metrics') ? 'default' : 'light'}>
         <Routes>
           {navItems.map(navItem => (
             <Route key={navItem.id} path={navItem.id} element={navItem.component} />

--- a/packages/hawtio/src/plugins/runtime/Runtime.tsx
+++ b/packages/hawtio/src/plugins/runtime/Runtime.tsx
@@ -40,7 +40,10 @@ export const Runtime: React.FunctionComponent = () => {
         </PageSection>
       </PageGroup>
       <Divider />
-      <PageSection variant={location.pathname.includes('metrics') ? 'default' : 'light'}>
+      <PageSection
+        variant={location.pathname.includes('metrics') ? 'default' : 'light'}
+        padding={{ default: location.pathname.includes('metrics') ? 'padding' : 'noPadding' }}
+      >
         <Routes>
           {navItems.map(navItem => (
             <Route key={navItem.id} path={navItem.id} element={navItem.component} />

--- a/packages/hawtio/src/plugins/runtime/SysProps.tsx
+++ b/packages/hawtio/src/plugins/runtime/SysProps.tsx
@@ -1,7 +1,6 @@
 import { objectSorter } from '@hawtiosrc/util/objects'
 import {
   Bullseye,
-  Card,
   Dropdown,
   DropdownItem,
   DropdownToggle,
@@ -10,6 +9,10 @@ import {
   EmptyStateIcon,
   FormGroup,
   Pagination,
+  Panel,
+  PanelHeader,
+  PanelMain,
+  PanelMainBody,
   SearchInput,
   Toolbar,
   ToolbarContent,
@@ -188,42 +191,46 @@ export const SysProps: React.FunctionComponent = () => {
   )
 
   return (
-    <Card isFullHeight>
-      {tableToolbar}
-      {sortProperties().length > 0 && (
-        <FormGroup>
-          <TableComposable aria-label='Message Table' variant='compact' height='80vh' isStriped isStickyHeader>
-            <Thead>
-              <Tr>
-                <Th data-testid={'name-header'} sort={getSortParams(0)}>
-                  Property Name
-                </Th>
-                <Th data-testid={'value-header'} sort={getSortParams(1)}>
-                  Property Value
-                </Th>
-              </Tr>
-            </Thead>
-            <Tbody>
-              {getPageProperties().map((prop, index) => {
-                return (
-                  <Tr key={'row' + index} data-testid={'row' + index}>
-                    <Td style={{ width: '20%' }}>{prop.key}</Td>
-                    <Td style={{ flex: 3 }}>{prop.value}</Td>
+    <Panel>
+      <PanelHeader>{tableToolbar}</PanelHeader>
+      <PanelMain>
+        <PanelMainBody>
+          {sortProperties().length > 0 && (
+            <FormGroup>
+              <TableComposable aria-label='Message Table' variant='compact' height='80vh' isStriped isStickyHeader>
+                <Thead>
+                  <Tr>
+                    <Th data-testid={'name-header'} sort={getSortParams(0)}>
+                      Property Name
+                    </Th>
+                    <Th data-testid={'value-header'} sort={getSortParams(1)}>
+                      Property Value
+                    </Th>
                   </Tr>
-                )
-              })}
-            </Tbody>
-          </TableComposable>
-        </FormGroup>
-      )}
-      {filteredProperties.length === 0 && (
-        <Bullseye>
-          <EmptyState>
-            <EmptyStateIcon icon={SearchIcon} />
-            <EmptyStateBody>No results found.</EmptyStateBody>
-          </EmptyState>
-        </Bullseye>
-      )}
-    </Card>
+                </Thead>
+                <Tbody>
+                  {getPageProperties().map((prop, index) => {
+                    return (
+                      <Tr key={'row' + index} data-testid={'row' + index}>
+                        <Td style={{ width: '20%' }}>{prop.key}</Td>
+                        <Td style={{ flex: 3 }}>{prop.value}</Td>
+                      </Tr>
+                    )
+                  })}
+                </Tbody>
+              </TableComposable>
+            </FormGroup>
+          )}
+          {filteredProperties.length === 0 && (
+            <Bullseye>
+              <EmptyState>
+                <EmptyStateIcon icon={SearchIcon} />
+                <EmptyStateBody>No results found.</EmptyStateBody>
+              </EmptyState>
+            </Bullseye>
+          )}
+        </PanelMainBody>
+      </PanelMain>
+    </Panel>
   )
 }

--- a/packages/hawtio/src/plugins/runtime/Threads.tsx
+++ b/packages/hawtio/src/plugins/runtime/Threads.tsx
@@ -1,7 +1,6 @@
 import {
   Bullseye,
   Button,
-  Card,
   CodeBlock,
   CodeBlockCode,
   Dropdown,
@@ -13,6 +12,10 @@ import {
   FormGroup,
   Modal,
   Pagination,
+  Panel,
+  PanelHeader,
+  PanelMain,
+  PanelMainBody,
   SearchInput,
   Toolbar,
   ToolbarContent,
@@ -280,63 +283,67 @@ export const Threads: React.FunctionComponent = () => {
   )
 
   return (
-    <Card isFullHeight>
+    <Panel>
       <ThreadsDumpModal isOpen={isThreadsDumpModalOpen} setIsOpen={setIsThreadsDumpModalOpen} />
       <ThreadInfoModal isOpen={isThreadDetailsOpen} thread={currentThread} setIsOpen={setIsThreadDetailsOpen} />
-      {tableToolbar}
-      {sortThreads().length > 0 && (
-        <FormGroup>
-          <TableComposable aria-label='Message Table' variant='compact' height='80vh' isStriped isStickyHeader>
-            <Thead>
-              <Tr>
-                {tableColumns.map((att, index) => (
-                  <Th key={'th-key' + index} data-testid={'id-' + att.key} sort={getSortParams(index)}>
-                    {att.value}
-                  </Th>
-                ))}
-                <Th></Th>
-              </Tr>
-            </Thead>
-            <Tbody>
-              {getThreadsPage().map((thread, index) => {
-                return (
-                  <Tr key={'row' + index} data-testid={'row' + index}>
-                    {tableColumns.map((att, column) => (
-                      <Td key={'col' + index + '-' + column}>
-                        {att.key === 'threadState' ? (
-                          <ThreadState state={getIndexedThread(thread)[column] as string} />
-                        ) : (
-                          getIndexedThread(thread)[column]
-                        )}
-                      </Td>
+      <PanelHeader>{tableToolbar}</PanelHeader>
+      <PanelMain>
+        <PanelMainBody>
+          {sortThreads().length > 0 && (
+            <FormGroup>
+              <TableComposable aria-label='Message Table' variant='compact' height='80vh' isStriped isStickyHeader>
+                <Thead>
+                  <Tr>
+                    {tableColumns.map((att, index) => (
+                      <Th key={'th-key' + index} data-testid={'id-' + att.key} sort={getSortParams(index)}>
+                        {att.value}
+                      </Th>
                     ))}
-                    <Td>
-                      <Button
-                        onClick={_event => {
-                          setIsThreadDetailsOpen(true)
-                          setCurrentThread(thread)
-                        }}
-                        isSmall
-                        variant='link'
-                      >
-                        Details
-                      </Button>
-                    </Td>
+                    <Th></Th>
                   </Tr>
-                )
-              })}
-            </Tbody>
-          </TableComposable>
-        </FormGroup>
-      )}
-      {filteredThreads.length === 0 && (
-        <Bullseye>
-          <EmptyState>
-            <EmptyStateIcon icon={SearchIcon} />
-            <EmptyStateBody>No results found.</EmptyStateBody>
-          </EmptyState>
-        </Bullseye>
-      )}
-    </Card>
+                </Thead>
+                <Tbody>
+                  {getThreadsPage().map((thread, index) => {
+                    return (
+                      <Tr key={'row' + index} data-testid={'row' + index}>
+                        {tableColumns.map((att, column) => (
+                          <Td key={'col' + index + '-' + column}>
+                            {att.key === 'threadState' ? (
+                              <ThreadState state={getIndexedThread(thread)[column] as string} />
+                            ) : (
+                              getIndexedThread(thread)[column]
+                            )}
+                          </Td>
+                        ))}
+                        <Td>
+                          <Button
+                            onClick={_event => {
+                              setIsThreadDetailsOpen(true)
+                              setCurrentThread(thread)
+                            }}
+                            isSmall
+                            variant='link'
+                          >
+                            Details
+                          </Button>
+                        </Td>
+                      </Tr>
+                    )
+                  })}
+                </Tbody>
+              </TableComposable>
+            </FormGroup>
+          )}
+          {filteredThreads.length === 0 && (
+            <Bullseye>
+              <EmptyState>
+                <EmptyStateIcon icon={SearchIcon} />
+                <EmptyStateBody>No results found.</EmptyStateBody>
+              </EmptyState>
+            </Bullseye>
+          )}
+        </PanelMainBody>
+      </PanelMain>
+    </Panel>
   )
 }

--- a/packages/hawtio/src/plugins/shared/JmxContentMBeans.tsx
+++ b/packages/hawtio/src/plugins/shared/JmxContentMBeans.tsx
@@ -1,5 +1,5 @@
 import { useContext } from 'react'
-import { Card, CardBody, Text } from '@patternfly/react-core'
+import { Card, CardBody, Panel, Text } from '@patternfly/react-core'
 import { InfoCircleIcon } from '@patternfly/react-icons'
 import { OnRowClick, Table, TableBody, TableHeader, TableProps } from '@patternfly/react-table'
 import { PluginNodeSelectionContext } from '@hawtiosrc/plugins/context'
@@ -36,11 +36,11 @@ export const JmxContentMBeans: React.FunctionComponent = () => {
   }
 
   return (
-    <Card isFullHeight>
+    <Panel>
       <Table aria-label='MBeans' variant='compact' cells={columns} rows={rows}>
         <TableHeader />
         <TableBody onRowClick={selectChild} className={'jmx-table-body'} />
       </Table>
-    </Card>
+    </Panel>
   )
 }

--- a/packages/hawtio/src/plugins/shared/attributes/Attributes.tsx
+++ b/packages/hawtio/src/plugins/shared/attributes/Attributes.tsx
@@ -128,14 +128,12 @@ export const Attributes: React.FunctionComponent = () => {
     </div>
   )
   return (
-    <React.Fragment>
-      <Panel>
-        <Drawer isExpanded={isModalOpen} className={'pf-m-inline-on-2xl'}>
-          <DrawerContent panelContent={panelContent}>
-            <DrawerContentBody hasPadding> {attributesTable}</DrawerContentBody>
-          </DrawerContent>
-        </Drawer>
-      </Panel>
-    </React.Fragment>
+    <Panel>
+      <Drawer isExpanded={isModalOpen} className={'pf-m-inline-on-2xl'}>
+        <DrawerContent panelContent={panelContent}>
+          <DrawerContentBody hasPadding> {attributesTable}</DrawerContentBody>
+        </DrawerContent>
+      </Drawer>
+    </Panel>
   )
 }

--- a/packages/hawtio/src/plugins/springboot/Health.tsx
+++ b/packages/hawtio/src/plugins/springboot/Health.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { Card, CardBody, CardHeader, Flex, FlexItem, Grid, GridItem, PageSection, Title } from '@patternfly/react-core'
+import { Card, CardBody, CardHeader, Flex, FlexItem, Grid, GridItem, Title } from '@patternfly/react-core'
 import { springbootService } from './springboot-service'
 import { HealthComponentDetail, HealthData } from './types'
 import { TableComposable, Tbody, Td, Tr } from '@patternfly/react-table'
@@ -88,7 +88,7 @@ export const Health: React.FunctionComponent = () => {
   }, [])
 
   return (
-    <PageSection variant='default'>
+    <React.Fragment>
       {healthData && (
         <Grid hasGutter span={4}>
           <GridItem span={12}>
@@ -137,6 +137,6 @@ export const Health: React.FunctionComponent = () => {
             })}
         </Grid>
       )}
-    </PageSection>
+    </React.Fragment>
   )
 }

--- a/packages/hawtio/src/plugins/springboot/Health.tsx
+++ b/packages/hawtio/src/plugins/springboot/Health.tsx
@@ -87,56 +87,56 @@ export const Health: React.FunctionComponent = () => {
     })
   }, [])
 
+  if (!healthData) {
+    return null
+  }
+
   return (
-    <React.Fragment>
-      {healthData && (
-        <Grid hasGutter span={4}>
-          <GridItem span={12}>
-            <Card>
-              <CardHeader>
-                <Flex>
-                  <HealthStatusIcon status={healthData?.status} />
-                  <Title headingLevel='h3'>
-                    <span>Overall status: {healthData?.status}</span>
-                  </Title>
-                </Flex>
-              </CardHeader>
-            </Card>
-          </GridItem>
-          {healthData?.components
-            .sort((a, b) => {
-              if (SPAN_6_COMPONENTS.includes(a.name)) return -1
-              else if (SPAN_6_COMPONENTS.includes(b.name)) return 1
-              else return a.name.localeCompare(b.name)
-            })
-            .map(component => {
-              const span = SPAN_6_COMPONENTS.includes(component.name) ? 6 : 4
-              return (
-                <GridItem span={span} key={component.name}>
-                  <Card isFullHeight>
-                    <CardHeader>
-                      <Title headingLevel='h3'>{humanizeLabels(component.name!)}</Title>
-                    </CardHeader>
-                    <CardBody style={{ overflow: 'auto' }}>
-                      <Flex>
-                        <FlexItem>
-                          <HealthStatusIcon status={component.status} />
-                        </FlexItem>
-                        <FlexItem>Status: {component.status}</FlexItem>
-                        {component.details &&
-                          (component.name === 'diskSpace' ? (
-                            <DiskComponentDetails componentDetails={component.details} />
-                          ) : (
-                            <ComponentDetails componentDetails={component.details} />
-                          ))}
-                      </Flex>
-                    </CardBody>
-                  </Card>
-                </GridItem>
-              )
-            })}
-        </Grid>
-      )}
-    </React.Fragment>
+    <Grid hasGutter span={4}>
+      <GridItem span={12}>
+        <Card>
+          <CardHeader>
+            <Flex>
+              <HealthStatusIcon status={healthData?.status} />
+              <Title headingLevel='h3'>
+                <span>Overall status: {healthData?.status}</span>
+              </Title>
+            </Flex>
+          </CardHeader>
+        </Card>
+      </GridItem>
+      {healthData?.components
+        .sort((a, b) => {
+          if (SPAN_6_COMPONENTS.includes(a.name)) return -1
+          else if (SPAN_6_COMPONENTS.includes(b.name)) return 1
+          else return a.name.localeCompare(b.name)
+        })
+        .map(component => {
+          const span = SPAN_6_COMPONENTS.includes(component.name) ? 6 : 4
+          return (
+            <GridItem span={span} key={component.name}>
+              <Card isFullHeight>
+                <CardHeader>
+                  <Title headingLevel='h3'>{humanizeLabels(component.name!)}</Title>
+                </CardHeader>
+                <CardBody style={{ overflow: 'auto' }}>
+                  <Flex>
+                    <FlexItem>
+                      <HealthStatusIcon status={component.status} />
+                    </FlexItem>
+                    <FlexItem>Status: {component.status}</FlexItem>
+                    {component.details &&
+                      (component.name === 'diskSpace' ? (
+                        <DiskComponentDetails componentDetails={component.details} />
+                      ) : (
+                        <ComponentDetails componentDetails={component.details} />
+                      ))}
+                  </Flex>
+                </CardBody>
+              </Card>
+            </GridItem>
+          )
+        })}
+    </Grid>
   )
 }

--- a/packages/hawtio/src/plugins/springboot/Info.tsx
+++ b/packages/hawtio/src/plugins/springboot/Info.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { FormGroup, PageSection } from '@patternfly/react-core'
+import { FormGroup } from '@patternfly/react-core'
 import { springbootService } from './springboot-service'
 import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table'
 
@@ -13,7 +13,7 @@ export const Info: React.FunctionComponent = () => {
   }, [])
 
   return (
-    <PageSection variant='light'>
+    <React.Fragment>
       <FormGroup>
         <TableComposable aria-label='Message Table' variant='compact' height='80vh' isStriped isStickyHeader>
           <Thead>
@@ -34,6 +34,6 @@ export const Info: React.FunctionComponent = () => {
           </Tbody>
         </TableComposable>
       </FormGroup>
-    </PageSection>
+    </React.Fragment>
   )
 }

--- a/packages/hawtio/src/plugins/springboot/Info.tsx
+++ b/packages/hawtio/src/plugins/springboot/Info.tsx
@@ -13,27 +13,25 @@ export const Info: React.FunctionComponent = () => {
   }, [])
 
   return (
-    <React.Fragment>
-      <FormGroup>
-        <TableComposable aria-label='Message Table' variant='compact' height='80vh' isStriped isStickyHeader>
-          <Thead>
-            <Tr>
-              <Th data-testid={'name-header'}>Property Name</Th>
-              <Th data-testid={'value-header'}>Property Value</Th>
-            </Tr>
-          </Thead>
-          <Tbody>
-            {systemProperties.map((prop, index) => {
-              return (
-                <Tr key={'row' + index} data-testid={'row' + index}>
-                  <Td style={{ width: '20%' }}>{prop.key}</Td>
-                  <Td style={{ flex: 3 }}>{prop.value}</Td>
-                </Tr>
-              )
-            })}
-          </Tbody>
-        </TableComposable>
-      </FormGroup>
-    </React.Fragment>
+    <FormGroup>
+      <TableComposable aria-label='Message Table' variant='compact' height='80vh' isStriped isStickyHeader>
+        <Thead>
+          <Tr>
+            <Th data-testid={'name-header'}>Property Name</Th>
+            <Th data-testid={'value-header'}>Property Value</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {systemProperties.map((prop, index) => {
+            return (
+              <Tr key={'row' + index} data-testid={'row' + index}>
+                <Td style={{ width: '20%' }}>{prop.key}</Td>
+                <Td style={{ flex: 3 }}>{prop.value}</Td>
+              </Tr>
+            )
+          })}
+        </Tbody>
+      </TableComposable>
+    </FormGroup>
   )
 }

--- a/packages/hawtio/src/plugins/springboot/Loggers.tsx
+++ b/packages/hawtio/src/plugins/springboot/Loggers.tsx
@@ -10,7 +10,6 @@ import {
   EmptyStateIcon,
   FormGroup,
   Label,
-  PageSection,
   Pagination,
   SearchInput,
   Toolbar,
@@ -210,7 +209,7 @@ export const Loggers: React.FunctionComponent = () => {
   )
 
   return (
-    <PageSection variant='light'>
+    <React.Fragment>
       {tableToolbar}
       {getCurrentPage().length > 0 && (
         <FormGroup>
@@ -253,6 +252,6 @@ export const Loggers: React.FunctionComponent = () => {
           </EmptyState>
         </Bullseye>
       )}
-    </PageSection>
+    </React.Fragment>
   )
 }

--- a/packages/hawtio/src/plugins/springboot/SpringBoot.tsx
+++ b/packages/hawtio/src/plugins/springboot/SpringBoot.tsx
@@ -1,4 +1,4 @@
-import { Nav, NavItem, NavList, PageGroup, PageNavigation, PageSection, Title } from '@patternfly/react-core'
+import { Divider, Nav, NavItem, NavList, PageSection, PageSectionVariants, Title } from '@patternfly/react-core'
 import React, { useEffect, useState } from 'react'
 
 import { Navigate, NavLink, Route, Routes, useLocation } from 'react-router-dom'
@@ -52,20 +52,23 @@ export const SpringBoot: React.FunctionComponent = () => {
       <PageSection variant='light'>
         <Title headingLevel='h1'>Spring Boot</Title>
       </PageSection>
-      <PageGroup>
-        <PageNavigation>
-          <Nav aria-label='Spring-boot Nav' variant='tertiary'>
-            <NavList>
-              {navItems.map(navItem => (
-                <NavItem key={navItem.id} isActive={location.pathname === `/springboot/${navItem.id}`}>
-                  <NavLink to={navItem.id}>{navItem.title}</NavLink>
-                </NavItem>
-              ))}
-            </NavList>
-          </Nav>
-        </PageNavigation>
-      </PageGroup>
-      <PageSection>
+      <Divider />
+      <PageSection type='tabs' hasShadowBottom>
+        <Nav aria-label='Spring-boot Nav' variant='tertiary'>
+          <NavList>
+            {navItems.map(navItem => (
+              <NavItem key={navItem.id} isActive={location.pathname === `/springboot/${navItem.id}`}>
+                <NavLink to={navItem.id}>{navItem.title}</NavLink>
+              </NavItem>
+            ))}
+          </NavList>
+        </Nav>
+      </PageSection>
+      <Divider />
+      <PageSection
+        aria-label='Spring-boot Content'
+        variant={location.pathname === '/springboot/health' ? PageSectionVariants.default : PageSectionVariants.light}
+      >
         <Routes>
           {navItems.map(navItem => (
             <Route key={navItem.id} path={navItem.id} element={navItem.component} />

--- a/packages/hawtio/src/plugins/springboot/SpringBoot.tsx
+++ b/packages/hawtio/src/plugins/springboot/SpringBoot.tsx
@@ -68,6 +68,7 @@ export const SpringBoot: React.FunctionComponent = () => {
       <PageSection
         aria-label='Spring-boot Content'
         variant={location.pathname === '/springboot/health' ? PageSectionVariants.default : PageSectionVariants.light}
+        padding={{ default: location.pathname.includes('health') ? 'padding' : 'noPadding' }}
       >
         <Routes>
           {navItems.map(navItem => (


### PR DESCRIPTION
Similar as in #883 for the rest of the plugins: 
<img width="1749" alt="Screenshot 2024-04-23 at 13 34 27" src="https://github.com/hawtio/hawtio-next/assets/6814482/fbb44f97-b3b2-4164-a4f2-4571781e536c">
<img width="1779" alt="Screenshot 2024-04-23 at 13 34 08" src="https://github.com/hawtio/hawtio-next/assets/6814482/9986b2e7-a38c-43e3-b195-7e29f572f397">
<img width="1760" alt="Screenshot 2024-04-23 at 13 34 01" src="https://github.com/hawtio/hawtio-next/assets/6814482/3171c410-5f25-428e-a671-5b7d0cff1d7f">
<img width="1772" alt="Screenshot 2024-04-23 at 13 33 56" src="https://github.com/hawtio/hawtio-next/assets/6814482/5defc838-493a-4af3-8526-ed0e5845dabe">
<img width="1778" alt="Screenshot 2024-04-23 at 13 33 52" src="https://github.com/hawtio/hawtio-next/assets/6814482/9719403a-a1bf-4bf3-bdfa-a51b7667a287">
<img width="1788" alt="Screenshot 2024-04-23 at 13 32 46" src="https://github.com/hawtio/hawtio-next/assets/6814482/1d3f9884-822a-4826-8821-24a82af33768">
<img width="1771" alt="Screenshot 2024-04-23 at 13 32 41" src="https://github.com/hawtio/hawtio-next/assets/6814482/b3b215b9-0299-4edd-b70c-a729868b6e72">
