### PR TITLE
Add readSpecifiedAttributes function to jolokia-service

### DIFF
--- a/packages/hawtio/src/plugins/shared/__mocks__/jolokia-service.ts
+++ b/packages/hawtio/src/plugins/shared/__mocks__/jolokia-service.ts
@@ -46,6 +46,10 @@ class MockJolokiaService implements IJolokiaService {
     return null
   }
 
+  async readSpecifiedAttributes(_mbean: string, _attributes: string[]): Promise<AttributeValues> {
+    return {}
+  }
+
   async writeAttribute(_mbean: string, _attribute: string, _value: unknown): Promise<unknown> {
     return null
   }


### PR DESCRIPTION
I'd like to add a function which allows for gathering specific properties from a mbean.

Currently there's only 2 options for getting _n_ properties from a mbean:
- get all properties and filter out what's needed later
- get _n_ single properties by making _n_ calls

The first option is used in different parts of activemq artemis console and that's what led me down this path. The more queues and addresses there are, the more resource intensive the call
I also don't want to use a new network call for every new property, especially since jolokia can handle many attributes inside one request - hence this PR.

In the case of activemq artemis console, the call for all properties is being executed periodically, but we only need 8 properties which we get out of the response. When testing, this call produces 20kb of data for 1000 addresses, each with 1 queue - generating unnecessary load. The call takes ~8ms. After "filtering" and using readSpecifiedAttributes, the call is less than 1kB in size and takes ~1ms.
