### PR TITLE
fix: catch exception on http code 403 properly

### DIFF
--- a/packages/hawtio/src/plugins/shared/connect-service.ts
+++ b/packages/hawtio/src/plugins/shared/connect-service.ts
@@ -423,17 +423,15 @@ class ConnectService implements IConnectService {
 
   private async forbiddenReasonMatches(response: Response, reason: string): Promise<boolean> {
     // Preserve compatibility with versions of Hawtio 2.x that return JSON on 403 responses
-    return response
-      .text()
-      .then(txt => {
+    return response.text().then(txt => {
+      try {
         const json = JSON.parse(txt)
-        // exception will propagate to .catch()
         return json['reason'] === reason
-      })
-      .catch(_ => {
+      } catch (_) {
         // Otherwise expect a response header containing a forbidden reason
         return response.headers.get('Hawtio-Forbidden-Reason') === reason
-      })
+      }
+    })
   }
 
   connect(connection: Connection, current = false) {


### PR DESCRIPTION
Testing through activemq artemis console.

The exception is not handled properly in the current version, see screenshot.

This also causes some issues with website/browser when developer tools are open, since it takes a lot of time to open the debug tab and the webpage in the browser can freeze.

I tested this fix with hawtio v4.4 and it works.
Please check.
![debug](https://github.com/user-attachments/assets/2216a9af-d57f-4afa-b921-049bab581acd)
