### PR TITLE
fix: Sort out the node alignment to support all node diagrams (#1543)

### DIFF
--- a/packages/hawtio/src/plugins/camel/CamelContent.css
+++ b/packages/hawtio/src/plugins/camel/CamelContent.css
@@ -7,9 +7,14 @@
 }
 #camel-content {
   height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 #camel-content-header > #camel-contexts-toolbar {
   float: right;
   padding-top: 0;
   padding-bottom: 0.5em;
+}
+#camel-content-main {
+  flex-grow: 1;
 }

--- a/packages/hawtio/src/plugins/camel/route-diagram/RouteDiagram.css
+++ b/packages/hawtio/src/plugins/camel/route-diagram/RouteDiagram.css
@@ -124,13 +124,16 @@
   text-align: right;
 }
 
+#camel-route-diagram-outer-div {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+}
+
 .camel-route-diagram {
   flex-grow: 1;
   position: relative;
-  /* 230px representss size of hawtio bar, panel header,tab  navigation,and footer  */
-  height: calc(100vh - 230px);
-  min-height: 50vh;
-  max-height: calc(100vh - 230px);
   width: 100%;
 }
 

--- a/packages/hawtio/src/plugins/camel/route-diagram/visualization-service.ts
+++ b/packages/hawtio/src/plugins/camel/route-diagram/visualization-service.ts
@@ -28,13 +28,6 @@ export type CamelNodeData = {
   nodeClicked?: (node: Node) => void
 }
 
-export type Bounds = {
-  x: number
-  y: number
-  width: number
-  height: number
-}
-
 class VisualizationService {
   dagreGraph: dagre.graphlib.Graph
   nodeWidth = 250
@@ -53,7 +46,6 @@ class VisualizationService {
   getLayoutedElements(
     nodes: Node[],
     edges: Edge[],
-    bounds: Bounds,
     direction = 'TB',
   ): { layoutedNodes: Node[]; layoutedEdges: Edge[] } {
     const isHorizontal = direction === 'LR'
@@ -76,17 +68,9 @@ class VisualizationService {
       // We are shifting the dagre node position (anchor=center center) to the top left
       // so it matches the React Flow node anchor point (top left).
 
-      let posX = bounds.width / 2 - this.margin.left
-      let posY = nodeWithPosition.y - this.nodeHeight / 2 + this.margin.top
-
-      if (isHorizontal) {
-        posX = nodeWithPosition.x - this.nodeWidth / 2 + this.margin.left
-        posY = bounds.height / 2 - this.margin.top
-      }
-
       node.position = {
-        x: posX,
-        y: posY,
+        x: nodeWithPosition.x - this.nodeWidth / 2 + this.margin.left,
+        y: nodeWithPosition.y - this.nodeHeight / 2 + this.margin.top,
       }
     })
 


### PR DESCRIPTION
* Fits the view, zooms and centres nodes correctly in both Routes and Route diagrams

* visualization-service.ts
  * Reverts to previous version prior to c1520188b

* RouteDiagram.tsx
  * Moves all state back into single component although retains the outer RouteDiagram to allow for the use of the ReactFlowProvider which is required for the useReactFlow and useNodesInitialized hooks
  * Adds useEffect on nodesInitialized - only when true is fitView called as this ensures the nodes have been given their dimensions. Calling any sooner, fitView does not work properly (see [1])
  * Separate out the refreshing of stats from the loading of nodes

* RouteDiagram.css
  * Removes absolute measurements in view height to ensure the portability of the component and ensures that fitView correctly renders the viewport correctly

[1] https://github.com/xyflow/xyflow/issues/533