### PR TITLE
fix(CPU load): Fix CPU load showing 0% in Runtime -> Metrics -> System

### DIFF
--- a/packages/hawtio/src/plugins/runtime/runtime-service.ts
+++ b/packages/hawtio/src/plugins/runtime/runtime-service.ts
@@ -105,7 +105,8 @@ class RuntimeService {
       }
       case 'java.lang:type=OperatingSystem': {
         const osMetrics = response.value as {
-          SystemCpuLoad: number
+          CpuLoad?: number
+          SystemCpuLoad?: number
           SystemLoadAverage: number
           FreePhysicalMemorySize: number
           TotalPhysicalMemorySize: number
@@ -113,7 +114,7 @@ class RuntimeService {
           OpenFileDescriptorCount: number
           MaxFileDescriptorCount: number
         }
-        const cpuLoad = osMetrics.SystemCpuLoad * 100
+        const cpuLoad = (osMetrics.CpuLoad ?? osMetrics.SystemCpuLoad ?? 0) * 100
         const loadAverage = osMetrics.SystemLoadAverage
         const memFree = this.formatBytes(osMetrics.FreePhysicalMemorySize)
         const memTotal = this.formatBytes(osMetrics.TotalPhysicalMemorySize)


### PR DESCRIPTION
The problem I am seeing in a downstream project is while viewing the Runtime->Metrics tab, CPU load almost always shows 0.00%. What I think is going on after some digging is that Jolokia is returning 0 for SystemCpuLoad due to this problem here: https://medium.com/infobipdev/the-java-cpu-usage-observer-effect-18808b18323f
> The hidden cause of this discrepancy is the rename of the metric in JDK 14 from SystemCpuLoad to CpuLoad. The old metric was not removed, only deprecated in the API. JmxCollector pulls and publishes all available metrics, effectively calculating the same CPU usage twice in a row. The value was corrupted by merely measuring it — twice.

In the back end, [`getSystemCpuLoad()` actually just calls `getCpuLoad()`](https://github.com/openjdk/jdk/blob/5e021cbcc7a6cb30a27380950e115ff12846239c/src/jdk.management/share/classes/com/sun/management/OperatingSystemMXBean.java#L153C27-L153C43), resulting in two nearly subsequent calls to that getCpuLoad method when the whole OperatingSystem mbean is called, which the medium article warns about. 

From looking at the actual jolokia response object, `CpuLoad` in actually does have a real value, so this proposed change would just use that instead if available.

Made both fields conditional in the ts class in order to:

1. Support servers running <JDK14, before `CpuLoad` was added
2. Protect against SystemCpuLoad possibly getting removed in a future version of Java