### PR TITLE
feat(camel): Improved tracer feature adding extra fields

### DIFF
--- a/packages/hawtio/src/plugins/camel/debug/debug-service.ts
+++ b/packages/hawtio/src/plugins/camel/debug/debug-service.ts
@@ -16,6 +16,12 @@ export interface MessageData {
   id: string | null
   uid: string
   timestamp: string
+  endpointUri?: string
+  isRemoteEndpoint?: string
+  elapsed?: string
+  endpointServiceUrl?: string
+  endpointServiceProtocol?: string
+  endpointServiceMetadata?: string
   headers: Record<string, string>
   headerTypes: Record<string, string>
   headerHtml: string
@@ -196,6 +202,13 @@ class DebugService {
   createMessageFromXml(exchange: Element): MessageData | null {
     const uid = childText(exchange, 'uid') || ''
     const timestamp = childText(exchange, 'timestamp') || ''
+    const endpointUri = childText(exchange, 'endpointUri') || ''
+    const isRemoteEndpoint = childText(exchange, 'remoteEndpoint') || ''
+    const elapsed = childText(exchange, 'elapsed') || ''
+    const endpointElement = exchange.querySelector('endpointService')
+    const endpointServiceUrl = (endpointElement && childText(endpointElement, 'serviceUrl')) || ''
+    const endpointServiceProtocol = (endpointElement && childText(endpointElement, 'serviceProtocol')) || ''
+    const endpointServiceMetadata = (endpointElement && childText(endpointElement, 'serviceMetadata')) || ''
 
     let message = exchange.querySelector('message')
     if (!message) {
@@ -239,7 +252,22 @@ class DebugService {
       bodyType = this.humanizeJavaType(bodyType)
     }
 
-    return { headers, headerTypes, id, uid, timestamp, headerHtml, body, bodyType }
+    return {
+      headers,
+      headerTypes,
+      id,
+      uid,
+      timestamp,
+      headerHtml,
+      body,
+      bodyType,
+      endpointUri,
+      isRemoteEndpoint,
+      elapsed,
+      endpointServiceUrl,
+      endpointServiceProtocol,
+      endpointServiceMetadata,
+    }
   }
 
   private getIdFromHeaders(headers: Record<string, string>): string {

--- a/packages/hawtio/src/plugins/camel/trace/Trace.tsx
+++ b/packages/hawtio/src/plugins/camel/trace/Trace.tsx
@@ -245,6 +245,12 @@ export const Trace: React.FunctionComponent = () => {
                           <Tr>
                             <Th>ID</Th>
                             <Th>To Node</Th>
+                            <Th>Elapsed</Th>
+                            <Th>Endpoint Uri</Th>
+                            <Th>Is Remote?</Th>
+                            <Th>Service Url</Th>
+                            <Th>Protocol</Th>
+                            <Th>Metadata</Th>
                           </Tr>
                         </Thead>
                         <Tbody isOddStriped>
@@ -260,6 +266,12 @@ export const Trace: React.FunctionComponent = () => {
                                 </Button>
                               </Td>
                               <Td dataLabel='ToNode'>{message.toNode}</Td>
+                              <Td dataLabel='Elapsed'>{message.elapsed}ms</Td>
+                              <Td dataLabel='EndpointUri'>{message.endpointUri}</Td>
+                              <Td dataLabel='IsRemote'>{message.isRemoteEndpoint}</Td>
+                              <Td dataLabel='ServiceUrl'>{message.endpointServiceUrl}</Td>
+                              <Td dataLabel='Protocol'>{message.endpointServiceProtocol}</Td>
+                              <Td dataLabel='Metadata'>{message.endpointServiceMetadata}</Td>
                             </Tr>
                           ))}
                         </Tbody>

--- a/packages/hawtio/src/plugins/camel/trace/Tracing.css
+++ b/packages/hawtio/src/plugins/camel/trace/Tracing.css
@@ -16,6 +16,7 @@
 #route-message-table-body {
   height: 100%;
   max-height: 60vh;
+  max-width: 40vw;
   overflow: auto;
 }
 


### PR DESCRIPTION
Fixes: https://github.com/hawtio/hawtio/issues/3526

Update: There was a breaking change in Camel 4.5, the property needed for the BacklogTracer to show now is camel.trace.enabled = true

I have already been able to test it. Here it's how it looks.

https://github.com/user-attachments/assets/dc4c702b-5559-478e-9d0e-1c04c44c532d

Previous draft comments:

Uploading as draft to get input @tadayosi as I can't get the tab to show to see if it works.

Original task: https://github.com/hawtio/hawtio/issues/3526

I have added the new fields requested by Claus

Implemented in Hawtio React as I believe is the front end for current Hawtio version, if I should update hawtio standalone/console please tell me and I'll get with it.

The XML format I have got from: https://github.com/apache/camel/blob/7d046c0016d7f5603444641cc02c6a20b9abeba4/core/camel-base-engine/src/main/java/org/apache/camel/impl/debugger/DefaultBacklogTracerEventMessage.java#L283, following the structure set in debug-service for Messages which as far as I've seen is the same structure/function for debug and tracer.

I would need to improve how the metadata is extracted, as it's a map structure and I'm just extracting the text. But for now that's something I'd like to do after seeing how the new table is shown in the tracer page, as I have only got the code to work with right now.

Other than that, that would be ready to test, the thing is I'm totally stuck trying to test it.

Now, what I need help (other than please clarify if I'm doing the work on the wrong place or anything else you see).

I'm unable to get the BacklogTracer bean to show up. 

Following the documentation https://camel.apache.org/manual/backlog-tracer.html#_enabling I have already enabled the tracer using the application properties file.

![image](https://github.com/user-attachments/assets/052bdde1-0efb-4393-85d3-ed8b2a33ffc9)

As you can see it's also in a comment in the examples themselves, so that should work.

Yet, it doesn't work. The generated bean is called DefaultTracer 

![image](https://github.com/user-attachments/assets/a2c5cfa2-e485-4cc1-9b3c-4c0481725528)

And it doesn't have the necessary getXML operation that's defined in the code for the tab to appear and from where we extract the information.

Things I have tried:

- Checking if Camel version is correct -> It's correct, version 4.10
- Trying different examples from Hawtio and Hawtio-examples
- Trying to run examples from Camel-examples trying to put the Actuator client like it's mentioned in hawtio docs.
- Reviewing the documentation for any string of this DefaultTracer -> No mention
- Reviewing Camel's codebase for any string of this DefaultTracer
  - There is classes for DefaultTracer https://github.com/apache/camel/blob/7d046c0016d7f5603444641cc02c6a20b9abeba4/core/camel-base-engine/src/main/java/org/apache/camel/impl/engine/DefaultTracer.java#L49
  - And BacklogTracer https://github.com/apache/camel/blob/7d046c0016d7f5603444641cc02c6a20b9abeba4/core/camel-base-engine/src/main/java/org/apache/camel/impl/debugger/BacklogTracer.java#L46
  - But I'm unaware where is the factory method that chooses which one to use.
  - DefaultTracer has also been updated more recently, along the lines of when the new fields where added to the messages (9-11 months on the GitBlame), but as you can see DefaultTracer doesn't have the XML export function

So far I don't know how to continue to get the BacklogTracer to show. It seems like some kind of regression bug but I heavily doubt that it went unnoticed for 5 versions, so I guess there is something I'm missing. But I can't find any more info on the docs. Could you lend a hand @tadayosi ?

I'll try to be awake extra early today to see if we can get into a call and show you, it might be easier to fix that way.

-> To add to that: there is https://github.com/hawtio/hawtio-next/blob/9175e678ee78f74d64d7c891143b4a7929a6a8dc/packages/hawtio/src/plugins/springboot/TraceView.tsx#L87 

- I would need to update it to use the new FilteredTables.
-  It seems this is for more general Trace from SpringBoot, not only Camel Springboot applications, so I think it doesn't apply to this ticket. - Yes I checked and it doesn't apply.

In any case I had the same problem where no info is shown at all, so I couldn't test it, but I would like confirmation before creating a new ticket to put the FilteredTable there.
