### PR TITLE
feat(camel): make it possible to quickly enable/disable EIPs for Camel 4.14+

### DIFF
--- a/packages/hawtio/src/plugins/camel/route-diagram/RouteDiagram.css
+++ b/packages/hawtio/src/plugins/camel/route-diagram/RouteDiagram.css
@@ -20,9 +20,11 @@
   align-items: center;
   justify-content: center;
 }
+
 .react-flow__node-camel .camel-node-content {
   display: grid;
-  grid-template-rows: 25% 25% 25% 25%; /* Now there are four rows */
+  /* Now there are four rows */
+  grid-template-rows: 25% 25% 25% 25%;
   grid-template-columns: 40% 35% 25%;
   border: 2px solid #8a8d90;
   background-color: var(--hawtio-diagram-node--BackgroundColor);
@@ -68,6 +70,7 @@
   grid-column: 1 / 4;
   justify-self: center;
 }
+
 .react-flow__node-camel .camel-node-content .camel-node-id {
   grid-row: 4 / 5;
   grid-column: 1 / 4;
@@ -138,5 +141,9 @@
 }
 
 .highlighted {
-  border-color: red !important;
+  border-color: var(--pf-v5-global--primary-color--100) !important;
+}
+
+.disabled {
+  background-color: var(--pf-v5-global--disabled-color--200) !important;
 }

--- a/packages/hawtio/src/plugins/camel/route-diagram/visualization-service.ts
+++ b/packages/hawtio/src/plugins/camel/route-diagram/visualization-service.ts
@@ -1,11 +1,11 @@
-import { routesService, RouteStats, Statistics } from '@hawtiosrc/plugins/camel/routes-service'
-import { schemaService } from '@hawtiosrc/plugins/camel/schema-service'
 import { MBeanNode } from '@hawtiosrc/plugins/shared'
 import { parseXML } from '@hawtiosrc/util/xml'
 import dagre from 'dagre'
 import { ReactNode } from 'react'
 import { Edge, MarkerType, Node, Position } from 'reactflow'
 import { camelPreferencesService } from '../camel-preferences-service'
+import { routesService, RouteStats, Statistics } from '../routes-service'
+import { schemaService } from '../schema-service'
 
 export type CamelNodeData = {
   id: string
@@ -14,6 +14,7 @@ export type CamelNodeData = {
   label: string
   labelSummary: string
   group: 1
+  disabled: boolean
 
   elementId: string | null
   imageUrl: ReactNode
@@ -143,6 +144,7 @@ class VisualizationService {
       }
       const pStats = routeStat?.processorStats.find(p => node.data.cid === p.id)
       const newData = { ...node.data, stats: pStats }
+      newData.disabled = pStats?.disabled === 'true'
       return { ...node, data: newData }
     })
   }
@@ -186,14 +188,14 @@ class VisualizationService {
           tooltip += ' ' + uri
         }
         const { ignoreIdForLabel, maximumLabelWidth } = camelPreferencesService.loadOptions()
-        const elementID = routeElement.getAttribute('id')
+        const elementId = routeElement.getAttribute('id')
         let labelSummary = label
-        if (elementID) {
+        if (elementId) {
           const customId = routeElement.getAttribute('customId')
           if (ignoreIdForLabel || !customId || customId === 'false') {
-            labelSummary = 'id: ' + elementID
+            labelSummary = 'id: ' + elementId
           } else {
-            label = elementID
+            label = elementId
           }
         }
         // lets check if we need to trim the label
@@ -220,19 +222,20 @@ class VisualizationService {
         let cid = routeElement.getAttribute('_cid') || routeElement.getAttribute('id')
         const parallelProcessing: boolean = routeElement.getAttribute('parallelProcessing')?.toLowerCase() === 'true'
         nodeData = {
-          id: id,
-          routeIdx: routeIdx,
+          id,
+          routeIdx,
           name: nodeId,
-          label: label,
-          labelSummary: labelSummary,
+          label,
+          labelSummary,
           group: 1,
-          elementId: elementID,
-          imageUrl: imageUrl,
+          disabled: false,
+          elementId,
+          imageUrl,
           cid: cid ?? id,
-          tooltip: tooltip,
+          tooltip,
           type: nodeId,
           uri: uri ?? '',
-          routeId: routeId,
+          routeId,
           isParallel: parallelProcessing,
         }
 

--- a/packages/hawtio/src/plugins/camel/routes-service.ts
+++ b/packages/hawtio/src/plugins/camel/routes-service.ts
@@ -40,6 +40,8 @@ export type Statistics = {
 export type ProcessorStats = Statistics & {
   index?: string
   sourceLineNumber?: string
+  // Available in Camel 4.14 and later
+  disabled?: string
 }
 
 export type RouteStats = Statistics & {


### PR DESCRIPTION
Fix #1644

With the PR, we can now disable/enable each node in the routes like this

https://github.com/user-attachments/assets/4e3e4aa2-7f32-483a-8bc7-51c2ad5e32da


