### PR TITLE
Ensures route elements only are checked when processing route XML (#1866)

### DIFF
--- a/packages/hawtio/src/plugins/camel/route-stats-service.ts
+++ b/packages/hawtio/src/plugins/camel/route-stats-service.ts
@@ -181,8 +181,20 @@ class RouteStatsService {
    */
   processRouteXml(xml: string, routeNode: MBeanNode): Element {
     const doc = parseXML(xml)
-    const routeXml = doc.getElementById(routeNode.name)
-    if (!routeXml || routeXml.tagName?.toLowerCase() !== 'route') {
+
+    /*
+     * Fetches route elements and then checks the tag id property
+     * This is superior to fetching an element by id as it is possible
+     * that other types of elements have the same id, which camel allows.
+     */
+
+    // Get all elements that are <route> tags
+    const routes = doc.getElementsByTagName('route')
+
+    // Find any single route than specifically matches the node id
+    const routeXml = Array.from(routes).find(r => r.id === routeNode.name)
+
+    if (!routeXml) {
       throw new Error(`No routes named '${routeNode.name}' found in the routes xml`)
     }
     return routeXml


### PR DESCRIPTION
* It is possible for a Camel route source to contain different element types that have the same identifier property. Camel's registry allows this. Therefore, Hawtio should handle this too.

* doc.getElementById() fetches the first element with the requested id and if this is not a route then an exception is incorrectly thrown.

* Changes logic of processRouteXml to fetch all route tagged elements then check if one of them has the required node name. This does not produce the false-negative of 'hiding' a route with an id the same as another elemnent of a different type.