### PR TITLE
fix(help): Add help tabs for OIDC and Keycloak only if enabled (fixes #1330)

### DIFF
--- a/packages/hawtio/src/plugins/auth/keycloak/index.ts
+++ b/packages/hawtio/src/plugins/auth/keycloak/index.ts
@@ -4,6 +4,11 @@ import help from './help.md'
 import { keycloakService } from './keycloak-service'
 
 export const keycloak: HawtioPlugin = () => {
-  keycloakService.registerUserHooks()
-  helpRegistry.add('keycloak', 'Keycloak', help, 21)
+  let helpRegistered = false
+  keycloakService.registerUserHooks(() => {
+    if (!helpRegistered) {
+      helpRegistry.add('keycloak', 'Keycloak', help, 21)
+      helpRegistered = true
+    }
+  })
 }

--- a/packages/hawtio/src/plugins/auth/keycloak/keycloak-service.ts
+++ b/packages/hawtio/src/plugins/auth/keycloak/keycloak-service.ts
@@ -27,7 +27,7 @@ export const KEYCLOAK_TOKEN_MINIMUM_VALIDITY = 5 // 5 sec.
 
 export interface IKeycloakService {
   isKeycloakEnabled(): Promise<boolean>
-  registerUserHooks(): void
+  registerUserHooks(helpRegistration: () => void): void
   validateSubjectMatches(user: string): Promise<boolean>
 }
 
@@ -125,7 +125,7 @@ class KeycloakService implements IKeycloakService {
     return this.enabled
   }
 
-  registerUserHooks() {
+  registerUserHooks(helpRegistration: () => void) {
     const fetchUser = async (resolve: ResolveUser) => {
       const keycloak = await this.keycloak
       const userProfile = await this.userProfile
@@ -139,6 +139,9 @@ class KeycloakService implements IKeycloakService {
       }
 
       this.setupFetch()
+
+      // only now register help tab for OIDC
+      helpRegistration()
 
       return true
     }

--- a/packages/hawtio/src/plugins/auth/oidc/index.ts
+++ b/packages/hawtio/src/plugins/auth/oidc/index.ts
@@ -4,8 +4,13 @@ import help from './help.md'
 import { oidcService } from './oidc-service'
 
 const oidc: HawtioPlugin = () => {
-  oidcService.registerUserHooks()
-  helpRegistry.add('oidc', 'OpenID Connect', help, 22)
+  let helpRegistered = false
+  oidcService.registerUserHooks(() => {
+    if (!helpRegistered) {
+      helpRegistry.add('oidc', 'OpenID Connect', help, 22)
+      helpRegistered = true
+    }
+  })
 }
 
 export { oidc, oidcService }

--- a/packages/hawtio/src/plugins/auth/oidc/oidc-service.ts
+++ b/packages/hawtio/src/plugins/auth/oidc/oidc-service.ts
@@ -43,7 +43,7 @@ export type OidcConfig = {
 }
 
 export interface IOidcService {
-  registerUserHooks(): void
+  registerUserHooks(helpRegistration: () => void): void
 }
 
 class UserInfo {
@@ -338,7 +338,7 @@ export class OidcService implements IOidcService {
     }
   }
 
-  registerUserHooks() {
+  registerUserHooks(helpRegistration: () => void) {
     const fetchUser = async (resolveUser: ResolveUser, proceed?: () => boolean) => {
       if (proceed && !proceed()) {
         return false
@@ -350,6 +350,9 @@ export class OidcService implements IOidcService {
       }
       resolveUser({ username: userInfo.user!, isLogin: true })
       userService.setToken(userInfo.access_token!)
+
+      // only now register help tab for OIDC
+      helpRegistration()
 
       return true
     }


### PR DESCRIPTION
With this PR, Keycloak and OIDC help tabs are added only after successful authentication and checking if these plugins are not only active, but configured correctly.
See: #1330.