### PR TITLE
fix(runtime): Search terms can be removed (#1435)

### DIFF
--- a/packages/hawtio/src/ui/util/FilteredTable.tsx
+++ b/packages/hawtio/src/ui/util/FilteredTable.tsx
@@ -173,7 +173,7 @@ export function FilteredTable<T>({
   }
 
   const onDeleteFilter = (filter: string) => {
-    if (filter === `${attributeMenuItem}: ${searchTerm.value}`) {
+    if (filter === `${attributeMenuItem?.name}: ${searchTerm.value}`) {
       setSearchTerm({
         key: attributeMenuItem?.key,
         value: '',


### PR DESCRIPTION
Fixes bug where search items couldn't be removed unless they were set by changing the type of the filter.

https://github.com/user-attachments/assets/cd617ece-79f7-45aa-9361-8fb831f13e52

I'm adding @mmuzikar to the reviewers as he was the original creator of the component





