### PR TITLE
Removes overrides for background color of Route Diagram

### DIFF
--- a/packages/hawtio/src/plugins/camel/debug/Debug.css
+++ b/packages/hawtio/src/plugins/camel/debug/Debug.css
@@ -8,18 +8,6 @@
   align-items: center;
 }
 
-.react-flow {
-  background-color: white !important;
-}
-
-.react-flow__renderer {
-  background-color: white !important;
-}
-
-.react-flow__viewport {
-  background-color: white !important;
-}
-
 .breakpoint-symbol {
   text-align: right;
   color: darkred;


### PR DESCRIPTION
There css overrides were introduced while the camel plugin was being implemented. Whether there was some difference in colour in Patternfly 4, am not sure why there were necessary. Removing causes no ill-effects in the test-app, a build of hawtio or an install of Hawtio-Online. For example, the background of the debug pane remains white.

Including them, causes an override in the hawtio-online dynamic-console-plugin which renders the Debug white while the rest of the UI is dark so it would be advantageous to remove them.