### PR TITLE
fix(RouteDiagram): Show total exchanges instead of completed

### DIFF
--- a/packages/hawtio/src/plugins/camel/route-diagram/RouteDiagram.tsx
+++ b/packages/hawtio/src/plugins/camel/route-diagram/RouteDiagram.tsx
@@ -201,7 +201,7 @@ const CamelNode: React.FunctionComponent<NodeProps<CamelNodeData>> = ({
                     <Td>{data.stats?.meanProcessingTime} (ms)</Td>
                   </Tr>
                   <Tr>
-                    <Td>Mix</Td>
+                    <Td>Min</Td>
                     <Td>{data.stats?.minProcessingTime} (ms)</Td>
                   </Tr>
                   <Tr>

--- a/packages/hawtio/src/plugins/camel/route-diagram/RouteDiagram.tsx
+++ b/packages/hawtio/src/plugins/camel/route-diagram/RouteDiagram.tsx
@@ -147,6 +147,9 @@ const CamelNode: React.FunctionComponent<NodeProps<CamelNodeData>> = ({
     return newLabel.substring(0, 17) + '...'
   }
 
+  const totalExchanges: number =
+    parseInt(data.stats?.exchangesCompleted ?? '0') + parseInt(data.stats?.exchangesInflight ?? '0')
+
   return (
     <div
       className={'camel-node-content' + (selected ? ' highlighted' : '')}
@@ -163,7 +166,7 @@ const CamelNode: React.FunctionComponent<NodeProps<CamelNodeData>> = ({
       <div className='annotation'>{annotation?.element}</div>
       <div className='icon'>{data.imageUrl}</div>
       <div className='inflights'>{showInflightCounter && data.stats?.exchangesInflight}</div>
-      <div className='number'>{data.stats?.exchangesCompleted}</div>
+      <div className='number'>{totalExchanges}</div>
       <div className='camel-node-label'>{truncate(data.label)}</div>
       {data.cid && <div className='camel-node-id'> (ID: {data.cid})</div>}
       {showStatistics && (
@@ -176,6 +179,10 @@ const CamelNode: React.FunctionComponent<NodeProps<CamelNodeData>> = ({
                   <Tr>
                     <Td>ID</Td>
                     <Td>{data.stats.id}</Td>
+                  </Tr>
+                  <Tr>
+                    <Td>Total</Td>
+                    <Td>{totalExchanges}</Td>
                   </Tr>
                   <Tr>
                     <Td>Completed</Td>

--- a/packages/hawtio/src/plugins/camel/routes-service.ts
+++ b/packages/hawtio/src/plugins/camel/routes-service.ts
@@ -49,6 +49,7 @@ export type RouteStats = Statistics & {
 
 export const ROUTE_OPERATIONS = {
   dumpRoutesAsXml: 'dumpRoutesAsXml()',
+  dumpRoutesStatsAsXml: 'dumpRoutesStatsAsXml',
 } as const
 
 // TODO: This service should be named more properly like RoutesXmlService, RouteStatisticsService, etc.
@@ -212,15 +213,11 @@ class RoutesService {
 
   async dumpRoutesStatsXML(routesNode: MBeanNode): Promise<string | null> {
     let xml = null
-    const routeNodeOperation = 'dumpRouteStatsAsXml'
-    const routesFolderOperation = 'dumpRoutesStatsAsXml'
-
     const mbeanName = routesNode.getMetadata(contextNodeType)
-    const operationForMBean = mbeanName ? routesFolderOperation : routeNodeOperation
-    const mbeanToQuery = mbeanName ? mbeanName : (routesNode.objectName ?? '')
+    const mbeanToQuery = mbeanName ? mbeanName : (routesNode.parent?.getMetadata(contextNodeType) ?? '')
 
     try {
-      xml = await jolokiaService.execute(mbeanToQuery, operationForMBean, [true, true])
+      xml = await jolokiaService.execute(mbeanToQuery, ROUTE_OPERATIONS.dumpRoutesStatsAsXml, [true, true])
     } catch (error) {
       throw new Error('Failed to dump routes stats from mbean ' + mbeanName + ': ' + error)
     }


### PR DESCRIPTION
closes: #535

Now the routeDiagram shows correct number of messages while routes being debugged: 
<img width="1304" alt="Screenshot 2024-10-22 at 17 14 19" src="https://github.com/user-attachments/assets/faf8a6c4-e8ba-44b7-a028-08179c967757">

Also the route diagram for the single route now displays the inflight count: 
<img width="1591" alt="Screenshot 2024-10-22 at 18 23 48" src="https://github.com/user-attachments/assets/0f56277a-eaa1-493c-91a2-7d6420551e34">
