### PR TITLE
Changes to build configuration

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -22,6 +22,7 @@
     "jest": "^29.7.0",
     "monaco-editor": "^0.52.2",
     "monaco-editor-webpack-plugin": "^7.1.0",
+    "source-map-loader": "^5.0.0",
     "style-loader": "^4.0.0",
     "swc-loader": "^0.2.6",
     "typescript": "^5.4.5",

--- a/app/webpack.config.cjs
+++ b/app/webpack.config.cjs
@@ -14,6 +14,7 @@ module.exports = (_, args) => {
   const isProduction = args.mode === 'production'
   return {
     entry: './src/index',
+    devtool: 'eval-source-map',
     plugins: [
       new ModuleFederationPlugin({
         name: 'app',
@@ -92,6 +93,11 @@ module.exports = (_, args) => {
               },
             },
           },
+        },
+        {
+          test: /\.js$/,
+          enforce: 'pre',
+          use: ['source-map-loader'],
         },
         {
           test: /\.css$/i,

--- a/packages/hawtio/tsconfig.json
+++ b/packages/hawtio/tsconfig.json
@@ -4,6 +4,7 @@
     "paths": {
       "@hawtiosrc/*": ["src/*"]
     },
+    "target": "es2015",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4920,6 +4920,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     react-router-dom: "npm:^6.29.0"
+    source-map-loader: "npm:^5.0.0"
     style-loader: "npm:^4.0.0"
     swc-loader: "npm:^0.2.6"
     typescript: "npm:^5.4.5"
@@ -9251,7 +9252,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:0.6.3, iconv-lite@npm:^0.6.2":
+"iconv-lite@npm:0.6.3, iconv-lite@npm:^0.6.2, iconv-lite@npm:^0.6.3":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
   dependencies:
@@ -13798,10 +13799,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map-js@npm:^1.0.2":
+  version: 1.2.1
+  resolution: "source-map-js@npm:1.2.1"
+  checksum: 10/ff9d8c8bf096d534a5b7707e0382ef827b4dd360a577d3f34d2b9f48e12c9d230b5747974ee7c607f0df65113732711bb701fe9ece3c7edbd43cb2294d707df3
+  languageName: node
+  linkType: hard
+
 "source-map-js@npm:^1.2.0":
   version: 1.2.0
   resolution: "source-map-js@npm:1.2.0"
   checksum: 10/74f331cfd2d121c50790c8dd6d3c9de6be21926de80583b23b37029b0f37aefc3e019fa91f9a10a5e120c08135297e1ecf312d561459c45908cb1e0e365f49e5
+  languageName: node
+  linkType: hard
+
+"source-map-loader@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "source-map-loader@npm:5.0.0"
+  dependencies:
+    iconv-lite: "npm:^0.6.3"
+    source-map-js: "npm:^1.0.2"
+  peerDependencies:
+    webpack: ^5.72.1
+  checksum: 10/9bc90a50df1a3570ddc1ea9cd1aeadb241fd6f6ddb03e72a8f45f5d3fcc357e7edcc9fff8d35d2e338d17edf13c38a7b6e530308ac263d1b462a1e6bfacaf1a1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Specifies the target of ts building as 'es2015'. This is consistent with React 17 and is the target already specified in Hawtio-Online. So seemed to help with initial issues but might not be essential;

- Debugging the demo app in @hawtio/react proved particularly useful when considering the routing issues seen early on. So adding source-map generation to this app has been effective.