### PR TITLE
issue-1316 rendering html result of jmx operations

### DIFF
--- a/packages/hawtio/package.json
+++ b/packages/hawtio/package.json
@@ -55,6 +55,7 @@
     "@types/react-dom": "^18.3.1",
     "@types/react-router-dom": "^5.3.3",
     "dagre": "^0.8.5",
+    "dompurify": "^3.2.3",
     "eventemitter3": "^5.0.1",
     "jolokia.js": "^2.1.9",
     "js-logger": "^1.6.1",

--- a/packages/hawtio/src/plugins/shared/operations/OperationForm.tsx
+++ b/packages/hawtio/src/plugins/shared/operations/OperationForm.tsx
@@ -215,10 +215,7 @@ const OperationFormContents: React.FunctionComponent<{ isExpanded: boolean }> = 
 
         {isResultHtml() && (
           <FlexItem>
-            <Button
-              variant="secondary"
-              onClick={() => setIsRenderHtmlMode(!isRenderHtmlMode)}
-            >
+            <Button variant='secondary' onClick={() => setIsRenderHtmlMode(!isRenderHtmlMode)}>
               {isRenderHtmlMode ? 'Raw View' : 'Render HTML'}
             </Button>
           </FlexItem>
@@ -228,7 +225,7 @@ const OperationFormContents: React.FunctionComponent<{ isExpanded: boolean }> = 
       {isRenderHtmlMode && isResultHtml() ? (
         <Card>
           <CardBody>
-            <div dangerouslySetInnerHTML={{__html: sanitizeHTML(result!)}}/>
+            <div dangerouslySetInnerHTML={{ __html: sanitizeHTML(result!) }} />
           </CardBody>
         </Card>
       ) : (
@@ -248,11 +245,11 @@ const OperationFormContents: React.FunctionComponent<{ isExpanded: boolean }> = 
   return (
     <React.Fragment>
       <DataListContent id={`operation-execute-${name}`} aria-label={`operation execute ${name}`} isHidden={!isExpanded}>
-        <OperationExecuteForm setResult={setResult} setIsFailed={setIsFailed}/>
+        <OperationExecuteForm setResult={setResult} setIsFailed={setIsFailed} />
       </DataListContent>
       {result && (
         <DataListContent id={`operation-result-${name}`} aria-label={`operation result ${name}`} isHidden={!isExpanded}>
-          <OperationExecuteResult/>
+          <OperationExecuteResult />
         </DataListContent>
       )}
     </React.Fragment>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2049,6 +2049,7 @@ __metadata:
     "@types/react-router-dom": "npm:^5.3.3"
     commit-and-tag-version: "npm:^12.5.0"
     dagre: "npm:^0.8.5"
+    dompurify: "npm:^3.2.3"
     eventemitter3: "npm:^5.0.1"
     jest: "npm:^29.7.0"
     jest-environment-jsdom: "npm:^29.7.0"
@@ -4082,6 +4083,13 @@ __metadata:
   version: 4.0.2
   resolution: "@types/tough-cookie@npm:4.0.2"
   checksum: 10/8682b4062959c15c0521361825839e10d374344fa84166ee0b731b815ac7b79a942f6e9192fad6383d69df2251021678c86c46748ff69c61609934a3e27472f2
+  languageName: node
+  linkType: hard
+
+"@types/trusted-types@npm:^2.0.7":
+  version: 2.0.7
+  resolution: "@types/trusted-types@npm:2.0.7"
+  checksum: 10/8e4202766a65877efcf5d5a41b7dd458480b36195e580a3b1085ad21e948bc417d55d6f8af1fd2a7ad008015d4117d5fdfe432731157da3c68678487174e4ba3
   languageName: node
   linkType: hard
 
@@ -7178,6 +7186,18 @@ __metadata:
   dependencies:
     domelementtype: "npm:^2.2.0"
   checksum: 10/e0d2af7403997a3ca040a9ace4a233b75ebe321e0ef628b417e46d619d65d47781b2f2038b6c2ef6e56e73e66aec99caf6a12c7e687ecff18ef74af6dfbde5de
+  languageName: node
+  linkType: hard
+
+"dompurify@npm:^3.2.3":
+  version: 3.2.3
+  resolution: "dompurify@npm:3.2.3"
+  dependencies:
+    "@types/trusted-types": "npm:^2.0.7"
+  dependenciesMeta:
+    "@types/trusted-types":
+      optional: true
+  checksum: 10/aad472bcdff40afdbb307fd02abbca86acefee9c39cb35e9634ebbc5e047750a7eeb021b02cd66894d60cf75ad021f69394de2e9e8786b0dd91c5832f497a9af
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
fix https://github.com/hawtio/hawtio-next/issues/1316
@tadayosi please kindly take a look

Enhance JMX Operation Result Rendering

Improve handling of HTML results in JMX operations using the existing [`isResultHtml()` ](https://github.com/hawtio/hawtio-next/blob/main/packages/hawtio/src/plugins/shared/operations/OperationForm.tsx#L194) method:
- Render HTML results by default after sanitization
- Add a toggle button to switch between rendered HTML and raw text view

![image](https://github.com/user-attachments/assets/cd551c09-da65-493f-a5cf-79cc26d6ef39)
![image](https://github.com/user-attachments/assets/48e9b3ac-705b-410a-b691-f54e6c3b9f01)

