### PR TITLE
feat(shared,jmx): support serialising long to string in JSON response from Jolokia

### DIFF
--- a/packages/hawtio/package.json
+++ b/packages/hawtio/package.json
@@ -54,7 +54,7 @@
     "@types/react-router-dom": "^5.3.3",
     "dagre": "^0.8.5",
     "eventemitter3": "^5.0.1",
-    "jolokia.js": "^2.0.1",
+    "jolokia.js": "^2.0.3",
     "jquery": "^3.7.1",
     "js-logger": "^1.6.1",
     "jwt-decode": "^4.0.0",

--- a/packages/hawtio/src/plugins/jmx/JmxPreferences.tsx
+++ b/packages/hawtio/src/plugins/jmx/JmxPreferences.tsx
@@ -1,0 +1,31 @@
+import { JmxOptions, jmxPreferencesService } from '@hawtiosrc/plugins/shared/jmx-preferences-service'
+import { TooltipHelpIcon } from '@hawtiosrc/ui/icons'
+import { CardBody, Checkbox, Form, FormGroup } from '@patternfly/react-core'
+import React, { useState } from 'react'
+
+export const JmxPreferences: React.FunctionComponent = () => {
+  const [options, setOptions] = useState(jmxPreferencesService.loadOptions())
+
+  const updateOptions = (updated: Partial<JmxOptions>) => {
+    jmxPreferencesService.saveOptions(updated)
+    setOptions({ ...options, ...updated })
+  }
+
+  return (
+    <CardBody>
+      <Form isHorizontal>
+        <FormGroup
+          label='Serialize long to string'
+          fieldId='serialize-long-to-string'
+          labelIcon={<TooltipHelpIcon tooltip='Serialize long values in the JSON responses from Jolokia to string' />}
+        >
+          <Checkbox
+            id='serialize-long-to-string-input'
+            isChecked={options.serializeLong}
+            onChange={(_event, serializeLong) => updateOptions({ serializeLong })}
+          />
+        </FormGroup>
+      </Form>
+    </CardBody>
+  )
+}

--- a/packages/hawtio/src/plugins/jmx/index.ts
+++ b/packages/hawtio/src/plugins/jmx/index.ts
@@ -1,9 +1,11 @@
 import { hawtio, HawtioPlugin } from '@hawtiosrc/core'
 import { helpRegistry } from '@hawtiosrc/help/registry'
 import { workspace } from '@hawtiosrc/plugins/shared'
+import { preferencesRegistry } from '@hawtiosrc/preferences'
 import { pluginPath } from './globals'
 import help from './help.md'
 import { Jmx } from './Jmx'
+import { JmxPreferences } from './JmxPreferences'
 
 const order = 13
 
@@ -17,4 +19,5 @@ export const jmx: HawtioPlugin = () => {
     isActive: async () => workspace.hasMBeans(),
   })
   helpRegistry.add('jmx', 'JMX', help, order)
+  preferencesRegistry.add('jmx', 'JMX', JmxPreferences, order)
 }

--- a/packages/hawtio/src/plugins/logs/logs-service.ts
+++ b/packages/hawtio/src/plugins/logs/logs-service.ts
@@ -48,7 +48,7 @@ export interface ILogsService {
   filter(logs: LogEntry[], filter: LogFilter): LogEntry[]
 
   loadOptions(): LogsOptions
-  saveOptions(value: Partial<LogsOptions>): void
+  saveOptions(options: Partial<LogsOptions>): void
 }
 
 class LogsService implements ILogsService {

--- a/packages/hawtio/src/plugins/shared/__mocks__/jolokia-service.ts
+++ b/packages/hawtio/src/plugins/shared/__mocks__/jolokia-service.ts
@@ -1,7 +1,7 @@
 import Jolokia, { ListRequestOptions, Request, Response } from 'jolokia.js'
 import { AttributeValues, IJolokiaService, JolokiaListMethod, JolokiaStoredOptions } from '../jolokia-service'
-import jmxCamelResponse from './jmx-camel-tree.json'
 import { OptimisedJmxDomains } from '../tree'
+import jmxCamelResponse from './jmx-camel-tree.json'
 
 class MockJolokiaService implements IJolokiaService {
   constructor() {
@@ -42,6 +42,10 @@ class MockJolokiaService implements IJolokiaService {
   }
 
   async readAttribute(mbean: string, attribute: string): Promise<unknown> {
+    return null
+  }
+
+  async writeAttribute(mbean: string, attribute: string, value: unknown): Promise<unknown> {
     return null
   }
 

--- a/packages/hawtio/src/plugins/shared/jmx-preferences-service.test.ts
+++ b/packages/hawtio/src/plugins/shared/jmx-preferences-service.test.ts
@@ -1,0 +1,16 @@
+import { DEFAULT_OPTIONS, STORAGE_KEY_PREFERENCES, jmxPreferencesService } from './jmx-preferences-service'
+
+describe('JmxPreferencesService', () => {
+  beforeEach(() => {
+    localStorage.removeItem(STORAGE_KEY_PREFERENCES)
+  })
+
+  test('loadOptions/saveOptions', () => {
+    let options = jmxPreferencesService.loadOptions()
+    expect(options).toEqual(DEFAULT_OPTIONS)
+
+    jmxPreferencesService.saveOptions({ serializeLong: true })
+    options = jmxPreferencesService.loadOptions()
+    expect(options).toEqual({ ...DEFAULT_OPTIONS, serializeLong: true })
+  })
+})

--- a/packages/hawtio/src/plugins/shared/jmx-preferences-service.ts
+++ b/packages/hawtio/src/plugins/shared/jmx-preferences-service.ts
@@ -1,0 +1,29 @@
+export const STORAGE_KEY_PREFERENCES = 'jmx.preferences'
+
+export type JmxOptions = {
+  serializeLong: boolean
+}
+
+export const DEFAULT_OPTIONS: JmxOptions = {
+  serializeLong: false,
+} as const
+
+export interface IJmxPreferencesService {
+  loadOptions(): JmxOptions
+  saveOptions(options: Partial<JmxOptions>): void
+}
+
+class JmxPreferencesService implements IJmxPreferencesService {
+  loadOptions(): JmxOptions {
+    const item = localStorage.getItem(STORAGE_KEY_PREFERENCES)
+    const savedOptions = item ? JSON.parse(item) : {}
+    return { ...DEFAULT_OPTIONS, ...savedOptions }
+  }
+
+  saveOptions(options: Partial<JmxOptions>) {
+    const updated = { ...this.loadOptions(), ...options }
+    localStorage.setItem(STORAGE_KEY_PREFERENCES, JSON.stringify(updated))
+  }
+}
+
+export const jmxPreferencesService = new JmxPreferencesService()

--- a/packages/hawtio/src/plugins/shared/operations/operation-service.ts
+++ b/packages/hawtio/src/plugins/shared/operations/operation-service.ts
@@ -1,11 +1,18 @@
 import { jolokiaService } from '@hawtiosrc/plugins/shared/jolokia-service'
 import { escapeMBean } from '@hawtiosrc/util/jolokia'
+import { ExecuteRequestOptions } from 'jolokia.js'
 import { log } from '../globals'
+import { jmxPreferencesService } from '../jmx-preferences-service'
 
 class OperationService {
+  private requestOptions(): ExecuteRequestOptions {
+    const { serializeLong } = jmxPreferencesService.loadOptions()
+    return serializeLong ? { serializeLong: 'string' } : {}
+  }
+
   async execute(mbean: string, operation: string, args: unknown[]): Promise<unknown> {
     log.debug('Execute:', mbean, '-', operation, '-', args)
-    return jolokiaService.execute(mbean, operation, args)
+    return jolokiaService.execute(mbean, operation, args, this.requestOptions())
   }
 
   async getJolokiaUrl(mbean: string, operation: string): Promise<string> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -814,7 +814,7 @@ __metadata:
     jest-environment-jsdom: "npm:^29.7.0"
     jest-fetch-mock: "npm:^3.0.3"
     jest-watch-typeahead: "npm:^2.2.2"
-    jolokia.js: "npm:^2.0.1"
+    jolokia.js: "npm:^2.0.3"
     jquery: "npm:^3.7.1"
     js-logger: "npm:^1.6.1"
     jwt-decode: "npm:^4.0.0"
@@ -8716,9 +8716,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jolokia.js@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "jolokia.js@npm:2.0.1"
+"jolokia.js@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "jolokia.js@npm:2.0.3"
   dependencies:
     jquery: "npm:^3.7.1"
   peerDependencies:
@@ -8729,7 +8729,7 @@ __metadata:
       optional: true
     jsdom:
       optional: true
-  checksum: 10/2286502549a51a0df6e6151d4d117ccdc4cd5c26965121ac58a954de64ff43437083c05aa1b1769581d7840d07c67f0f27152e77355d27e30fac4a6e13f89903
+  checksum: 10/0410a7563b5a2fb2b947309ff0fe863bd5df4ec4acf52e8184df8f92765b707a89398ad94aac138965911abf7639821ced8c4116b8a9fbf9e3f8c60fca1a9982
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* Upgrade jolokia.js to 2.0.3 (that supports `serializeLong` option)
* Create JMX preferences and provide `Serialize long to string` option, which can affect Jolokia requests within JMX plugin

![image](https://github.com/hawtio/hawtio-next/assets/156692/55d92ff7-710c-43e3-b586-dde0a4adac9d)

This fix limits the `serializeLong=string` option to JMX, because the change of the bahaviour might cause unexpected errors in other plugins. JMX is a generic MBeans manipulation plugin, so it should make sense to have such an option plugin-wide.

Each plugin should decide whether it's worth applying the option or not.

Fix #292