### PR TITLE
fix: Disable help for disabled plugins

### DIFF
--- a/packages/hawtio/src/help/HawtioHelp.tsx
+++ b/packages/hawtio/src/help/HawtioHelp.tsx
@@ -11,16 +11,30 @@ import {
   TextContent,
   Title,
 } from '@patternfly/react-core'
-import React from 'react'
+import React, { useMemo } from 'react'
 import Markdown from 'react-markdown'
 import { NavLink, Navigate, Route, Routes, useLocation } from 'react-router-dom'
 import help from './help.md'
 import { helpRegistry } from './registry'
+import { hawtio, usePlugins } from '@hawtiosrc/core'
 
 helpRegistry.add('home', 'Home', help, 1)
 
 export const HawtioHelp: React.FunctionComponent = () => {
   const location = useLocation()
+  const { plugins } = usePlugins()
+
+  const helps = useMemo(() => {
+    const pluginIds = hawtio.getPlugins().map(p => p.id)
+    const activePlugins = plugins.map(p => p.id)
+    return helpRegistry.getHelps().filter(help => {
+      if (pluginIds.includes(help.id)) {
+        return activePlugins.includes(help.id)
+      }
+      return true
+    })
+  }, [plugins])
+
   return (
     <React.Fragment>
       <PageSection variant={PageSectionVariants.light}>
@@ -30,7 +44,7 @@ export const HawtioHelp: React.FunctionComponent = () => {
         <PageNavigation>
           <Nav aria-label='Nav' variant='tertiary'>
             <NavList>
-              {helpRegistry.getHelps().map(help => (
+              {helps.map(help => (
                 <NavItem key={help.id} isActive={location.pathname === `/help/${help.id}`}>
                   <NavLink to={help.id}>{help.title}</NavLink>
                 </NavItem>


### PR DESCRIPTION
Dev build connected to quarkus looks like this:
![image](https://github.com/user-attachments/assets/6a94f4ad-5dca-415a-b13f-211c92dc5733)
with `"disabledRoutes": ["/disabled", "/camel", "/quartz"]`:
![image](https://github.com/user-attachments/assets/4d9eca32-72af-48f0-a388-0b6dd38fcc90)
