### PR TITLE
Addresses both node sizing and theming of application

### DIFF
--- a/packages/hawtio/src/Hawtio.tsx
+++ b/packages/hawtio/src/Hawtio.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { BrowserRouter, Route, Routes } from 'react-router-dom'
 import { hawtio } from './core'
 import './Hawtio.css'
@@ -15,6 +15,24 @@ export const Hawtio: React.FunctionComponent<HawtioProps> = props => {
   if (basepath) {
     hawtio.setBasePath(basepath)
   }
+
+  /*
+   * Initialise a window theme listener to update the application theme
+   * depending on the browser's chosen / default theme.
+   *
+   * Note: Will be ignored if a hawtio.disableThemeListener flag is set
+   * to true in localStorage.
+   */
+  hawtio.addWindowThemeListener()
+
+  useEffect(() => {
+    return () => {
+      /*
+       * Clean up the window listener on unmount
+       */
+      hawtio.removeWindowThemeListener()
+    }
+  }, [])
 
   return (
     <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }} basename={hawtio.getBasePath()}>

--- a/packages/hawtio/src/plugins/camel/route-diagram/RouteDiagram.css
+++ b/packages/hawtio/src/plugins/camel/route-diagram/RouteDiagram.css
@@ -1,3 +1,17 @@
+/*
+ * By default, in the light theme, define diagram variables
+ */
+:root {
+  --hawtio-diagram-node--BackgroundColor: #fafafa;
+}
+
+/*
+ * When the theme is dark override the diagram variables
+ */
+:where(.pf-v5-theme-dark):root {
+  --hawtio-diagram-node--BackgroundColor: #656565;
+}
+
 .react-flow__node-camel {
   height: 80px;
   width: 150px;
@@ -11,7 +25,7 @@
   grid-template-rows: 25% 25% 25% 25%; /* Now there are four rows */
   grid-template-columns: 40% 35% 25%;
   border: 2px solid #8a8d90;
-  background-color: #fafafa;
+  background-color: var(--hawtio-diagram-node--BackgroundColor);
   padding: 5px;
   height: 100px;
   min-width: 150px;
@@ -60,12 +74,54 @@
   justify-self: center;
 }
 
+/*
+ * Attribution logo box for ReactFlow is grey by default & doesn't
+ * change when theme becomes dark. So set the background color to a
+ * patternfly var that does change when the theme is updated.
+ */
+.react-flow__attribution {
+  background-color: var(--pf-v5-c-page__main-section--BackgroundColor) !important;
+}
+
+/*
+ * Attribution logo box's text colour does not change on dark theme
+ * update so change it to a subtle dark colour when the theme is updated
+ */
+:where(.pf-v5-theme-dark) .react-flow__attribution a {
+  color: var(--pf-v5-global--BackgroundColor--dark-200) !important;
+}
+
 .node-tooltip {
-  background-color: white;
   border: solid 1px black;
-  border-radius: 5px;
-  padding: 10px;
-  font-size: x-small;
+  border-radius: 1px;
+  font-size: xx-small;
+}
+
+.node-tooltip table tbody td {
+  padding-top: 1px;
+  padding-bottom: 1px;
+  padding-left: 3px;
+  padding-right: 3px;
+}
+
+.node-tooltip-odd-row {
+  background-color: var(--pf-v5-global--BackgroundColor--100);
+}
+
+.node-tooltip-odd-row td {
+  color: var(--pf-v5-global--Color--100);
+}
+
+.node-tooltip-even-row {
+  background-color: var(--pf-v5-global--BackgroundColor--200);
+}
+
+.node-tooltip-even-row td {
+  color: var(--pf-v5-global--Color--200);
+}
+
+.node-tooltip-value {
+  text-align: right;
 }
 
 .camel-route-diagram {

--- a/packages/hawtio/src/plugins/camel/route-diagram/RouteDiagram.tsx
+++ b/packages/hawtio/src/plugins/camel/route-diagram/RouteDiagram.tsx
@@ -234,37 +234,37 @@ const CamelNode: React.FunctionComponent<NodeProps<CamelNodeData>> = ({
             {data.stats && !showFull && (
               <Table variant={'compact'}>
                 <Tbody style={{ fontSize: 'xx-small' }}>
-                  <Tr>
+                  <Tr className={'node-tooltip-odd-row'}>
                     <Td>ID</Td>
-                    <Td>{data.stats.id}</Td>
+                    <Td className={'node-tooltip-value'}>{data.stats.id}</Td>
                   </Tr>
-                  <Tr>
+                  <Tr className={'node-tooltip-even-row'}>
                     <Td>Total</Td>
-                    <Td>{totalExchanges}</Td>
+                    <Td className={'node-tooltip-value'}>{totalExchanges}</Td>
                   </Tr>
-                  <Tr>
+                  <Tr className={'node-tooltip-odd-row'}>
                     <Td>Completed</Td>
-                    <Td>{data.stats?.exchangesCompleted}</Td>
+                    <Td className={'node-tooltip-value'}>{data.stats?.exchangesCompleted}</Td>
                   </Tr>
-                  <Tr>
+                  <Tr className={'node-tooltip-even-row'}>
                     <Td>Inflight</Td>
-                    <Td>{data.stats?.exchangesInflight}</Td>
+                    <Td className={'node-tooltip-value'}>{data.stats?.exchangesInflight}</Td>
                   </Tr>
-                  <Tr>
+                  <Tr className={'node-tooltip-odd-row'}>
                     <Td>Last</Td>
-                    <Td>{data.stats?.lastProcessingTime} (ms)</Td>
+                    <Td className={'node-tooltip-value'}>{data.stats?.lastProcessingTime} (ms)</Td>
                   </Tr>
-                  <Tr>
+                  <Tr className={'node-tooltip-even-row'}>
                     <Td>Mean</Td>
-                    <Td>{data.stats?.meanProcessingTime} (ms)</Td>
+                    <Td className={'node-tooltip-value'}>{data.stats?.meanProcessingTime} (ms)</Td>
                   </Tr>
-                  <Tr>
+                  <Tr className={'node-tooltip-odd-row'}>
                     <Td>Min</Td>
-                    <Td>{data.stats?.minProcessingTime} (ms)</Td>
+                    <Td className={'node-tooltip-value'}>{data.stats?.minProcessingTime} (ms)</Td>
                   </Tr>
-                  <Tr>
+                  <Tr className={'node-tooltip-even-row'}>
                     <Td>Max</Td>
-                    <Td>{data.stats?.maxProcessingTime} (ms)</Td>
+                    <Td className={'node-tooltip-value'}>{data.stats?.maxProcessingTime} (ms)</Td>
                   </Tr>
                 </Tbody>
               </Table>

--- a/packages/hawtio/src/plugins/camel/route-diagram/visualization-service.ts
+++ b/packages/hawtio/src/plugins/camel/route-diagram/visualization-service.ts
@@ -28,6 +28,13 @@ export type CamelNodeData = {
   nodeClicked?: (node: Node) => void
 }
 
+export type Bounds = {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
 class VisualizationService {
   dagreGraph: dagre.graphlib.Graph
   nodeWidth = 250
@@ -46,6 +53,7 @@ class VisualizationService {
   getLayoutedElements(
     nodes: Node[],
     edges: Edge[],
+    bounds: Bounds,
     direction = 'TB',
   ): { layoutedNodes: Node[]; layoutedEdges: Edge[] } {
     const isHorizontal = direction === 'LR'
@@ -58,7 +66,7 @@ class VisualizationService {
     edges.forEach(edge => {
       this.dagreGraph.setEdge(edge.source, edge.target)
     })
-    dagre.layout(this.dagreGraph)
+    dagre.layout(this.dagreGraph, { width: this.nodeWidth, height: this.nodeHeight })
 
     nodes.forEach(node => {
       const nodeWithPosition = this.dagreGraph.node(node.id)
@@ -68,9 +76,17 @@ class VisualizationService {
       // We are shifting the dagre node position (anchor=center center) to the top left
       // so it matches the React Flow node anchor point (top left).
 
+      let posX = bounds.width / 2 - this.margin.left
+      let posY = nodeWithPosition.y - this.nodeHeight / 2 + this.margin.top
+
+      if (isHorizontal) {
+        posX = nodeWithPosition.x - this.nodeWidth / 2 + this.margin.left
+        posY = bounds.height / 2 - this.margin.top
+      }
+
       node.position = {
-        x: nodeWithPosition.x - this.nodeWidth / 2 + this.margin.left,
-        y: nodeWithPosition.y - this.nodeHeight / 2 + this.margin.top,
+        x: posX,
+        y: posY,
       }
     })
 

--- a/packages/hawtio/src/setupTests.ts
+++ b/packages/hawtio/src/setupTests.ts
@@ -30,3 +30,18 @@ declare const global: any
 Object.defineProperty(global, 'crypto', { value: crypto.webcrypto })
 global.TextEncoder = TextEncoder
 global.TextDecoder = TextDecoder
+
+// For mocking window matchMedia function
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // Deprecated
+    removeListener: jest.fn(), // Deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+})


### PR DESCRIPTION
Apologies this is 2 commits for 2 issues but if they are submitted separately then one or other would have to be rebased once one was merged. Therefore, if you can indulge me and review the 2 commits separately for 1 PR, I'd appreciate it.

Commits

1.  fix: Aligns the size of the camel diagram content with parent bounds (#1543)
    * When opening the route diagram, gets the bounds of the parent div and
      creates the camel nodes in proportion and centres them appropriately
    * RouteDiagram.tsx
      * Splits the diagram component to provide an outer div with a reference
         that can maintain the bound box dimensions. The inner
         ReactFlowRouteDiagram is then refreshed with the correctly sized nodes
         and 'onLoad' sizes the viewport correctly using the reference's bounds
         before fitting the view.

2.  fix: Aligns the theme of the application with browser setting (#1542)
    
    * Camel Diagram
      * Colours the node popup table (odd/even) according to the theme of the
        browser
      * Reduces the padding of the table to make the popup not so prominent and
        more in keeping with the size of the diagram nodes
      * Defines the hawtio-diagram-node--BackgroundColor var to determine the
        background colour of the nodes by default or and if mode is dark
    
    *  theme.ts
      * Defines a window listener that updates the html class to the requisite
        Patternfly class (see [1]) if the browser theme is changed
      * Adds a localStorage flag if clients want to disable this functionality
         * hawtio.disableThemeListener = true in LocalStorage
    
     * index.ts
       * Initialises the theme listener when the library is loaded
    
    [1] https://www.patternfly.org/developer-resources/dark-theme-handbook/#enabling-dark-theme


