### PR TITLE
fix(connect): HAWNG-1008 copy paste error

### DIFF
--- a/packages/hawtio/src/plugins/connect/discover/discover-service.ts
+++ b/packages/hawtio/src/plugins/connect/discover/discover-service.ts
@@ -122,7 +122,7 @@ class DiscoverService {
   agentToConnection(agent: Agent): Connection {
     const conn = {
       ...INITIAL_CONNECTION,
-      id: agent.agent_id ?? `discover-${agent.agent_id}`,
+      id: agent.agent_id ? `discover-${agent.agent_id}` : '',
       name: agent.agent_description ?? `discover-${agent.agent_id}`,
     }
     if (!agent.url) {


### PR DESCRIPTION
If agent.agent_id is undefined, it should always become 'discover-undefined'. Then it should be rather simply ''.