### PR TITLE
feat(connect): enable auto-connect based on preset connections from backend

### DIFF
--- a/app/webpack.config.cjs
+++ b/app/webpack.config.cjs
@@ -218,6 +218,7 @@ module.exports = (_, args) => {
         devServer.app.get(`${publicPath}/keycloak/validate-subject-matches`, (_, res) => res.send('true'))
 
         // Testing preset connections
+        /*
         devServer.app.get(`${publicPath}/preset-connections`, (_, res) => {
           res.type('application/json')
           res.send(
@@ -227,6 +228,7 @@ module.exports = (_, args) => {
             ]),
           )
         })
+        */
 
         // Hawtio backend middleware should be run before other middlewares (thus 'unshift')
         // in order to handle GET requests to the proxied Jolokia endpoint.

--- a/app/webpack.config.cjs
+++ b/app/webpack.config.cjs
@@ -163,7 +163,11 @@ module.exports = (_, args) => {
         // Hawtio backend API mock
         let login = true
         devServer.app.get(`${publicPath}/user`, (_, res) => {
-          login ? res.send(`"${username}"`) : res.sendStatus(403)
+          if (login) {
+            res.send(`"${username}"`)
+          } else {
+            res.sendStatus(403)
+          }
         })
         devServer.app.post(`${publicPath}/auth/login`, (req, res) => {
           // Test authentication throttling with username 'throttled'
@@ -212,6 +216,17 @@ module.exports = (_, args) => {
           res.send(JSON.stringify(keycloakClientConfig)),
         )
         devServer.app.get(`${publicPath}/keycloak/validate-subject-matches`, (_, res) => res.send('true'))
+
+        // Testing preset connections
+        devServer.app.get(`${publicPath}/preset-connections`, (_, res) => {
+          res.type('application/json')
+          res.send(
+            JSON.stringify([
+              { name: 'test1', scheme: 'http', host: 'localhost', port: 8778, path: '/jolokia/' },
+              { name: 'test2' },
+            ]),
+          )
+        })
 
         // Hawtio backend middleware should be run before other middlewares (thus 'unshift')
         // in order to handle GET requests to the proxied Jolokia endpoint.

--- a/packages/hawtio/src/plugins/shared/__mocks__/connect-service.ts
+++ b/packages/hawtio/src/plugins/shared/__mocks__/connect-service.ts
@@ -1,19 +1,23 @@
-import 'jolokia.js'
 import Jolokia, { IJolokiaSimple } from '@jolokia.js/simple'
+import 'jolokia.js'
 import {
+  ConnectStatus,
   Connection,
   ConnectionCredentials,
   ConnectionTestResult,
   Connections,
   IConnectService,
   LoginResult,
-  ConnectStatus,
 } from '../connect-service'
 
 class MockConnectService implements IConnectService {
   constructor() {
     // eslint-disable-next-line no-console
     console.log('Using mock connect service')
+  }
+
+  getCurrentConnectionId(): string | null {
+    return null
   }
 
   getCurrentConnectionName(): string | null {
@@ -72,7 +76,7 @@ class MockConnectService implements IConnectService {
     return ''
   }
 
-  getJolokiaUrlFromName(name: string): string | null {
+  getJolokiaUrlFromId(name: string): string | null {
     return null
   }
 

--- a/packages/hawtio/src/plugins/shared/connect-service.ts
+++ b/packages/hawtio/src/plugins/shared/connect-service.ts
@@ -64,7 +64,7 @@ export const PARAM_KEY_CONNECTION = 'con'
 export const PARAM_KEY_REDIRECT = 'redirect'
 
 const PATH_LOGIN = '/connect/login'
-const PATH_PRESET_CONNECTIONS = 'preset-connections'
+const PATH_PRESET_CONNECTIONS = '/preset-connections'
 
 export interface IConnectService {
   getCurrentConnectionId(): string | null
@@ -137,7 +137,8 @@ class ConnectService implements IConnectService {
    */
   private async loadPresetConnections(): Promise<void> {
     try {
-      const res = await fetch(PATH_PRESET_CONNECTIONS)
+      const path = this.getPresetConnectionsPath()
+      const res = await fetch(path)
       if (!res.ok) {
         log.debug('Failed to load preset connections:', res.status, res.statusText)
         return
@@ -187,6 +188,11 @@ class ConnectService implements IConnectService {
       // Silently ignore errors
       log.debug('Error loading preset connections:', err)
     }
+  }
+
+  private getPresetConnectionsPath(): string {
+    const basePath = hawtio.getBasePath()
+    return basePath ? `${basePath}${PATH_PRESET_CONNECTIONS}` : PATH_PRESET_CONNECTIONS
   }
 
   getCurrentConnectionId(): string | null {
@@ -574,7 +580,7 @@ class ConnectService implements IConnectService {
 
   getLoginPath(): string {
     const basePath = hawtio.getBasePath()
-    return `${basePath}${PATH_LOGIN}`
+    return basePath ? `${basePath}${PATH_LOGIN}` : PATH_LOGIN
   }
 
   export(connections: Connections) {


### PR DESCRIPTION
Required by hawtio/hawtio#3731

This enhancement introduces support for the new backend API `/preset-connections` which can return a set of preset connections from the Hawtio CLI `--connection` option and automatically connecting to them.