### PR TITLE
refactor(Dropdowns):Refactor the components across the hawtio to use the PF5 dropdown instead of old deprecate ones

### DIFF
--- a/app/src/examples/example3/Example3HeaderItems.tsx
+++ b/app/src/examples/example3/Example3HeaderItems.tsx
@@ -54,8 +54,9 @@ export const Example3HeaderItem2: React.FunctionComponent = () => {
     <Dropdown
       id='example3-header-item2-dropdown'
       onSelect={onSelect}
+      onOpenChange={setIsOpen}
       toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-        <MenuToggle id='example3-header-item2-dropdown-toggle' ref={toggleRef} onClick={onToggle}>
+        <MenuToggle variant='plain' id='example3-header-item2-dropdown-toggle' ref={toggleRef} onClick={onToggle}>
           Example 3
         </MenuToggle>
       )}

--- a/packages/hawtio/src/plugins/camel/contexts/ContextToolbar.tsx
+++ b/packages/hawtio/src/plugins/camel/contexts/ContextToolbar.tsx
@@ -1,8 +1,21 @@
 import { eventService } from '@hawtiosrc/core'
 import { workspace } from '@hawtiosrc/plugins/shared'
-import { Button, Modal, ModalVariant, Skeleton, Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core'
-import { Dropdown, DropdownItem, KebabToggle } from '@patternfly/react-core/deprecated'
+import {
+  Button,
+  Dropdown,
+  DropdownItem,
+  DropdownList,
+  MenuToggle,
+  MenuToggleElement,
+  Modal,
+  ModalVariant,
+  Skeleton,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
+} from '@patternfly/react-core'
 import { AsleepIcon, PlayIcon, Remove2Icon } from '@patternfly/react-icons'
+import EllipsisVIcon from '@patternfly/react-icons/dist/js/icons/ellipsis-v-icon'
 import React, { useState } from 'react'
 import {
   CONTEXT_OPERATIONS,
@@ -90,8 +103,10 @@ export const ContextToolbar: React.FunctionComponent<{
   }
 
   const onDeleteClicked = () => {
-    setIsDropdownOpen(false)
-    handleConfirmDeleteToggle()
+    if (isDeleteEnabled()) {
+      setIsDropdownOpen(false)
+      handleConfirmDeleteToggle()
+    }
   }
 
   const onDeleteConfirmClicked = () => {
@@ -187,18 +202,11 @@ export const ContextToolbar: React.FunctionComponent<{
   const dropdownItems = [
     <DropdownItem
       key='delete'
-      component={
-        <Button
-          variant='plain'
-          isDisabled={
-            !(firstContext && firstContext.node.hasInvokeRights(CONTEXT_OPERATIONS.stop)) || !isDeleteEnabled()
-          }
-          onClick={onDeleteClicked}
-        >
-          <Remove2Icon /> Delete
-        </Button>
-      }
-    />,
+      isDisabled={!(firstContext && firstContext.node.hasInvokeRights(CONTEXT_OPERATIONS.stop)) || !isDeleteEnabled()}
+      onClick={onDeleteClicked}
+    >
+      <Remove2Icon /> Delete
+    </DropdownItem>,
   ]
 
   return (
@@ -208,16 +216,22 @@ export const ContextToolbar: React.FunctionComponent<{
           {toolbarButtons}
           <ToolbarItem id='camel-contexts-toolbar-item-dropdown'>
             <Dropdown
-              toggle={
-                <KebabToggle
+              onSelect={() => onDropdownToggle(!isDropdownOpen)}
+              onOpenChange={onDropdownToggle}
+              toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                <MenuToggle
+                  ref={toggleRef}
+                  variant='plain'
                   id='camel-contexts-toolbar-item-dropdown-toggle'
-                  onToggle={(_event, isOpen: boolean) => onDropdownToggle(isOpen)}
-                />
-              }
+                  onClick={() => onDropdownToggle(!isDropdownOpen)}
+                >
+                  <EllipsisVIcon />
+                </MenuToggle>
+              )}
               isOpen={isDropdownOpen}
-              dropdownItems={dropdownItems}
-              isPlain
-            />
+            >
+              <DropdownList>{dropdownItems}</DropdownList>
+            </Dropdown>
           </ToolbarItem>
         </ToolbarContent>
       </Toolbar>

--- a/packages/hawtio/src/plugins/camel/endpoints/EndpointsStats.tsx
+++ b/packages/hawtio/src/plugins/camel/endpoints/EndpointsStats.tsx
@@ -16,8 +16,13 @@ import {
   ToolbarFilter,
   ToolbarGroup,
   EmptyStateHeader,
+  DropdownItem,
+  Dropdown,
+  MenuToggle,
+  MenuToggleElement,
+  DropdownList,
 } from '@patternfly/react-core'
-import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core/deprecated'
+
 import { Table, Tbody, Td, Th, Thead, ThProps, Tr } from '@patternfly/react-table'
 import { SearchIcon } from '@patternfly/react-icons'
 import { objectSorter } from '@hawtiosrc/util/objects'
@@ -137,18 +142,21 @@ export const EndpointStats: React.FunctionComponent = () => {
               data-testid='attribute-select'
               onSelect={() => setIsDropdownOpen(false)}
               defaultValue='url'
-              toggle={
-                <DropdownToggle
+              onOpenChange={setIsDropdownOpen}
+              toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                <MenuToggle
+                  ref={toggleRef}
                   data-testid='attribute-select-toggle'
                   id='toggle-basic'
-                  onToggle={(_event, val) => setIsDropdownOpen(val)}
+                  onClick={() => setIsDropdownOpen(!isDropdownOpen)}
                 >
                   {attributes.find(att => att.key === attributeMenuItem)?.value}
-                </DropdownToggle>
-              }
+                </MenuToggle>
+              )}
               isOpen={isDropdownOpen}
-              dropdownItems={dropdownItems}
-            />
+            >
+              <DropdownList>{dropdownItems}</DropdownList>
+            </Dropdown>
 
             <ToolbarFilter
               chips={filters}

--- a/packages/hawtio/src/plugins/camel/routes/CamelRoutes.tsx
+++ b/packages/hawtio/src/plugins/camel/routes/CamelRoutes.tsx
@@ -1,14 +1,26 @@
 import { eventService } from '@hawtiosrc/core'
 import { HawtioEmptyCard, HawtioLoadingCard, workspace } from '@hawtiosrc/plugins/shared'
 import { objectSorter } from '@hawtiosrc/util/objects'
-import { Button, Label, Modal, Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core'
-import { Dropdown, DropdownItem, KebabToggle } from '@patternfly/react-core/deprecated'
+import {
+  Button,
+  Dropdown,
+  DropdownItem,
+  DropdownList,
+  Label,
+  MenuToggle,
+  MenuToggleElement,
+  Modal,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
+} from '@patternfly/react-core'
 import { AsleepIcon, PlayIcon, Remove2Icon } from '@patternfly/react-icons'
 import { Table, Tbody, Td, Th, ThProps, Thead, Tr } from '@patternfly/react-table'
 import React, { useContext, useEffect, useState } from 'react'
 import { CamelContext } from '../context'
 import { CamelRoute } from './route'
 import { routesService } from './routes-service'
+import EllipsisVIcon from '@patternfly/react-icons/dist/js/icons/ellipsis-v-icon'
 
 const ROUTES_REFRESH_INTERVAL = 10000 // milliseconds
 
@@ -347,16 +359,11 @@ const CamelRoutesToolbar: React.FunctionComponent<{
   const dropdownItems = [
     <DropdownItem
       key='action'
-      component={
-        <Button
-          variant='plain'
-          isDisabled={!routesService.canDeleteRoute(firstRoute.node) || !isSuspendEnabled('Stopped')}
-          onClick={onDeleteClicked}
-        >
-          <Remove2Icon /> Delete
-        </Button>
-      }
-    />,
+      isDisabled={!routesService.canDeleteRoute(firstRoute.node) || !isSuspendEnabled('Stopped')}
+      onClick={onDeleteClicked}
+    >
+      <Remove2Icon /> Delete
+    </DropdownItem>,
   ]
 
   return (
@@ -365,16 +372,22 @@ const CamelRoutesToolbar: React.FunctionComponent<{
         {toolbarButtons}
         <ToolbarItem id='camel-routes-toolbar-item-dropdown'>
           <Dropdown
-            toggle={
-              <KebabToggle
+            onSelect={() => onDropdownToggle(!isDropdownOpen)}
+            onOpenChange={setIsDropdownOpen}
+            toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+              <MenuToggle
+                ref={toggleRef}
+                variant='plain'
                 id='camel-routes-toolbar-item-dropdown-toggle'
-                onToggle={(_event, isOpen: boolean) => onDropdownToggle(isOpen)}
-              />
-            }
+                onClick={() => onDropdownToggle(!isDropdownOpen)}
+              >
+                <EllipsisVIcon />
+              </MenuToggle>
+            )}
             isOpen={isDropdownOpen}
-            dropdownItems={dropdownItems}
-            isPlain
-          />
+          >
+            <DropdownList>{dropdownItems}</DropdownList>
+          </Dropdown>
         </ToolbarItem>
       </ToolbarContent>
     </Toolbar>

--- a/packages/hawtio/src/plugins/connect/remote/Remote.tsx
+++ b/packages/hawtio/src/plugins/connect/remote/Remote.tsx
@@ -13,14 +13,18 @@ import {
   DataListItem,
   DataListItemCells,
   DataListItemRow,
+  Dropdown,
+  DropdownItem,
+  DropdownList,
   Icon,
+  MenuToggle,
+  MenuToggleElement,
   Modal,
   ModalVariant,
   Toolbar,
   ToolbarContent,
   ToolbarItem,
 } from '@patternfly/react-core'
-import { Dropdown, DropdownItem, DropdownPosition, KebabToggle } from '@patternfly/react-core/deprecated'
 import { PluggedIcon, PlusIcon, UnpluggedIcon } from '@patternfly/react-icons'
 import React, { useContext, useEffect, useState } from 'react'
 import { DELETE } from '../connections'
@@ -28,6 +32,7 @@ import { ConnectContext } from '../context'
 import { log } from '../globals'
 import { ConnectionModal } from './ConnectionModal'
 import { ImportModal } from './ImportModal'
+import EllipsisVIcon from '@patternfly/react-icons/dist/js/icons/ellipsis-v-icon'
 
 export const Remote: React.FunctionComponent = () => {
   const { connections } = useContext(ConnectContext)
@@ -76,18 +81,21 @@ const RemoteToolbar: React.FunctionComponent = () => {
         <ToolbarItem>
           <Dropdown
             key='connect-toolbar-dropdown'
-            isPlain
             isOpen={isDropdownOpen}
-            toggle={<KebabToggle onToggle={() => setIsDropdownOpen(!isDropdownOpen)} />}
-            dropdownItems={[
+            onOpenChange={setIsDropdownOpen}
+            toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+              <MenuToggle ref={toggleRef} onClick={() => setIsDropdownOpen(!isDropdownOpen)}></MenuToggle>
+            )}
+          >
+            <DropdownList>
               <DropdownItem key='connect-toolbar-dropdown-import' onClick={handleImportModalToggle}>
                 Import connections
-              </DropdownItem>,
+              </DropdownItem>
               <DropdownItem key='connect-toolbar-dropdown-export' onClick={exportConnections}>
                 Export connections
-              </DropdownItem>,
-            ]}
-          />
+              </DropdownItem>
+            </DropdownList>
+          </Dropdown>
         </ToolbarItem>
       </ToolbarContent>
       <ConnectionModal mode='add' isOpen={isAddOpen} onClose={handleAddToggle} input={initialConnection} />
@@ -218,19 +226,23 @@ const ConnectionItem: React.FunctionComponent<{
           </Button>
           <Dropdown
             key={`connection-action-dropdown-${id}`}
-            isPlain
-            position={DropdownPosition.right}
             isOpen={isDropdownOpen}
-            toggle={<KebabToggle onToggle={handleDropdownToggle} />}
-            dropdownItems={[
+            onOpenChange={setIsDropdownOpen}
+            toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+              <MenuToggle variant='plain' ref={toggleRef} onClick={handleDropdownToggle}>
+                <EllipsisVIcon />
+              </MenuToggle>
+            )}
+          >
+            <DropdownList>
               <DropdownItem key={`connection-action-edit-${id}`} onClick={handleEditToggle}>
                 Edit
-              </DropdownItem>,
+              </DropdownItem>
               <DropdownItem key={`connection-action-delete-${id}`} onClick={handleConfirmDeleteToggle}>
                 Delete
-              </DropdownItem>,
-            ]}
-          />
+              </DropdownItem>
+            </DropdownList>
+          </Dropdown>
           <ConfirmDeleteModal />
         </DataListAction>
       </DataListItemRow>

--- a/packages/hawtio/src/plugins/runtime/SysProps.tsx
+++ b/packages/hawtio/src/plugins/runtime/SysProps.tsx
@@ -1,6 +1,8 @@
 import { objectSorter } from '@hawtiosrc/util/objects'
 import {
   Bullseye,
+  Dropdown,
+  DropdownItem,
   EmptyState,
   EmptyStateBody,
   EmptyStateIcon,
@@ -17,8 +19,10 @@ import {
   ToolbarGroup,
   ToolbarItem,
   EmptyStateHeader,
+  MenuToggleElement,
+  MenuToggle,
+  DropdownList,
 } from '@patternfly/react-core'
-import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core/deprecated'
 import { SearchIcon } from '@patternfly/react-icons'
 import { Table, Tbody, Td, Th, ThProps, Thead, Tr } from '@patternfly/react-table'
 import React, { useEffect, useState } from 'react'
@@ -156,18 +160,23 @@ export const SysProps: React.FunctionComponent = () => {
               addToFilters()
             }}
             defaultValue='name'
-            toggle={
-              <DropdownToggle
+            onOpenChange={setIsDropdownOpen}
+            toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+              <MenuToggle
+                ref={toggleRef}
                 data-testid='attribute-select-toggle'
                 id='toggle-basic'
-                onToggle={(_event, val) => setIsDropdownOpen(val)}
+                onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+                isExpanded={isDropdownOpen}
               >
                 {attributes.find(att => att.key === filteredAttribute)?.value}
-              </DropdownToggle>
-            }
+              </MenuToggle>
+            )}
+            shouldFocusToggleOnSelect
             isOpen={isDropdownOpen}
-            dropdownItems={dropdownItems}
-          />
+          >
+            <DropdownList>{dropdownItems}</DropdownList>
+          </Dropdown>
           <ToolbarFilter
             chips={searchTerm !== '' ? [...filters, `${filteredAttribute}:${searchTerm}`] : filters}
             deleteChip={(_e, filter) => onDeleteFilter(filter as string)}

--- a/packages/hawtio/src/plugins/runtime/Threads.tsx
+++ b/packages/hawtio/src/plugins/runtime/Threads.tsx
@@ -20,8 +20,12 @@ import {
   ToolbarGroup,
   ToolbarItem,
   EmptyStateHeader,
+  DropdownItem,
+  MenuToggle,
+  MenuToggleElement,
+  Dropdown,
+  DropdownList,
 } from '@patternfly/react-core'
-import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core/deprecated'
 import React, { useEffect, useState } from 'react'
 
 import { Thread } from './types'
@@ -234,19 +238,22 @@ export const Threads: React.FunctionComponent = () => {
               setIsDropdownOpen(false)
               addToFilters()
             }}
+            onOpenChange={setIsDropdownOpen}
             defaultValue='Name'
-            toggle={
-              <DropdownToggle
+            toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+              <MenuToggle
+                ref={toggleRef}
                 data-testid='attribute-select-toggle'
                 id='toggle-basic'
-                onToggle={(_event, val) => setIsDropdownOpen(val)}
+                onClick={() => setIsDropdownOpen(!isDropdownOpen)}
               >
                 {tableColumns.find(att => att.value === attributeMenuItem)?.value}
-              </DropdownToggle>
-            }
+              </MenuToggle>
+            )}
             isOpen={isDropdownOpen}
-            dropdownItems={dropdownItems}
-          />
+          >
+            <DropdownList>{dropdownItems}</DropdownList>
+          </Dropdown>
           <ToolbarFilter
             chips={searchTerm !== '' ? [...filters, `${attributeMenuItem}:${searchTerm}`] : filters}
             deleteChip={(_e, filter) => onDeleteFilter(filter as string)}

--- a/packages/hawtio/src/plugins/shared/operations/OperationForm.tsx
+++ b/packages/hawtio/src/plugins/shared/operations/OperationForm.tsx
@@ -13,21 +13,26 @@ import {
   DataListItemCells,
   DataListItemRow,
   DataListToggle,
+  Dropdown,
+  DropdownItem,
+  DropdownList,
   Form,
   FormGroup,
   FormHelperText,
   HelperText,
   HelperTextItem,
+  MenuToggle,
+  MenuToggleElement,
   Text,
   TextInput,
   Title,
 } from '@patternfly/react-core'
-import { Dropdown, DropdownItem, DropdownPosition, KebabToggle } from '@patternfly/react-core/deprecated'
 import { LockIcon } from '@patternfly/react-icons'
 import React, { createContext, useContext, useState } from 'react'
 import './OperationForm.css'
 import { Operation, OperationArgument } from './operation'
 import { operationService } from './operation-service'
+import EllipsisVIcon from '@patternfly/react-icons/dist/js/icons/ellipsis-v-icon'
 
 export const OperationContext = createContext<{
   name: string
@@ -124,19 +129,23 @@ const OperationActions: React.FunctionComponent = () => {
     >
       <Dropdown
         key={`operation-action-dropdown-${name}`}
-        isPlain
-        position={DropdownPosition.right}
         isOpen={isDropdownOpen}
-        toggle={<KebabToggle onToggle={handleDropdownToggle} />}
-        dropdownItems={[
+        onOpenChange={setIsDropdownOpen}
+        toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+          <MenuToggle variant='plain' ref={toggleRef} onClick={handleDropdownToggle}>
+            <EllipsisVIcon />
+          </MenuToggle>
+        )}
+      >
+        <DropdownList>
           <DropdownItem key={`operation-action-copy-method-name-${name}`} onClick={copyMethodName}>
             Copy method name
-          </DropdownItem>,
+          </DropdownItem>
           <DropdownItem key={`operation-action-copy-jolokia-url-${name}`} onClick={copyJolokiaURL}>
             Copy Jolokia URL
-          </DropdownItem>,
-        ]}
-      />
+          </DropdownItem>
+        </DropdownList>
+      </Dropdown>
     </DataListAction>
   )
 }

--- a/packages/hawtio/src/plugins/springboot/Loggers.tsx
+++ b/packages/hawtio/src/plugins/springboot/Loggers.tsx
@@ -15,8 +15,12 @@ import {
   ToolbarGroup,
   ToolbarItem,
   EmptyStateHeader,
+  DropdownItem,
+  Dropdown,
+  MenuToggleElement,
+  MenuToggle,
+  DropdownList,
 } from '@patternfly/react-core'
-import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core/deprecated'
 import { springbootService } from './springboot-service'
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table'
 import { SearchIcon } from '@patternfly/react-icons'
@@ -44,20 +48,22 @@ const SetLogDropdown: React.FunctionComponent<{
 
   return (
     <Dropdown
-      isPlain
       onSelect={() => setIsDropdownOpen(null)}
+      onOpenChange={() => setIsDropdownOpen(null)}
       defaultValue={currentLevel}
-      toggle={
-        <DropdownToggle
+      toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+        <MenuToggle
+          ref={toggleRef}
           id={`toggle-basic-${loggerName}`}
-          onToggle={() => setIsDropdownOpen(prevState => (prevState === loggerName ? null : loggerName))}
+          onClick={() => setIsDropdownOpen(prevState => (prevState === loggerName ? null : loggerName))}
         >
           <LogLevel level={currentLevel} />
-        </DropdownToggle>
-      }
+        </MenuToggle>
+      )}
       isOpen={isDropdownOpen === loggerName}
-      dropdownItems={items}
-    />
+    >
+      <DropdownList>{items}</DropdownList>
+    </Dropdown>
   )
 }
 const LogLevel: React.FunctionComponent<{ level: string }> = ({ level }) => {
@@ -166,19 +172,22 @@ export const Loggers: React.FunctionComponent = () => {
           <Dropdown
             data-testid='attribute-select'
             onSelect={() => setIsLogLevelDropdownOpen(false)}
+            onOpenChange={setIsLogLevelDropdownOpen}
             defaultValue='INFO'
-            toggle={
-              <DropdownToggle
+            toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+              <MenuToggle
+                ref={toggleRef}
                 data-testid='attribute-select-toggle'
                 id='toggle-basic'
-                onToggle={(_event, val) => setIsLogLevelDropdownOpen(val)}
+                onClick={() => setIsLogLevelDropdownOpen(!isLogLevelDropdownOpen)}
               >
                 <LogLevel level={logLevel} />
-              </DropdownToggle>
-            }
+              </MenuToggle>
+            )}
             isOpen={isLogLevelDropdownOpen}
-            dropdownItems={dropdownItems}
-          />
+          >
+            <DropdownList>{dropdownItems}</DropdownList>
+          </Dropdown>
           <ToolbarFilter
             chips={filters}
             deleteChip={(_e, filter) => onDeleteFilter(filter as string)}

--- a/packages/hawtio/src/plugins/springboot/TraceView.tsx
+++ b/packages/hawtio/src/plugins/springboot/TraceView.tsx
@@ -21,8 +21,12 @@ import {
   ToolbarItem,
   EmptyStateHeader,
   Icon,
+  Dropdown,
+  DropdownItem,
+  MenuToggle,
+  MenuToggleElement,
+  DropdownList,
 } from '@patternfly/react-core'
-import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core/deprecated'
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table'
 import { CheckCircleIcon, ExclamationCircleIcon, SearchIcon } from '@patternfly/react-icons'
 import { Trace } from './types'
@@ -201,36 +205,42 @@ export const TraceView: React.FunctionComponent = () => {
             data-testid='http-method-select'
             id='http-dropdown'
             onSelect={() => setIsHttpMethodFilterDropdownOpen(false)}
-            toggle={
-              <DropdownToggle
+            onOpenChange={setIsHttpMethodFilterDropdownOpen}
+            toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+              <MenuToggle
+                ref={toggleRef}
                 data-testid='http-method-select-toggle'
                 id='http-method-toggle'
-                onToggle={(_event, val) => setIsHttpMethodFilterDropdownOpen(val)}
+                onClick={() => setIsHttpMethodFilterDropdownOpen(!isHttpMethodFilterDropdownOpen)}
               >
                 <HttpMethodLabel method={httpMethodFilter} />
-              </DropdownToggle>
-            }
+              </MenuToggle>
+            )}
             isOpen={isHttpMethodFilterDropdownOpen}
-            dropdownItems={httpMethodsDropdownItems}
-          />
+          >
+            <DropdownList>{httpMethodsDropdownItems}</DropdownList>
+          </Dropdown>
         </ToolbarItem>
         <ToolbarGroup>
           <Dropdown
             data-testid='attribute-select'
             onSelect={() => setIsFilterDropdownOpen(false)}
+            onOpenChange={setIsFilterDropdownOpen}
             defaultValue='HTTP Method'
-            toggle={
-              <DropdownToggle
+            toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+              <MenuToggle
+                ref={toggleRef}
                 data-testid='attribute-select-toggle'
                 id='toggle-basic'
-                onToggle={(_event, val) => setIsFilterDropdownOpen(val)}
+                onClick={() => setIsFilterDropdownOpen(!isFilterDropdownOpen)}
               >
                 {tableColumns.find(att => att.value === currentTraceFilter)?.value}
-              </DropdownToggle>
-            }
+              </MenuToggle>
+            )}
             isOpen={isFilterDropdownOpen}
-            dropdownItems={dropdownItems}
-          />
+          >
+            <DropdownList>{dropdownItems}</DropdownList>
+          </Dropdown>
           <ToolbarFilter
             chips={filters}
             deleteChip={(_e, filter) => onDeleteFilter(filter as string)}

--- a/packages/hawtio/src/preferences/LogsPreferences.tsx
+++ b/packages/hawtio/src/preferences/LogsPreferences.tsx
@@ -8,15 +8,19 @@ import {
   DataListItem,
   DataListItemCells,
   DataListItemRow,
+  Dropdown,
+  DropdownItem,
+  DropdownList,
   Form,
   FormGroup,
   FormSection,
+  MenuToggle,
+  MenuToggleElement,
   Slider,
   Toolbar,
   ToolbarContent,
   ToolbarItem,
 } from '@patternfly/react-core'
-import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core/deprecated'
 import { PlusIcon, TrashIcon } from '@patternfly/react-icons'
 import React, { useContext, useState } from 'react'
 import { LogsContext, useChildLoggers } from './context'
@@ -102,18 +106,21 @@ const ChildLoggerToolbar: React.FunctionComponent = () => {
         <ToolbarItem>
           <Dropdown
             onSelect={handleAddToggle}
-            toggle={
-              <DropdownToggle
+            onOpenChange={setIsAddOpen}
+            toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+              <MenuToggle
+                ref={toggleRef}
                 id='logs-child-logger-toolbar-dropdown-toggle'
-                toggleVariant='secondary'
-                onToggle={handleAddToggle}
+                variant='secondary'
+                onClick={handleAddToggle}
               >
                 <PlusIcon /> Add
-              </DropdownToggle>
-            }
+              </MenuToggle>
+            )}
             isOpen={isAddOpen}
-            dropdownItems={availableChildLoggerItems}
-          />
+          >
+            <DropdownList>{availableChildLoggerItems}</DropdownList>
+          </Dropdown>
         </ToolbarItem>
       </ToolbarContent>
     </Toolbar>

--- a/packages/hawtio/src/ui/page/HawtioHeader.tsx
+++ b/packages/hawtio/src/ui/page/HawtioHeader.tsx
@@ -6,11 +6,16 @@ import { HawtioAbout } from '@hawtiosrc/ui/about'
 import {
   Avatar,
   Brand,
+  Dropdown,
+  DropdownItem,
+  DropdownList,
   Masthead,
   MastheadBrand,
   MastheadContent,
   MastheadMain,
   MastheadToggle,
+  MenuToggle,
+  MenuToggleElement,
   PageToggleButton,
   Title,
   Toolbar,
@@ -18,7 +23,7 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core'
-import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core/deprecated'
+
 import { BarsIcon, HelpIcon } from '@patternfly/react-icons'
 import React, { useContext, useState } from 'react'
 import { Link, useLocation } from 'react-router-dom'
@@ -93,14 +98,18 @@ const HawtioHeaderToolbar: React.FunctionComponent = () => {
   const logout = () => userService.logout()
 
   const helpItems = [
-    <DropdownItem key='help' component={<Link to='/help'>Help</Link>} />,
+    <DropdownItem key='help'>
+      <Link to='/help'>Help</Link>{' '}
+    </DropdownItem>,
     <DropdownItem key='about' onClick={onAboutToggle}>
       About
     </DropdownItem>,
   ]
 
   const userItems = [
-    <DropdownItem key='preferences' component={<Link to='/preferences'>Preferences</Link>} />,
+    <DropdownItem key='preferences'>
+      <Link to='/preferences'>Preferences</Link>
+    </DropdownItem>,
     <DropdownItem key='logout' onClick={logout}>
       Log out
     </DropdownItem>,
@@ -159,37 +168,45 @@ const HawtioHeaderToolbar: React.FunctionComponent = () => {
         <ToolbarGroup>
           <ToolbarItem>
             <Dropdown
-              isPlain
-              position='right'
               onSelect={onHelpSelect}
-              toggle={
-                <DropdownToggle toggleIndicator={null} onToggle={(_event, val) => setHelpOpen(val)}>
+              onOpenChange={setHelpOpen}
+              toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                <MenuToggle
+                  variant='plain'
+                  ref={toggleRef}
+                  onClick={() => setHelpOpen(!helpOpen)}
+                  isExpanded={helpOpen}
+                >
                   <HelpIcon />
-                </DropdownToggle>
-              }
+                </MenuToggle>
+              )}
               isOpen={helpOpen}
-              dropdownItems={helpItems}
-            />
+            >
+              {helpItems}
+            </Dropdown>
           </ToolbarItem>
         </ToolbarGroup>
         <ToolbarGroup>
           <ToolbarItem>
             <Dropdown
-              isPlain
-              position='right'
               onSelect={onUserSelect}
               isOpen={userOpen}
-              toggle={
-                <DropdownToggle
+              onOpenChange={setUserOpen}
+              toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                <MenuToggle
+                  ref={toggleRef}
                   id='hawtio-header-user-dropdown-toggle'
-                  onToggle={(_event, val) => setUserOpen(val)}
+                  onClick={() => setUserOpen(!userOpen)}
                   icon={<Avatar src={userAvatar} alt='user' />}
+                  isExpanded={userOpen}
+                  isFullHeight
                 >
                   {isPublic ? '' : username}
-                </DropdownToggle>
-              }
-              dropdownItems={userItems}
-            />
+                </MenuToggle>
+              )}
+            >
+              <DropdownList>{userItems}</DropdownList>
+            </Dropdown>
           </ToolbarItem>
         </ToolbarGroup>
       </ToolbarContent>


### PR DESCRIPTION
This PR gets rid of deprecated Dropdown components from the PF4 which is now at `'@patternfly/react-core/deprecated'` with the recent ones. 
`branch: jsolovjo:e2e-tests-fix-pf5-dropdowns`
