### PR TITLE
[E2E] Fix the e2e workflow file.

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -96,16 +96,16 @@ jobs:
         env:
           body: ${{ github.event.pull_request.body || ''}}
         run: |
-          if [[ "${body}" =~ \`branch:[[:space:]]([[:alnum:]\/_.-]+)(:([[:alnum:]\/_.-]+))?\` ]]; then
+          if [[ "${body}" =~ branch:[[:space:]]([[:alnum:]\/_.-]+)(:([[:alnum:]\/_.-]+))? ]]; then
             if [ -z "${BASH_REMATCH[2]}" ]; then
               echo "repo=hawtio/hawtio" >> $GITHUB_OUTPUT
               echo "branch=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
             else
               echo "repo=${BASH_REMATCH[1]}/hawtio" >> $GITHUB_OUTPUT
-              echo "branch=${BASH_REMATCH[2]:1}" >> $GITHUB_OUTPUT
+              echo "branch=${BASH_REMATCH[3]}" >> $GITHUB_OUTPUT
             fi
           else
-            branch=${{env.HAWTIO_BRANCH}}
+            branch="${HAWTIO_BRANCH}"
             app_image=quay.io/hawtio/hawtio-${{ matrix.runtime }}-test-app:$branch-${{ matrix.java }}
             testsuite_image=quay.io/hawtio/hawtio-test-suite:$branch-${{ matrix.java }}
 


### PR DESCRIPTION
This PR fixes an issue where incorrect syntax in the workflow file caused test app images to be selected incorrectly during github actions.

It should definitely help to pass checks in this PR - https://github.com/hawtio/hawtio-react/pull/1905 - as checking the logs I noticed that 4.x images were used for testing (with older PF version) instead of newer 5.x images.