### PR TITLE
Adds ability to set the current connection in the connect-service

### DIFF
--- a/packages/hawtio/src/plugins/shared/connect-service.ts
+++ b/packages/hawtio/src/plugins/shared/connect-service.ts
@@ -88,7 +88,7 @@ export interface IConnectService {
 }
 
 class ConnectService implements IConnectService {
-  private readonly currentConnectionId: string | null
+  private currentConnectionId: string | null
 
   constructor() {
     this.currentConnectionId = this.initCurrentConnectionId()
@@ -237,6 +237,18 @@ class ConnectService implements IConnectService {
     this.clearCredentialsOnLogout()
 
     return conn
+  }
+
+  setCurrentConnection(connection: Connection) {
+    const connectionId = connection.id
+    if (!this.resolveConnectionId(connectionId)) {
+      log.warn('Cannot resolve connection Id in saved connections')
+      return
+    }
+
+    // Set the connection as the current connection
+    sessionStorage.setItem(SESSION_KEY_CURRENT_CONNECTION, JSON.stringify(connectionId))
+    this.currentConnectionId = connectionId
   }
 
   private clearCredentialsOnLogout() {


### PR DESCRIPTION
The singleton jolokiaService uses the `currentConnectionId` attribute from the connect-service, which is assigned on its construction. If there is no id already in the storage then it will be null. Since Hawtio assumes a single tab (so essentially a new app) for each instance then this attribute is assigned read-only and remains its constructed value.

In an environment, like the console-plugin, the switching to show data from different pods is done by updating the current connection in the session storage. Since the connect-service is a singleton that is shared amongst all pods, this in effect requires the updating of the `currentConnectionId` , else the original data is requested and wrong data shown.

Therefore, it is necessary to update the currentConnectionId should a new pod be changed to.

A check is made to ensure the connection being assigned is resolvable via the connections already saved in the storage.