### PR TITLE
refactor(logs): Swapped positions of fixed search filter and text filter (#1479)

### DIFF
--- a/packages/hawtio/src/plugins/logs/Logs.tsx
+++ b/packages/hawtio/src/plugins/logs/Logs.tsx
@@ -217,7 +217,7 @@ const LogsTable: React.FunctionComponent = () => {
           setSelected(row.logEntry)
           setIsModalOpen(true)
         }}
-        extraToolbar={levelToggles}
+        fixedSetToolbar={levelToggles}
         onClearAllFilters={() => handleFiltersChange('level', [])}
       />
     </>

--- a/packages/hawtio/src/ui/util/FilteredTable.tsx
+++ b/packages/hawtio/src/ui/util/FilteredTable.tsx
@@ -30,6 +30,7 @@ import { ExpandableText } from './ExpandableText'
 import { isNumber, objectSorter } from '@hawtiosrc/util/objects'
 
 interface Props<T> {
+  fixedSetToolbar?: React.ReactNode
   extraToolbar?: React.ReactNode
   tableColumns: {
     name?: string
@@ -53,6 +54,7 @@ function numberOrString(value: unknown): string | number {
 }
 
 export function FilteredTable<T>({
+  fixedSetToolbar,
   extraToolbar,
   tableColumns,
   rows,
@@ -192,6 +194,7 @@ export function FilteredTable<T>({
   const tableToolBar = (
     <Toolbar clearAllFilters={clearFilters}>
       <ToolbarContent>
+        {fixedSetToolbar}
         <ToolbarGroup>
           <Dropdown
             data-testid='attribute-select'


### PR DESCRIPTION
Fixes #1479 

![image](https://github.com/user-attachments/assets/0ea404d9-efbb-4658-86c7-e4e048920b5b)

I think I'm going to add a bit more effort and refactor the fixed set so the logic is inside the Filtered Table component. Is that okay @tadayosi ?

I think I'll be able to do that in the day. If it's not desirable, we can just pick the previous commit which has just the fix.