### PR TITLE
build: Add ESM build alongside CJS for hawtio-next

### DIFF
--- a/packages/backend-middleware/package.json
+++ b/packages/backend-middleware/package.json
@@ -2,9 +2,13 @@
   "name": "@hawtio/backend-middleware",
   "version": "1.0.7",
   "description": "An Express middleware that implements Hawtio backend",
-  "main": "build/main/index.js",
-  "typings": "build/main/index.d.ts",
-  "module": "build/module/index.js",
+  "exports": {
+    ".": {
+      "types": "./build/main/index.d.ts",
+      "require": "./build/main/index.js",
+      "import": "./build/module/index.js"
+    }
+  },
   "author": "Hawtio developer team",
   "license": "Apache-2.0",
   "files": [

--- a/packages/hawtio/package.json
+++ b/packages/hawtio/package.json
@@ -2,22 +2,21 @@
   "name": "@hawtio/react",
   "version": "1.10.2",
   "description": "A Hawtio reimplementation based on TypeScript + React.",
-  "main": "./dist/index.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
-      "default": "./dist/index.js"
+      "import": "./dist/index.mjs"
     },
     "./init": {
       "types": "./dist/init.d.ts",
       "require": "./dist/init.js",
-      "default": "./dist/init.js"
+      "import": "./dist/init.mjs"
     },
     "./ui": {
       "types": "./dist/ui/index.d.ts",
       "require": "./dist/ui/index.js",
-      "default": "./dist/ui/index.js"
+      "import": "./dist/ui/index.mjs"
     },
     "./dist/index.css": {
       "default": "./dist/index.css"

--- a/packages/hawtio/tsup.config.ts
+++ b/packages/hawtio/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   target: 'esnext',
   dts: true,
   sourcemap: true,
-  format: 'cjs',
+  format: ["esm", "cjs"],
   splitting: true,
   loader: {
     '.svg': 'dataurl',


### PR DESCRIPTION
This is just a working example - right now backend-middleware already builds CJS + ESM in separate folders (main and module).
I used .js and .mjs extensions in the same "dist" folder for hawtio-next. I'm not sure which is best - same folder or separate folders. The maintainers should decide on this anyway.
I also got rid of "main", "typings" and "module" top-level keys in package json and only used "exports".

According to the docs:
https://nodejs.org/api/packages.html#main

This decreases the bundle sizes and should also help with tree-shaking "downstream".

More info about export:
> When a package has an "exports" field, this will take precedence over the "main" field when importing the package by name.
> 
> The "exports" field allows defining the entry points of a package when imported by name loaded either via a node_modules lookup or a self-reference to its own name. It is supported in Node.js 12+ as an alternative to the "main" that can support defining subpath exports and conditional exports while encapsulating internal unexported modules.
> Conditional Exports can also be used within "exports" to define different package entry points per environment, including whether the package is referenced via require or via import.


