### PR TITLE
update(router): Upgrade router to 7 (#1282)

### DIFF
--- a/packages/hawtio/src/Hawtio.tsx
+++ b/packages/hawtio/src/Hawtio.tsx
@@ -17,7 +17,7 @@ export const Hawtio: React.FunctionComponent<HawtioProps> = props => {
   }
 
   return (
-    <BrowserRouter basename={hawtio.getBasePath()}>
+    <BrowserRouter future={{v7_startTransition: true}} basename={hawtio.getBasePath()}>
       <Routes>
         <Route path='/login' element={<HawtioLogin />} />
         <Route path='/*' element={<HawtioPage />} />

--- a/packages/hawtio/src/Hawtio.tsx
+++ b/packages/hawtio/src/Hawtio.tsx
@@ -17,10 +17,10 @@ export const Hawtio: React.FunctionComponent<HawtioProps> = props => {
   }
 
   return (
-    <BrowserRouter future={{v7_startTransition: true}} basename={hawtio.getBasePath()}>
+    <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }} basename={hawtio.getBasePath()}>
       <Routes>
         <Route path='/login' element={<HawtioLogin />} />
-        <Route path='/*' element={<HawtioPage />} />
+        <Route path='*' element={<HawtioPage />} />
       </Routes>
     </BrowserRouter>
   )

--- a/packages/hawtio/src/ui/page/HawtioHeader.tsx
+++ b/packages/hawtio/src/ui/page/HawtioHeader.tsx
@@ -123,7 +123,7 @@ const HawtioHeaderToolbar: React.FunctionComponent<HawtioHeaderToolbarProps> = p
 
   const helpItems = [
     <DropdownItem key='help'>
-      <Link to='/help'>Help</Link>{' '}
+      <Link to='../help'>Help</Link>{' '}
     </DropdownItem>,
     <DropdownItem key='about' onClick={onAboutToggle}>
       About
@@ -132,7 +132,7 @@ const HawtioHeaderToolbar: React.FunctionComponent<HawtioHeaderToolbarProps> = p
 
   const userItems = [
     <DropdownItem key='preferences'>
-      <Link to='/preferences'>Preferences</Link>
+      <Link to='../preferences'>Preferences</Link>
     </DropdownItem>,
     <DropdownItem key='logout' onClick={logout}>
       Log out

--- a/packages/hawtio/src/ui/page/HawtioPage.tsx
+++ b/packages/hawtio/src/ui/page/HawtioPage.tsx
@@ -86,11 +86,16 @@ export const HawtioPage: React.FunctionComponent = () => {
             {plugins
               .filter(plugin => plugin.path != null && plugin.component != null)
               .map(plugin => (
-                <Route key={plugin.id} path={`${plugin.path}/*`} element={React.createElement(plugin.component!)} />
+                <Route key={plugin.id} path={`${plugin.path}`} element={React.createElement(plugin.component!)}>
+                  <Route path='*' element={React.createElement(plugin.component!)} />
+                </Route>
               ))}
-            <Route key='help' path='help/*' element={<HawtioHelp />} />
-            <Route key='preferences' path='preferences/*' element={<HawtioPreferences />} />
-
+            <Route key='help' path='/help' element={<HawtioHelp />}>
+              <Route path='*' element={<HawtioHelp />} />
+            </Route>
+            <Route key='preferences' path='/preferences' element={<HawtioPreferences />}>
+              <Route path='*' element={<HawtioPreferences />} />
+            </Route>
             <Route key='index' path='index.html' element={<Navigate to='/' />} />
             <Route key='root' index element={defaultPage} />
           </Routes>


### PR DESCRIPTION
Fixes #1282 

Updates the router component to use new features found in version 7. The guidelines https://reactrouter.com/upgrading/v6

There is a new warning, but it contradicts the fixes needed for https://reactrouter.com/upgrading/v6#v7_relativesplatpath. Trying to follow it is like we had before, and breaks the page. For now I have ignored it as I think that when we upgrade to 7 it should be removed.

![426104904-014f05f6-aefe-4eca-b0d2-1a6ec161dfbe](https://github.com/user-attachments/assets/fa753bbf-af28-486e-899a-215c14d5dfb1)

