### PR TITLE
Adds hawt config properties to change appearance of the header and sidebar

### DIFF
--- a/app/public/hawtconfig.json
+++ b/app/public/hawtconfig.json
@@ -7,6 +7,12 @@
     "css": "",
     "favicon": "favicon.ico"
   },
+  "appearance": {
+    "showHeader": true,
+    "showBrand": true,
+    "showUserHeader": true,
+    "showSideBar": true
+  },
   "login": {
     "description": "Login page for Hawtio Management Console.",
     "links": [

--- a/packages/hawtio/src/core/config-manager.test.ts
+++ b/packages/hawtio/src/core/config-manager.test.ts
@@ -177,4 +177,35 @@ describe('ConfigManager', () => {
     expect(product?.name).toEqual('Hawtio React')
     expect(product?.value).toEqual('1.0.0')
   })
+
+  test('appearance is loaded', async () => {
+    // response for fetching hawtconfig.json
+    fetchMock.mockResponse(
+      JSON.stringify({
+        appearance: {
+          showHeader: true,
+          showBrand: true,
+          showSideBar: true,
+          showUserHeader: true,
+        },
+      }),
+    )
+
+    const config = await configManager.getHawtconfig()
+    expect(config.appearance?.showHeader).toBe(true)
+    expect(config.appearance?.showBrand).toBe(true)
+    expect(config.appearance?.showUserHeader).toBe(true)
+    expect(config.appearance?.showSideBar).toBe(true)
+  })
+
+  test('appearance defaults', async () => {
+    // response for fetching hawtconfig.json
+    fetchMock.mockResponse(JSON.stringify({}))
+
+    const config = await configManager.getHawtconfig()
+    expect(config.appearance?.showHeader).toBeUndefined()
+    expect(config.appearance?.showBrand).toBeUndefined()
+    expect(config.appearance?.showUserHeader).toBeUndefined()
+    expect(config.appearance?.showSideBar).toBeUndefined()
+  })
 })

--- a/packages/hawtio/src/core/config-manager.ts
+++ b/packages/hawtio/src/core/config-manager.ts
@@ -16,6 +16,11 @@ export type Hawtconfig = {
   branding?: BrandingConfig
 
   /**
+   * Configuration for the placement and structure of the UI
+   */
+  appearance?: AppearanceConfig
+
+  /**
    * Configuration for the built-in login page.
    */
   login?: LoginConfig
@@ -53,6 +58,23 @@ export type BrandingConfig = {
   appLogoUrl?: string
   css?: string
   favicon?: string
+}
+
+/**
+ * Appearance configuration type.
+ */
+export type AppearanceConfig = {
+  // Whether to display the header bar (default: true)
+  showHeader?: boolean
+
+  // Whether to display the brand logo on the header bar (default: true)
+  showBrand?: boolean
+
+  // Whether to display the user header dropdown on the header bar (default: true)
+  showUserHeader?: boolean
+
+  // Whether to display the sidebar (default: true)
+  showSideBar?: boolean
 }
 
 /**

--- a/packages/hawtio/src/ui/page/HawtioPage.tsx
+++ b/packages/hawtio/src/ui/page/HawtioPage.tsx
@@ -1,5 +1,5 @@
 import { useUser } from '@hawtiosrc/auth/hooks'
-import { usePlugins } from '@hawtiosrc/core'
+import { useHawtconfig, usePlugins } from '@hawtiosrc/core'
 import { HawtioHelp } from '@hawtiosrc/help/HawtioHelp'
 import { background } from '@hawtiosrc/img'
 import { PluginNodeSelectionContext, usePluginNodeSelected } from '@hawtiosrc/plugins'
@@ -28,6 +28,7 @@ import './HawtioPage.css'
 export const HawtioPage: React.FunctionComponent = () => {
   const { username, isLogin, userLoaded, userLoading } = useUser()
   const { plugins, pluginsLoaded } = usePlugins()
+  const { hawtconfig, hawtconfigLoaded } = useHawtconfig()
   const navigate = useNavigate()
   const { search } = useLocation()
   const { selectedNode, setSelectedNode } = usePluginNodeSelected()
@@ -40,7 +41,7 @@ export const HawtioPage: React.FunctionComponent = () => {
     }
   }, [isLogin, navigate, userLoading])
 
-  if (!userLoaded || !pluginsLoaded || userLoading) {
+  if (!userLoaded || !pluginsLoaded || userLoading || !hawtconfigLoaded) {
     log.debug('Loading:', 'user =', userLoaded, ', plugins =', pluginsLoaded)
     return <HawtioLoadingPage />
   }
@@ -63,14 +64,18 @@ export const HawtioPage: React.FunctionComponent = () => {
     sessionService.userActivity()
   }
 
+  // If not defined then assume the default of shown
+  const headerShown = hawtconfig.appearance?.showHeader ?? true
+  const sideBarShown = hawtconfig.appearance?.showSideBar ?? true
+
   return (
     <PageContext.Provider value={{ username, plugins }}>
       <BackgroundImage src={background} />
       <Page
         id='hawtio-main-page'
-        header={<HawtioHeader />}
-        sidebar={<HawtioSidebar />}
-        isManagedSidebar
+        header={headerShown && <HawtioHeader />}
+        sidebar={sideBarShown && <HawtioSidebar />}
+        isManagedSidebar={sideBarShown}
         defaultManagedSidebarIsOpen={showVerticalNavByDefault}
         onClick={keepAlive}
       >


### PR DESCRIPTION
### Overview
Since the Hawtio-Online dynamic console plugin has much more limited space, it is necessary to re-organise the UI components. Therefore,
 - Being able to show/hide the header bar. This is no longer strictly necessary as the latest version of the console plugin still makes use of the header bar but figured this option was still useful, hence its inclusion;
 - Being able to hide the brand logo. This is out of place in a sub-component tab of the OCP console and takes up a significant amount of space so essential to hide it;
 - Being able to hide the User dropdown. This is redundant in the OCP console since the user is displayed at the top of the console, the Preferences are integrated in the console and logout action is redundant;
 - Being able to hide the sidebar. The sidebar is wide and unnecessary. The console-plugin provides a toolbar dropdown that is applied to the header bar so much more compact.

### Commit Changes
- Creates 'appearance' property group in hawtconfig with properties that determine whether
  - showHeader: to show/hide the main header bar
  - showBrand: to show/hide the brand logo in the header bar
  - showUserHeader: to show/hide the user header dropdown in the header bar
  - showSideBar: to show/hide the sidebar

- config-manager.ts
  - Introduction of Appearance type
  - Functions to fetch the value of the properties from a hawt config with the defaults being true if properties are not specified

- HawtioHeader.tsx / HawtioPage.tsx
  - Make the various components conditional according to the properties