### PR TITLE
fix(camel, jmx, quartz): Added independent scrolling to Tree View #1380

### DIFF
--- a/packages/hawtio/src/plugins/camel/CamelTreeView.css
+++ b/packages/hawtio/src/plugins/camel/CamelTreeView.css
@@ -2,6 +2,11 @@
   height: 100%;
 }
 
+#camel-tree-view > .pf-v5-c-tree-view__list {
+  max-height: 83vh;
+  overflow: auto;
+}
+
 #camel-tree-view .pf-v5-c-tree-view__node {
   padding-top: 1px;
   padding-bottom: 1px;

--- a/packages/hawtio/src/plugins/jmx/JmxTreeView.css
+++ b/packages/hawtio/src/plugins/jmx/JmxTreeView.css
@@ -2,6 +2,11 @@
   height: 100%;
 }
 
+#jmx-tree-view > .pf-v5-c-tree-view__list {
+  max-height: 83vh;
+  overflow: auto;
+}
+
 #jmx-tree-view .pf-v5-c-tree-view__node {
   padding-top: 1px;
   padding-bottom: 1px;

--- a/packages/hawtio/src/plugins/quartz/QuartzTreeView.css
+++ b/packages/hawtio/src/plugins/quartz/QuartzTreeView.css
@@ -2,6 +2,11 @@
   height: 100%;
 }
 
+#quartz-tree-view > .pf-v5-c-tree-view__list {
+  max-height: 83vh;
+  overflow: auto;
+}
+
 #quartz-tree-view .pf-v5-c-tree-view__node {
   padding-top: 1px;
   padding-bottom: 1px;


### PR DESCRIPTION
Fix #1380 



This is a best effort solution, setting the height of the first node of the tree list to 83% of the view height as it is similar to the height of the tree list. That allows the tree-list to have an overflow (as it has now a fixed height)

I would need to research more or do a refactor on the UI for a better solution, but it has already taken 3 days trying different things and I don't think it's worth investing more time on it.

Let me explain:

Currently, the current style breaks the size the tree list has for its contents. That's why all the page scrolls.

![Screenshot 2025-03-21 042406](https://github.com/user-attachments/assets/80d4bf72-593a-4061-9090-b8215d6da32f)

This is typical with lists, as they will usually overflow their container unless they have a fixed height. The typical solutions felt undesirable to use or had issues

- Height: 100% doesn't work, as the parent node doesn't have a fixed height either.
- Setting the height for the whole TreeListView is not desirable, as then the search bar scrolls as well
- Adding a container around the list felt the best solution, though I can't modify TreeListView as it's part of PatternFly, and adding an extra div inside through CSS using :after felt undesirable
- We don't really have fixed heights in general, letting PatternFly handle it through flex and grid, which is the better option. But we absolutely need a fixed height for the scroll to appear with a list element.

So the chosen solution has been to set the first node on the tree view to a fixed height, which I have chosen to be 83% view height. It has only to be the first node, you can't apply the rule in general as the class is used more times when creating the tree view so there are more nodes with the same class. This is done using the `>` rule.

This not only fixes the original issue, adding a scroll bar to the tree view, but also removes the scroll bar for the whole page, as the page will now fit inside the screen.

Please check the gif to see how it looks 

![Recording 2025-03-21 041613](https://github.com/user-attachments/assets/0e6cafc1-a265-4be5-8eed-c15a829154de)

What's the problem with the current solution? 

- Setting the vh like this might look cut out depending on the device. Although it should be barely noticeable.
- It might also make a scroll for the whole page appear in small screens. Although it should be close to the content height as well so even if the whole page scrolls it wont look ugly and you will still have the option to just scroll the tree or the content view.
- It can cause, although very rarely, issues with PF layout. This shouldn't be an issue for the most part because this is set in an element inside PatternFly container, so it should adapt well enough. Still, good to consider
Tell me your thoughts. I thought this might be the best approach.