### PR TITLE
fix(runtime, logs, shared): Fixed colum width changing in tables (#1452)

### DIFF
--- a/packages/hawtio/src/plugins/logs/Logs.tsx
+++ b/packages/hawtio/src/plugins/logs/Logs.tsx
@@ -184,19 +184,23 @@ const LogsTable: React.FunctionComponent = () => {
           {
             name: 'Timestamp',
             key: 'timestamp',
+            percentageWidth: 10,
           },
           {
             name: 'Level',
             key: 'level',
             renderer: val => <LogLevel level={val.level} />,
+            percentageWidth: 10,
           },
           {
             name: 'Logger',
             key: 'logger',
+            percentageWidth: 40,
           },
           {
             name: 'Message',
             key: 'message',
+            percentageWidth: 40,
           },
         ]}
         searchCategories={[

--- a/packages/hawtio/src/plugins/runtime/SysProps.tsx
+++ b/packages/hawtio/src/plugins/runtime/SysProps.tsx
@@ -17,10 +17,12 @@ export const SysProps: React.FunctionComponent = () => {
         {
           name: 'Property Name',
           key: 'key',
+          percentageWidth: 20,
         },
         {
           name: 'Property Value',
           key: 'value',
+          percentageWidth: 80,
         },
       ]}
       rows={properties}

--- a/packages/hawtio/src/plugins/runtime/Threads.tsx
+++ b/packages/hawtio/src/plugins/runtime/Threads.tsx
@@ -102,14 +102,14 @@ export const Threads: React.FunctionComponent = () => {
 
       <FilteredTable
         tableColumns={[
-          { key: 'threadId', name: 'ID' },
-          { key: 'threadState', name: 'State' },
-          { key: 'threadName', name: 'Name' },
-          { key: 'waitedTime', name: 'Waited Time' },
-          { key: 'blockedTime', name: 'Blocked Time' },
-          { key: 'inNative', name: 'Native' },
-          { key: 'suspended', name: 'Suspended' },
-          { renderer: DetailsButton },
+          { key: 'threadId', name: 'ID', percentageWidth: 10 },
+          { key: 'threadState', name: 'State', percentageWidth: 10 },
+          { key: 'threadName', name: 'Name', percentageWidth: 30 },
+          { key: 'waitedTime', name: 'Waited Time', percentageWidth: 10 },
+          { key: 'blockedTime', name: 'Blocked Time', percentageWidth: 10 },
+          { key: 'inNative', name: 'Native', percentageWidth: 10 },
+          { key: 'suspended', name: 'Suspended', percentageWidth: 10 },
+          { renderer: DetailsButton, percentageWidth: 10 },
         ]}
         searchCategories={[
           {

--- a/packages/hawtio/src/plugins/shared/JmxContentMBeans.tsx
+++ b/packages/hawtio/src/plugins/shared/JmxContentMBeans.tsx
@@ -42,8 +42,8 @@ export const JmxContentMBeans: React.FunctionComponent = () => {
       <Table aria-label='MBeans' variant='compact'>
         <Thead>
           <Tr>
-            <Th>MBean</Th>
-            <Th>Object Name</Th>
+            <Th width={50}>MBean</Th>
+            <Th width={50}>Object Name</Th>
           </Tr>
         </Thead>
         <Tbody className={'jmx-table-body'}>

--- a/packages/hawtio/src/ui/util/FilteredTable.tsx
+++ b/packages/hawtio/src/ui/util/FilteredTable.tsx
@@ -29,15 +29,13 @@ import { SearchIcon } from '@patternfly/react-icons'
 import { ExpandableText } from './ExpandableText'
 import { isNumber, objectSorter } from '@hawtiosrc/util/objects'
 
-type AvailablePercentageWidths = 10 | 15 | 20 | 25 | 30 | 35 | 40 | 45 | 50 | 60 | 70 | 80 | 90 | 100
-
 interface Props<T> {
   extraToolbar?: React.ReactNode
   tableColumns: {
     name?: string
     key?: keyof T
     renderer?: (value: T) => React.ReactNode
-    percentageWidth?: AvailablePercentageWidths
+    percentageWidth?: ThProps['width']
   }[]
   rows: T[]
   searchCategories: { name: string; key: keyof T }[]

--- a/packages/hawtio/src/ui/util/FilteredTable.tsx
+++ b/packages/hawtio/src/ui/util/FilteredTable.tsx
@@ -29,9 +29,16 @@ import { SearchIcon } from '@patternfly/react-icons'
 import { ExpandableText } from './ExpandableText'
 import { isNumber, objectSorter } from '@hawtiosrc/util/objects'
 
+type AvailablePercentageWidths = 10 | 15 | 20 | 25 | 30 | 35 | 40 | 45 | 50 | 60 | 70 | 80 | 90 | 100
+
 interface Props<T> {
   extraToolbar?: React.ReactNode
-  tableColumns: { name?: string; key?: keyof T; renderer?: (value: T) => React.ReactNode }[]
+  tableColumns: {
+    name?: string
+    key?: keyof T
+    renderer?: (value: T) => React.ReactNode
+    percentageWidth?: AvailablePercentageWidths
+  }[]
   rows: T[]
   searchCategories: { name: string; key: keyof T }[]
   onClick?: (value: T) => void
@@ -300,6 +307,7 @@ export function FilteredTable<T>({
                         key={'th-key' + index}
                         data-testid={`${String(att.key || index)}-header`}
                         sort={getSortParams(index)}
+                        width={att.percentageWidth}
                       >
                         {att.name}
                       </Th>


### PR DESCRIPTION
Fixes #1452 

Sets a new field to configure FilteredTable to add the width desired for the table. It's recommended to use it to ensure that the columns stay at a fixed width and the content is adjusted accordingly. Even then, there is no guarantees that a specially long string wont break the width but for now it seems working fine.

https://github.com/user-attachments/assets/adef98f1-9d8e-492e-be3c-b94c10a8c6a7

Also sets a width for JMXContentMBeans because that table was jumping widths while exploring through the MBeans in JMX and Camel, which looked odd.

I haven't touched other tables as they can't be filtered or paginated as far as I've seen, so the width will stay fixed for that table as all the content has already been loaded. Also, as the tables are different depending on the attributes we are viewing, it's normal for those tables to have variable widths depending on the data shown.

