### PR TITLE
Small UI fixes

### DIFF
--- a/app/src/examples/example3/Example3HeaderItems.tsx
+++ b/app/src/examples/example3/Example3HeaderItems.tsx
@@ -61,7 +61,6 @@ export const Example3HeaderItem2: React.FunctionComponent = () => {
         </MenuToggle>
       )}
       isOpen={isOpen}
-      isPlain
     >
       <DropdownItem key='link'>Link</DropdownItem>
       <DropdownItem key='action' component='button'>

--- a/packages/hawtio/src/plugins/connect/remote/Remote.tsx
+++ b/packages/hawtio/src/plugins/connect/remote/Remote.tsx
@@ -84,7 +84,9 @@ const RemoteToolbar: React.FunctionComponent = () => {
             isOpen={isDropdownOpen}
             onOpenChange={setIsDropdownOpen}
             toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-              <MenuToggle ref={toggleRef} onClick={() => setIsDropdownOpen(!isDropdownOpen)}></MenuToggle>
+              <MenuToggle ref={toggleRef} variant='plain' onClick={() => setIsDropdownOpen(!isDropdownOpen)}>
+                <EllipsisVIcon aria-hidden='true' />
+              </MenuToggle>
             )}
           >
             <DropdownList>

--- a/packages/hawtio/src/ui/page/HawtioHeader.tsx
+++ b/packages/hawtio/src/ui/page/HawtioHeader.tsx
@@ -156,7 +156,7 @@ const HawtioHeaderToolbar: React.FunctionComponent = () => {
   const headerComponents: React.ComponentType<any>[] = collectHeaderItems()
 
   return (
-    <Toolbar id='hawtio-header-toolbar'>
+    <Toolbar id='hawtio-header-toolbar' isFullHeight>
       <ToolbarContent>
         <ToolbarGroup>
           {headerComponents.map((component, index) => (


### PR DESCRIPTION
Switched dropdown in the Remote.tsx to the kebab style: 
<img width="1198" alt="Screenshot 2024-07-08 at 10 03 49" src="https://github.com/hawtio/hawtio-next/assets/6814482/02001db3-38fe-4e5c-ba96-bcd0f6fa5054">

Make Page header full height: 
<img width="1501" alt="Screenshot 2024-07-08 at 10 22 40" src="https://github.com/hawtio/hawtio-next/assets/6814482/9d62e897-f21f-46ef-bc67-751df5629558">

Make Dropdown in the example3 to have shadow and border:
<img width="412" alt="Screenshot 2024-07-08 at 10 23 29" src="https://github.com/hawtio/hawtio-next/assets/6814482/20c11e24-4dba-43ba-9ea1-bdcb1b7447bd">
