### PR TITLE
feat(camel-source): Make Source editor editable when it's enabled in the CamelContext

### DIFF
--- a/packages/hawtio/src/plugins/camel/routes/routes-service.ts
+++ b/packages/hawtio/src/plugins/camel/routes/routes-service.ts
@@ -7,6 +7,8 @@ export const ROUTE_OPERATIONS = {
   start: 'start()',
   stop: 'stop()',
   remove: 'remove()',
+  isUpdateEnabled: 'isUpdateRouteEnabled()',
+  updateRoute: 'updateRouteFromXml',
 } as const
 
 interface IRoutesService {
@@ -89,11 +91,25 @@ class RoutesService implements IRoutesService {
     return node.hasInvokeRights(ROUTE_OPERATIONS.remove)
   }
 
+  async isRouteUpdateEnabled(node: MBeanNode): Promise<boolean> {
+    const { objectName } = node
+    if (!objectName) return false
+
+    return (await jolokiaService.execute(objectName, ROUTE_OPERATIONS.isUpdateEnabled)) as boolean
+  }
+
   async deleteRoute(node: MBeanNode) {
     const { objectName } = node
     if (!objectName) return
 
     await jolokiaService.execute(objectName, ROUTE_OPERATIONS.remove)
+  }
+
+  saveRoute(node: MBeanNode, code: string) {
+    const { objectName } = node
+    if (!objectName) return
+
+    jolokiaService.execute(objectName, ROUTE_OPERATIONS.updateRoute, [code])
   }
 }
 


### PR DESCRIPTION
When updating the routes is enabled then the editor in the Source tab under particular route becomes writable additional control/check is shown: 
<img width="943" alt="Screenshot 2024-06-24 at 15 54 45" src="https://github.com/hawtio/hawtio-next/assets/6814482/bcb99e9f-1783-4a44-ab61-52436accb019">
When the code is changed:
<img width="1269" alt="Screenshot 2024-06-24 at 15 54 26" src="https://github.com/hawtio/hawtio-next/assets/6814482/8cd03c0a-3711-4b49-a390-93a4a85733ef">
When it's saved the notification is fired and control button is changed back: 
<img width="940" alt="Screenshot 2024-06-24 at 15 54 33" src="https://github.com/hawtio/hawtio-next/assets/6814482/3e00687a-5a9c-4c7e-a8cf-b83b8c42dabf">

