### PR TITLE
fix(#1379) - Fixed background for charts view

### DIFF
--- a/packages/hawtio/src/plugins/camel/CamelContent.tsx
+++ b/packages/hawtio/src/plugins/camel/CamelContent.tsx
@@ -176,8 +176,8 @@ export const CamelContent: React.FunctionComponent = () => {
       <Divider />
       <PageSection
         id='camel-content-main'
-        variant={pathname.includes('chart') ? PageSectionVariants.default : PageSectionVariants.light}
-        padding={{ default: pathname.includes('chart') ? 'padding' : 'noPadding' }}
+        variant={PageSectionVariants.light}
+        padding={{ default: 'noPadding' }}
         hasOverflowScroll
         aria-label='camel-content-main'
       >

--- a/packages/hawtio/src/plugins/jmx/JmxContent.tsx
+++ b/packages/hawtio/src/plugins/jmx/JmxContent.tsx
@@ -90,8 +90,8 @@ export const JmxContent: React.FunctionComponent = () => {
       <Divider />
       <PageSection
         id='jmx-content-main'
-        variant={pathname.includes('chart') ? PageSectionVariants.default : PageSectionVariants.light}
-        padding={{ default: pathname.includes('chart') ? 'padding' : 'noPadding' }}
+        variant={PageSectionVariants.light}
+        padding={{ default: 'noPadding' }}
         hasOverflowScroll
         aria-label='jmx-content-main'
       >


### PR DESCRIPTION
Fixes background for charts view in JMX and Camel. Now it has the same background as the other tabs.

![Screenshot 2025-03-19 014549](https://github.com/user-attachments/assets/0e8c4974-8459-46af-a0e8-fedd2147a7fc)
![Screenshot 2025-03-19 014900](https://github.com/user-attachments/assets/0346870b-5c1a-4f7e-99fa-f5c8595b83f5)
