### PR TITLE
fix(preferences): Tip icons next to labels (#1438)

### DIFF
--- a/packages/hawtio/src/plugins/camel/CamelPreferences.css
+++ b/packages/hawtio/src/plugins/camel/CamelPreferences.css
@@ -3,11 +3,11 @@
 }
 
 .pf-v5-c-form__group-label {
+  padding-top: 0px !important;
   display: flex;
-  justify-content: space-between;
   align-items: center;
 }
 
-.pf-v5-c-icon {
-  padding-right: 1em;
+.pf-v5-c-form__group-label > label {
+  padding-right: 0.5em;
 }


### PR DESCRIPTION
Aligns tip icons next to labels according to PF5 standarts as can be seen in https://www.patternfly.org/components/forms/form/html#horizontally-aligned-labels

It will be seen as this:

![Screenshot 2025-04-08 061423](https://github.com/user-attachments/assets/bfe9a87c-f636-4c71-ba3d-453dd897d79a)
![Screenshot 2025-04-08 061441](https://github.com/user-attachments/assets/0039e08d-c3ad-4891-bf5f-617db6b376ae)
![Screenshot 2025-04-08 061503](https://github.com/user-attachments/assets/8e5d765d-8c78-454e-920e-6f56f6c1c60f)
![Screenshot 2025-04-08 061523](https://github.com/user-attachments/assets/033197fc-bd66-4fe4-a7e2-169644d871ad)
