### PR TITLE
fix(runtime): Search terms can be set with enter key (#1435) (proposition)

### DIFF
--- a/packages/hawtio/src/ui/util/FilteredTable.tsx
+++ b/packages/hawtio/src/ui/util/FilteredTable.tsx
@@ -223,6 +223,11 @@ export function FilteredTable<T>({
               id='search-input'
               placeholder='Search...'
               value={searchTerm.value}
+              onKeyDown={e => {
+                if (e.key === 'Enter' || e.code.includes('Enter') || e.keyCode === 13) {
+                  addToFilters()
+                }
+              }}
               onChange={(_event, value) => setSearchTerm({ key: attributeMenuItem?.key, value })}
               aria-label='Search input'
             />


### PR DESCRIPTION
From #1435 I noticed that the only way to set a search term is by changing the type of filter. This PR allows the user to be able to add search terms pressing Enter key.

https://github.com/user-attachments/assets/71391ab2-14aa-4544-b715-fe7936bad56c

