### PR TITLE
fix: add missing aria-labels 

### DIFF
--- a/packages/hawtio/src/plugins/camel/contexts/Contexts.tsx
+++ b/packages/hawtio/src/plugins/camel/contexts/Contexts.tsx
@@ -117,13 +117,14 @@ export const Contexts: React.FunctionComponent = () => {
         <Thead>
           <Tr>
             <Th
+              aria-label='select-header'
               select={{
                 onSelect: (_event, isSelecting) => selectAllContexts(isSelecting),
                 isSelected: contexts.length === selectedCtx.length,
               }}
             />
             <Th key='context-header'>Context</Th>
-            <Th key={'state-header'}>State</Th>
+            <Th key='state-header'>State</Th>
           </Tr>
         </Thead>
         <Tbody>

--- a/packages/hawtio/src/plugins/camel/endpoints/BrowseMessages.tsx
+++ b/packages/hawtio/src/plugins/camel/endpoints/BrowseMessages.tsx
@@ -246,6 +246,7 @@ export const BrowseMessages: React.FunctionComponent = () => {
                 <Thead>
                   <Tr>
                     <Th
+                      aria-label='select-message-header'
                       select={{
                         onSelect: (_event, isSelecting) => onSelectAll(isSelecting),
                         isSelected: isAllSelected(),

--- a/packages/hawtio/src/plugins/camel/icons/CamelImageIcon.tsx
+++ b/packages/hawtio/src/plugins/camel/icons/CamelImageIcon.tsx
@@ -2,16 +2,11 @@ type CamelImageIconProps = {
   name: string
   svg: string
   size: number
-} & typeof defaultImageIconProps
-
-const defaultImageIconProps = {
-  size: 16,
 }
 
 const CamelImageIcon = (props: CamelImageIconProps) => {
-  return <img src={props.svg} width={props.size + 'px'} height={props.size + 'px'} alt={props.name} />
+  const { name, svg, size = 16 } = props
+  return <img src={svg} width={size + 'px'} height={size + 'px'} alt={name} />
 }
-
-CamelImageIcon.defaultProps = defaultImageIconProps
 
 export { CamelImageIcon }

--- a/packages/hawtio/src/plugins/camel/routes/CamelRoutes.tsx
+++ b/packages/hawtio/src/plugins/camel/routes/CamelRoutes.tsx
@@ -173,6 +173,7 @@ export const CamelRoutes: React.FunctionComponent = () => {
         <Thead noWrap>
           <Tr>
             <Th
+              aria-label='select-route-header'
               select={{
                 onSelect: (_event, isSelecting) => onSelectAll(isSelecting),
                 isSelected: isAllSelected(),

--- a/packages/hawtio/src/plugins/runtime/Threads.tsx
+++ b/packages/hawtio/src/plugins/runtime/Threads.tsx
@@ -309,7 +309,7 @@ export const Threads: React.FunctionComponent = () => {
                         {att.value}
                       </Th>
                     ))}
-                    <Th></Th>
+                    <Th aria-label='details-head' />
                   </Tr>
                 </Thead>
                 <Tbody>


### PR DESCRIPTION
This PR adds missing aria-labels that caused warning in the console. Also remove defaultProps for the CamelIcon and replace it with JS defaults.

fix: #971