### PR TITLE
HAWNG-646: Default connection modal to https scheme

### DIFF
--- a/packages/hawtio/src/plugins/shared/connect-service.ts
+++ b/packages/hawtio/src/plugins/shared/connect-service.ts
@@ -26,7 +26,7 @@ export type Connection = {
 
 export const INITIAL_CONNECTION: Connection = {
   name: '',
-  scheme: 'http',
+  scheme: 'https',
   host: 'localhost',
   port: 8080,
   path: '/hawtio/jolokia',


### PR DESCRIPTION
* Makes the switch on the ConnectionModal default to https