### PR TITLE
fix: Makes the showVerticalNav preference shown only if sidebar is visible

### DIFF
--- a/packages/hawtio/src/preferences/HomePreferences.tsx
+++ b/packages/hawtio/src/preferences/HomePreferences.tsx
@@ -15,19 +15,31 @@ import {
 import React, { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { preferencesService } from './preferences-service'
+import { useHawtconfig } from '@hawtiosrc/core'
+import { HawtioLoadingPage } from '@hawtiosrc/ui'
 
-export const HomePreferences: React.FunctionComponent = () => (
-  <CardBody>
-    <Form isHorizontal>
-      <FormSection title='UI' titleElement='h2'>
-        <UIForm />
-      </FormSection>
-      <FormSection title='Reset' titleElement='h2'>
-        <ResetForm />
-      </FormSection>
-    </Form>
-  </CardBody>
-)
+export const HomePreferences: React.FunctionComponent = () => {
+  const { hawtconfig, hawtconfigLoaded } = useHawtconfig()
+
+  if (!hawtconfigLoaded) return <HawtioLoadingPage />
+
+  const sideBarShown = hawtconfig.appearance?.showSideBar ?? true
+
+  return (
+    <CardBody>
+      <Form isHorizontal>
+        {sideBarShown && (
+          <FormSection title='UI' titleElement='h2'>
+            <UIForm />
+          </FormSection>
+        )}
+        <FormSection title='Reset' titleElement='h2'>
+          <ResetForm />
+        </FormSection>
+      </Form>
+    </CardBody>
+  )
+}
 
 const UIForm: React.FunctionComponent = () => {
   const [showVerticalNav, setShowVerticalNav] = useState(preferencesService.isShowVerticalNavByDefault())


### PR DESCRIPTION
If the hawtconfig.json has disabled the sidebar, eg. in the console-plugin, then the preference for setting the sidebar as shown/collapsed is irrelevant. Better to not display it at all. 