### PR TITLE
fix: Adds better error handling of workspace loading errors

### DIFF
--- a/packages/hawtio/src/core/core.ts
+++ b/packages/hawtio/src/core/core.ts
@@ -169,7 +169,7 @@ class HawtioCore {
   }
 
   /**
-   * Adds an angular module to the list of modules to bootstrap.
+   * Adds a module to the list of modules to bootstrap.
    */
   addPlugin(plugin: Plugin): HawtioCore {
     log.info('Add plugin:', plugin.id)

--- a/packages/hawtio/src/plugins/console-status/ConsoleStatus.css
+++ b/packages/hawtio/src/plugins/console-status/ConsoleStatus.css
@@ -1,0 +1,3 @@
+.console-alert {
+  margin-top: 1em;
+}

--- a/packages/hawtio/src/plugins/console-status/ConsoleStatus.tsx
+++ b/packages/hawtio/src/plugins/console-status/ConsoleStatus.tsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useRef, useState } from 'react'
+import {
+  Alert,
+  Card,
+  CardBody,
+  PageSection,
+  PageSectionVariants,
+  Panel,
+  PanelHeader,
+  PanelMain,
+  PanelMainBody,
+} from '@patternfly/react-core'
+import { HawtioLoadingCard, workspace } from '@hawtiosrc/plugins/shared'
+import './ConsoleStatus.css'
+
+export const ConsoleStatus: React.FunctionComponent = () => {
+  const timerRef = useRef<NodeJS.Timeout | null>(null)
+  const [errors, setErrors] = useState<Error[]>([])
+  const [loading, setLoading] = useState<boolean>(true)
+
+  useEffect(() => {
+    const waitLoading = async () => {
+      const hasErrors = await workspace.hasErrors()
+
+      if (hasErrors) {
+        const errors = [...(await workspace.getErrors())]
+        errors.reverse() // reverse so as to show latest first
+        setErrors(errors)
+      }
+
+      setLoading(false)
+    }
+
+    timerRef.current = setTimeout(waitLoading, 1000)
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    }
+  }, [])
+
+  if (loading) {
+    return (
+      <PageSection variant={PageSectionVariants.light}>
+        <Panel>
+          <PanelHeader>Waiting workspace to load ...</PanelHeader>
+          <PanelMain>
+            <PanelMainBody>
+              <HawtioLoadingCard />
+            </PanelMainBody>
+          </PanelMain>
+        </Panel>
+      </PageSection>
+    )
+  }
+
+  const hasCause = (error: Error) => {
+    if (!error || !error.cause) return false
+    return error.cause instanceof Error
+  }
+
+  return (
+    <PageSection variant={PageSectionVariants.light}>
+      <Card>
+        <CardBody>
+          <Alert variant='warning' title='Application returned no mbeans' />
+
+          {errors.map(error => (
+            <Alert variant='danger' title={error.message} className='console-alert'>
+              {hasCause(error) && <p>Cause: {(error.cause as Error).message}</p>}
+            </Alert>
+          ))}
+        </CardBody>
+      </Card>
+    </PageSection>
+  )
+}

--- a/packages/hawtio/src/plugins/console-status/globals.ts
+++ b/packages/hawtio/src/plugins/console-status/globals.ts
@@ -1,0 +1,6 @@
+import { Logger } from '@hawtiosrc/core/logging'
+
+export const pluginId = 'consolestatus'
+export const pluginName = 'Console Status'
+export const pluginPath = '/consolestatus'
+export const log = Logger.get(pluginName)

--- a/packages/hawtio/src/plugins/console-status/index.ts
+++ b/packages/hawtio/src/plugins/console-status/index.ts
@@ -1,0 +1,28 @@
+import { HawtioPlugin, hawtio } from '@hawtiosrc/core'
+import { connectService, workspace } from '@hawtiosrc/plugins/shared'
+import { ConsoleStatus } from './ConsoleStatus'
+import { pluginId, pluginPath, pluginName } from './globals'
+
+/*
+ * Target application status plugin
+ * only active if the workspace contains no mbeans, ie, totally empty.
+ * and / or the workspace has produced errors.
+ * Will communicate this to the user with a notice component.
+ */
+export const consoleStatus: HawtioPlugin = () => {
+  hawtio.addPlugin({
+    id: pluginId,
+    title: pluginName,
+    path: pluginPath,
+    component: ConsoleStatus,
+    isActive: async () => {
+      const connection = await connectService.getCurrentConnection()
+      const beans = await workspace.hasMBeans()
+      const errors = await workspace.hasErrors()
+
+      if (!connection) return false // no connection yet so no beans in workspace
+
+      return !beans || errors // either no beans or workspace has errors
+    },
+  })
+}

--- a/packages/hawtio/src/plugins/index.ts
+++ b/packages/hawtio/src/plugins/index.ts
@@ -9,6 +9,7 @@ import { quartz } from './quartz'
 import { rbac } from './rbac'
 import { runtime } from './runtime'
 import { springboot } from './springboot'
+import { consoleStatus } from './console-status'
 
 /**
  * Registers the builtin plugins for Hawtio React.
@@ -28,10 +29,11 @@ export const registerPlugins: HawtioPlugin = () => {
   logs()
   quartz()
   springboot()
+  consoleStatus()
 }
 
 // Export each plugin's entry point so that a custom console assembler can select which to bundle
-export { camel, connect, jmx, keycloak, oidc, logs, quartz, rbac, runtime, springboot }
+export { camel, connect, jmx, keycloak, oidc, logs, quartz, rbac, runtime, springboot, consoleStatus }
 
 // Common plugin API
 export * from './connect'


### PR DESCRIPTION
* Adds a status plugin for displaying errors messages if the workspace failed to load. Such errors can get lost in the console log and a blank page is the result in the client.

* workspace.ts
  * If an error occurs then add them to a collection in the workspace
  * Provides an api for quizzing the workspace on whether it has errored

* app-status
  * Plugin that is only active if
    * there is a current connection (no point in displaying if nothing has been connected to yet)
    * there are no mbeans collected from the jolokia connection
    * Errors were flagged from the workspace
  * Assuming the plugin is active, offer a component that provides notification of the workspace *