### PR TITLE
fix(connect): Fixed toggle moving when dropdown was shown (hawng-967)

### DIFF
--- a/packages/hawtio/src/plugins/connect/remote/Remote.css
+++ b/packages/hawtio/src/plugins/connect/remote/Remote.css
@@ -1,0 +1,3 @@
+.data-list-action-toggle {
+  margin-right: 0px !important;
+}

--- a/packages/hawtio/src/plugins/connect/remote/Remote.tsx
+++ b/packages/hawtio/src/plugins/connect/remote/Remote.tsx
@@ -25,6 +25,7 @@ import {
   ToolbarContent,
   ToolbarItem,
 } from '@patternfly/react-core'
+import './Remote.css'
 import { PluggedIcon, PlusIcon, UnpluggedIcon } from '@patternfly/react-icons'
 import React, { useContext, useEffect, useState } from 'react'
 import { DELETE } from '../connections'
@@ -230,8 +231,14 @@ const ConnectionItem: React.FunctionComponent<{
             key={`connection-action-dropdown-${id}`}
             isOpen={isDropdownOpen}
             onOpenChange={setIsDropdownOpen}
+            popperProps={{ position: 'right' }}
             toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-              <MenuToggle variant='plain' ref={toggleRef} onClick={handleDropdownToggle}>
+              <MenuToggle
+                variant='plain'
+                ref={toggleRef}
+                className='data-list-action-toggle'
+                onClick={handleDropdownToggle}
+              >
                 <EllipsisVIcon />
               </MenuToggle>
             )}


### PR DESCRIPTION
Fixes toggle moving in connect when the dropdown was shown.

https://github.com/user-attachments/assets/558689c6-3315-48a0-a9d5-ca2f46aa3224

The changes fixes the issue but I wasn't able to see what was causing it:

- The style of the buttons inside actions should have a margin-right set to 0 like in the examples in PF https://www.patternfly.org/components/data-list#checkboxes-actions-and-additional-cells
- The Inspector tells me the toggle button should have margin-right set to 0, but for some reason, when it's toggled, the toggle gets a margin-right: 16px. When you turn off the toggle, the margin-right is correctly set to 0.
  - Also, the connect button to the left also has this margin-right: 16px and it shouldn't have.
- There is no mention on Hawtio-next codebase of any CSS rule setting margin-right: 16px on buttons or data list actions.
- Inspector tells me PF sets margin-right: 0px to buttons so I don't think the issue comes from there
- Element CSS or Inline CSS wasn't working. They didn't even appear in the Inspector.
  - A custom class did but depending on how it was set up it wouldn't work as well

Another option could have been to separate the DataListAction component into two components, one with the connect button and another with the toggle and see if that might be the cause, but that would break the tests as it seems like they are using the DataListAction properties to find the element on the test. So I didn't try that.

The task didn't warrant more effort, it's a quick fix and this only affects Connect, so I went with this solution. I'll return to this and continue checking if we find this issue again.
