### PR TITLE
Changes the test app source map generation to reduce the memory footprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,30 @@ yarn lint && yarn format:check
 
 Read [Running E2E tests locally](./docs/e2e.md).
 
+### Debugging with Source-Maps
+
+When `yarn start` is run, the test application located in
+[app](https://github.com/hawtio/hawtio-next/tree/main/app) is the project actually
+executed. This uses [webpack](https://webpack.js.org) for the bundling of project
+compiled source and assets. By default, webpack has been configured to not generate any
+[source-maps](https://webpack.js.org/guides/development/#using-source-maps) since these
+are often unnecessary for development and can make the application memory-intensive.
+
+However, there maybe an occasion when the developer needs to debug an issue during
+runtime in the browser and as such source-maps can be vital. Therefore, in this use-case,
+the developer should update the webpack
+[configuration file](https://github.com/hawtio/hawtio-next/blob/main/app/webpack.config.cjs) and
+specifically change the `devtool`
+[property](https://github.com/hawtio/hawtio-next/blob/main/app/webpack.config.cjs#L25) in
+order to generate source-maps. The property should be modified to a value consistent with
+the information provided by the
+[webpack documentation](https://webpack.js.org/configuration/devtool#devtool), eg.
+`source-map` may be a good start while `eval-source-map` can be helpful for very tricky
+debugging problems but is the most memory-intensive.
+
+Once the configuration file is updated, `yarn start` should be re-run and the source-maps
+should then be available to use in the host browser.
+
 ### Contributing
 
 When making a PR E2E tests from hawtio/hawtio will be run against your frontend.

--- a/app/webpack.config.cjs
+++ b/app/webpack.config.cjs
@@ -14,7 +14,15 @@ module.exports = (_, args) => {
   const isProduction = args.mode === 'production'
   return {
     entry: './src/index',
-    devtool: 'eval-source-map',
+
+    /*
+     * To debug in development with source maps
+     * update accordingly
+     *
+     * For other alternatives see
+     * https://webpack.js.org/configuration/devtool
+     */
+    devtool: isProduction ? 'source-map' : false,
     plugins: [
       new ModuleFederationPlugin({
         name: 'app',


### PR DESCRIPTION
* eval-source-map is heavy on memory and not meant for production. See https://webpack.js.org/configuration/devtool

* For development, this option can be changed locally if developers require it. Most of the time, it seems people do not so disable entirely