### PR TITLE
 refactor(connect-plugin): adjust the look to be consistent with the rest of the plugins

### DIFF
--- a/packages/hawtio/src/plugins/connect/Connect.tsx
+++ b/packages/hawtio/src/plugins/connect/Connect.tsx
@@ -1,10 +1,11 @@
 import {
+  Divider,
   Nav,
   NavItem,
   NavList,
   PageGroup,
-  PageNavigation,
   PageSection,
+  PageSectionVariants,
   Popover,
   Text,
   TextContent,
@@ -53,9 +54,13 @@ export const Connect: React.FunctionComponent = () => {
             Connect <ConnectHint />
           </Title>
         </PageSection>
-        <PageNavigation>{nav}</PageNavigation>
+        <Divider />
+        <PageSection type='tabs' variant={PageSectionVariants.light} hasShadowBottom>
+          {nav}
+        </PageSection>
+        <Divider />
       </PageGroup>
-      <PageSection id='connect-main'>
+      <PageSection id='connect-main' variant={PageSectionVariants.light}>
         <Routes>
           {routes}
           {/* connect/login should be hidden to nav */}

--- a/packages/hawtio/src/plugins/connect/discover/Discover.tsx
+++ b/packages/hawtio/src/plugins/connect/discover/Discover.tsx
@@ -194,7 +194,9 @@ export const Discover: React.FunctionComponent = () => {
 
   return (
     <React.Fragment>
-      <Card style={{ marginBottom: '1rem' }}>{toolbar}</Card>
+      <Card style={{ marginBottom: '1rem' }} isFlat>
+        {toolbar}
+      </Card>
       <Gallery hasGutter minWidths={{ default: '400px' }}>
         {label === 'Agent' &&
           filteredAgents.map((agent, index) => (


### PR DESCRIPTION
![image](https://github.com/hawtio/hawtio-next/assets/6814482/1f6cc89f-fd6c-4915-a17d-1c5841600df2)
