### PR TITLE
HAWNG-1248: Handles error conditions on Route XML loading failures

### DIFF
--- a/packages/hawtio/src/util/xml.ts
+++ b/packages/hawtio/src/util/xml.ts
@@ -6,7 +6,14 @@ export function parseXML(xml: string): XMLDocument {
   if (!window.DOMParser) throw new Error('Cannot parse xml due to no available native parser')
 
   const parser = new DOMParser()
-  return parser.parseFromString(xml, 'text/xml')
+  const doc = parser.parseFromString(xml, 'text/xml')
+
+  const errorNode = doc.querySelector('parsererror')
+  if (errorNode) {
+    throw new Error(`Failed to parse XML: ${errorNode.textContent}`)
+  }
+
+  return doc
 }
 
 export function xmlText(element: Element): string | null {


### PR DESCRIPTION
* xml.ts
  * If an error has occurred in the parsing of the XML, ensure this is thrown by the parse function and not remained hidden in the XML Doc

* RouteDiagram.tsx
  * Better handle XML parsing errors. Rather than just a blank screen, displays an error message conveying the problem in an error in the diagram canvas.