### PR TITLE
Bug in ConsoleStatus - manifests in React 17

### DIFF
--- a/packages/hawtio/src/plugins/console-status/ConsoleStatus.tsx
+++ b/packages/hawtio/src/plugins/console-status/ConsoleStatus.tsx
@@ -64,8 +64,8 @@ export const ConsoleStatus: React.FunctionComponent = () => {
         <CardBody>
           <Alert variant='warning' title='Application returned no mbeans' />
 
-          {errors.map(error => (
-            <Alert variant='danger' title={error.message} className='console-alert'>
+          {errors.map((error, index) => (
+            <Alert key={index} variant='danger' title={error.message} className='console-alert'>
               {hasCause(error) && <p>Cause: {(error.cause as Error).message}</p>}
             </Alert>
           ))}


### PR DESCRIPTION
In React 17 there is an assumption that components instantiate through a map loop must carry a key attribute. Without this the 'setExtraStackFrame' error occurs (see https://github.com/facebook/react/issues/20359)