### PR TITLE
fix(HAWNG-753): tweak size of the Route Diagram to fill the screen

### DIFF
--- a/packages/hawtio/src/plugins/camel/route-diagram/RouteDiagram.css
+++ b/packages/hawtio/src/plugins/camel/route-diagram/RouteDiagram.css
@@ -66,9 +66,10 @@
 .camel-route-diagram {
   flex-grow: 1;
   position: relative;
-  height: 60vh;
+  /* 230px representss size of hawtio bar, panel header,tab  navigation,and footer  */
+  height: calc(100vh - 230px);
   min-height: 50vh;
-  max-height: 75vh;
+  max-height: calc(100vh - 230px);
   width: 100%;
 }
 

--- a/packages/hawtio/src/plugins/camel/trace/Tracing.css
+++ b/packages/hawtio/src/plugins/camel/trace/Tracing.css
@@ -23,6 +23,14 @@
   flex: 1;
 }
 
+#route-diagram-tracing-view .camel-route-diagram {
+  /* 330px is approximately size of hawtio bar, header, navigation, paddings and footer  */
+  height: calc(100vh - 330px);
+  min-height: 50vh;
+  max-height: calc(100vh - 330px);
+  width: 100%;
+}
+
 #trace-header-container {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
<img width="957" alt="Screenshot 2024-09-04 at 14 33 16" src="https://github.com/user-attachments/assets/134c7522-407f-4c6c-a528-a1b31f7e5a13">
<img width="1426" alt="Screenshot 2024-09-04 at 14 25 43" src="https://github.com/user-attachments/assets/92fa2f5e-45b0-486c-9ff3-28c92769c639">

Red border is NOT a part of this PR :) 