### PR TITLE
fix(springboot-plugin): Set background to PF5 style.

### DIFF
--- a/packages/hawtio/src/plugins/springboot/Health.css
+++ b/packages/hawtio/src/plugins/springboot/Health.css
@@ -1,0 +1,3 @@
+.pf-v5-c-icon {
+  padding-left: 0.5rem;
+}

--- a/packages/hawtio/src/plugins/springboot/Health.tsx
+++ b/packages/hawtio/src/plugins/springboot/Health.tsx
@@ -12,6 +12,7 @@ import {
   InfoCircleIcon,
   QuestionCircleIcon,
 } from '@patternfly/react-icons'
+import './Health.css'
 
 const SPAN_6_COMPONENTS = ['diskSpace', 'camelHealth', 'camel']
 

--- a/packages/hawtio/src/plugins/springboot/SpringBoot.tsx
+++ b/packages/hawtio/src/plugins/springboot/SpringBoot.tsx
@@ -67,8 +67,8 @@ export const SpringBoot: React.FunctionComponent = () => {
       <Divider />
       <PageSection
         aria-label='Spring-boot Content'
-        variant={location.pathname === '/springboot/health' ? PageSectionVariants.default : PageSectionVariants.light}
-        padding={{ default: location.pathname.includes('health') ? 'padding' : 'noPadding' }}
+        variant={PageSectionVariants.light}
+        padding={{ default: 'noPadding' }}
       >
         <Routes>
           {navItems.map(navItem => (


### PR DESCRIPTION
Sets the background/padding to the PF5 style.

I also added a bit of padding to the icons as they were too close to the margin.

Without padding:

![Screenshot 2025-03-21 011640](https://github.com/user-attachments/assets/529018d7-2bf9-4e40-9e63-945f0d1d98aa)

With the padding:

![Screenshot 2025-03-21 012756](https://github.com/user-attachments/assets/2251e384-d8ca-4f69-ae04-7fb9b3294b69)
