### PR TITLE
[1.6.x]: refactor(Help): refactor Help page style to reflect the rest of the UI

### DIFF
--- a/packages/hawtio/src/help/HawtioHelp.tsx
+++ b/packages/hawtio/src/help/HawtioHelp.tsx
@@ -1,11 +1,9 @@
 import {
-  Card,
   CardBody,
+  Divider,
   Nav,
   NavItem,
   NavList,
-  PageGroup,
-  PageNavigation,
   PageSection,
   PageSectionVariants,
   TextContent,
@@ -40,38 +38,37 @@ export const HawtioHelp: React.FunctionComponent = () => {
       <PageSection variant={PageSectionVariants.light}>
         <Title headingLevel='h1'>Help</Title>
       </PageSection>
-      <PageGroup>
-        <PageNavigation>
-          <Nav aria-label='Nav' variant='tertiary'>
-            <NavList>
-              {helps.map(help => (
-                <NavItem key={help.id} isActive={location.pathname === `/help/${help.id}`}>
-                  <NavLink to={help.id}>{help.title}</NavLink>
-                </NavItem>
-              ))}
-            </NavList>
-          </Nav>
-        </PageNavigation>
-      </PageGroup>
-      <PageSection>
-        <Card isFullHeight>
-          <Routes>
-            {helpRegistry.getHelps().map(help => (
-              <Route
-                key={help.id}
-                path={help.id}
-                element={
-                  <CardBody>
-                    <TextContent>
-                      <Markdown>{help.content}</Markdown>
-                    </TextContent>
-                  </CardBody>
-                }
-              />
+      <Divider />
+
+      <PageSection type='tabs' hasShadowBottom>
+        <Nav aria-label='Nav' variant='tertiary'>
+          <NavList>
+            {helps.map(help => (
+              <NavItem key={help.id} isActive={location.pathname === `/help/${help.id}`}>
+                <NavLink to={help.id}>{help.title}</NavLink>
+              </NavItem>
             ))}
-            <Route path='/' element={<Navigate to='home' />} />
-          </Routes>
-        </Card>
+          </NavList>
+        </Nav>
+      </PageSection>
+      <Divider />
+      <PageSection variant={PageSectionVariants.light}>
+        <Routes>
+          {helpRegistry.getHelps().map(help => (
+            <Route
+              key={help.id}
+              path={help.id}
+              element={
+                <CardBody>
+                  <TextContent>
+                    <Markdown>{help.content}</Markdown>
+                  </TextContent>
+                </CardBody>
+              }
+            />
+          ))}
+          <Route path='/' element={<Navigate to='home' />} />
+        </Routes>
       </PageSection>
     </React.Fragment>
   )

--- a/packages/hawtio/src/preferences/HomePreferences.tsx
+++ b/packages/hawtio/src/preferences/HomePreferences.tsx
@@ -94,7 +94,7 @@ const ResetForm: React.FunctionComponent = () => {
         <FormHelperText>
           <HelperText>
             <HelperTextItem>
-              Clear all custom settings stored in your browser `&apos;`s local storage and reset to defaults.
+              Clear all custom settings stored in your browser`s local storage and reset to defaults.
             </HelperTextItem>
           </HelperText>
         </FormHelperText>


### PR DESCRIPTION
`branch: jsolovjo:fix-e2e-pr-1201`

before: <img width="1636" alt="Screenshot 2024-10-31 at 15 41 07" src="https://github.com/user-attachments/assets/2fbc3d97-e3cd-4330-bd66-b1e03df03dde">

after: 
<img width="1630" alt="Screenshot 2024-10-31 at 15 40 20" src="https://github.com/user-attachments/assets/bda37799-7143-419e-b145-f58f7efb4dc5">
