### PR TITLE
fix: add warning for copying not working in insecure contexts

### DIFF
--- a/packages/hawtio/src/core/event-service.ts
+++ b/packages/hawtio/src/core/event-service.ts
@@ -1,5 +1,6 @@
 import EventEmitter from 'eventemitter3'
 import { Logger } from './logging'
+import React from 'react'
 
 const log = Logger.get('hawtio-core-event')
 
@@ -7,7 +8,7 @@ export type NotificationType = 'info' | 'success' | 'warning' | 'danger' | 'cust
 
 export type Notification = {
   type: NotificationType
-  message: string
+  message: React.ReactNode
   duration?: number
 }
 

--- a/packages/hawtio/src/ui/notification/HawtioNotification.tsx
+++ b/packages/hawtio/src/ui/notification/HawtioNotification.tsx
@@ -14,7 +14,7 @@ export const HawtioNotification: React.FunctionComponent = () => {
     return overflow > 0 ? `View ${overflow} more alerts` : ''
   }
 
-  const addAlert = (title: string, variant: NotificationType, key: React.Key) => {
+  const addAlert = (title: React.ReactNode, variant: NotificationType, key: React.Key) => {
     const newAlerts = [...alerts, { title, variant, key }]
     setAlerts(newAlerts)
     setOverflowMessage(getOverflowMessage(newAlerts.length))


### PR DESCRIPTION
Warning is displayed both in the dropdown and an alert gets displayed for the user to copy the text manually. 
[Peek 2024-08-29 10-16.webm](https://github.com/user-attachments/assets/dff3c4d0-23fc-4e50-ad84-c944456667e1)

Also, I tweaked the event service to be able to render any ReactNode, not just strings, but as string is also a ReactNode it just extended the uses. 

Closes #628 