### PR TITLE
fix(jmx): Parse MBean names using parser, not RegExp (fixes #1952)

### DIFF
--- a/packages/hawtio/src/plugins/shared/tree/node.test.ts
+++ b/packages/hawtio/src/plugins/shared/tree/node.test.ts
@@ -1,6 +1,6 @@
 import { userService } from '@hawtiosrc/auth'
 import { workspace } from '../workspace'
-import { Icons, MBeanNode, PropertyList } from './node'
+import { Icons, MBeanNode, PropertyList, parseMBeanName } from './node'
 import { MBeanTree } from './tree'
 
 jest.mock('@hawtiosrc/plugins/shared/jolokia-service')
@@ -266,6 +266,141 @@ describe('PropertyList', () => {
     const node = new MBeanNode(null, 'org.apache.camel', false)
     const propList = new PropertyList(node, 'context=SampleContext,type=context,name="SampleCamel"')
     expect(propList.objectName()).toEqual('org.apache.camel:context=SampleContext,type=context,name="SampleCamel"')
+  })
+
+  test('complexObjectNames', () => {
+    const node = new MBeanNode(null, 'org.apache.activemq.artemis', true)
+    const propList = new PropertyList(
+      node,
+      'broker="0.0.0.0",component=addresses,address="\\"\'<>",subcomponent=queues,routing-type="anycast",queue="\\"abc/def\\\\ghi.\\*.xxx\\""',
+    )
+    expect(propList.objectName()).toEqual(
+      'org.apache.activemq.artemis:broker="0.0.0.0",component=addresses,address="\\"\'<>",subcomponent=queues,routing-type="anycast",queue="\\"abc/def\\\\ghi.\\*.xxx\\""',
+    )
+    expect(propList.getPaths()).toEqual(['0.0.0.0', 'addresses', '"\'<>', 'queues', 'anycast', '"abc/def\\ghi.*.xxx"'])
+  })
+
+  test('parsingNames', () => {
+    let name = parseMBeanName('com.example:a=b')
+    expect(name.domain).toEqual('com.example')
+    expect(name.properties['a']).toEqual('b')
+    name = parseMBeanName('com.example:a=b,c=d')
+    expect(name.domain).toEqual('com.example')
+    expect(name.properties['c']).toEqual('d')
+
+    name = parseMBeanName('com.example:a=')
+    expect(name.domain).toEqual('com.example')
+    expect(name.properties['a']).toEqual('')
+    name = parseMBeanName('com.example:a=,c=d')
+    expect(name.domain).toEqual('com.example')
+    expect(name.properties['a']).toEqual('')
+    expect(name.properties['c']).toEqual('d')
+    name = parseMBeanName('com.example:a=,c=')
+    expect(name.domain).toEqual('com.example')
+    expect(name.properties['a']).toEqual('')
+    expect(name.properties['c']).toEqual('')
+
+    name = parseMBeanName('com.example:\\"a=b')
+    expect(name.properties['\\"a']).toEqual('b')
+
+    name = parseMBeanName('com.example:a="b=b"')
+    expect(name.properties['a']).toEqual('"b=b"')
+    expect(name.paths[0]!.value).toEqual('b=b')
+
+    name = parseMBeanName('com.example:a="\\"\\*\\?\\\\xxx\\n"')
+    expect(name.properties['a']).toEqual('"\\"\\*\\?\\\\xxx\\n"')
+    expect(name.paths[0]!.value).toEqual('"*?\\xxx\n')
+
+    expect(() => parseMBeanName('com.example:a=b=b')).toThrow()
+    expect(() => parseMBeanName('com.example:a')).toThrow()
+    expect(() => parseMBeanName('com.example:=a')).toThrow()
+    expect(() => parseMBeanName('com.example:a=\\"x')).toThrow()
+    expect(() => parseMBeanName('com.example:a=1,a=2')).toThrow()
+    expect(() => parseMBeanName('com.example:a=1,b=2,')).toThrow()
+  })
+
+  describe('parseMBeanName-ChatGPT', () => {
+    test('basic key=value parsing', () => {
+      const name = parseMBeanName('com.example:a=1,b=2')
+      expect(name.domain).toBe('com.example')
+      expect(name.properties).toEqual({ a: '1', b: '2' })
+      expect(name.paths).toEqual([
+        { key: 'a', value: '1' },
+        { key: 'b', value: '2' },
+      ])
+    })
+
+    test('empty value is allowed', () => {
+      const name = parseMBeanName('com.example:a=')
+      expect(name.properties['a']).toBe('')
+      expect(name.paths[0]!.value).toBe('')
+    })
+
+    test('quoted value parsing with escapes', () => {
+      const name = parseMBeanName('com.example:a="\\"*?\\\\n"')
+      expect(name.properties['a']).toBe('"\\"*?\\\\n"')
+      expect(name.paths[0]!.value).toBe('"*?\\n')
+    })
+
+    test('mixed quoted and unquoted', () => {
+      const name = parseMBeanName('com.example:a="quoted",b=unquoted')
+      expect(name.properties).toEqual({ a: '"quoted"', b: 'unquoted' })
+      expect(name.paths).toEqual([
+        { key: 'a', value: 'quoted' },
+        { key: 'b', value: 'unquoted' },
+      ])
+    })
+
+    test('duplicate key throws', () => {
+      expect(() => parseMBeanName('com.example:a=1,a=2')).toThrow(/duplicate key/)
+    })
+
+    test('missing key throws', () => {
+      expect(() => parseMBeanName('com.example:=1')).toThrow(/missing key value/)
+      const name = parseMBeanName('com.example:')
+      expect(name.paths).toEqual([])
+      expect(name.properties).toEqual({})
+    })
+
+    test('illegal characters in key throw', () => {
+      const illegal = [',', '?', '*', ':']
+      illegal.forEach(char => {
+        expect(() => parseMBeanName(`com.example:a${char}=1`)).toThrow(new RegExp(`'${char}' not allowed in the key`))
+      })
+    })
+
+    test('illegal characters in unquoted value throw', () => {
+      const illegal = ['=', ':', '"']
+      illegal.forEach(char => {
+        expect(() => parseMBeanName(`com.example:a=foo${char}bar`)).toThrow(new RegExp(`can't contain '${char}'`))
+      })
+    })
+
+    test('trailing comma throws', () => {
+      expect(() => parseMBeanName('com.example:a=1,')).toThrow(/trailing comma/)
+    })
+
+    test('missing closing quote throws', () => {
+      expect(() => parseMBeanName('com.example:a="unclosed')).toThrow(/missing closing quote/)
+    })
+
+    test('illegal escape throws', () => {
+      expect(() => parseMBeanName('com.example:a="\\x"')).toThrow(/illegal escape character/)
+    })
+
+    test('domain with newline throws', () => {
+      expect(() => parseMBeanName('com\n.example:a=1')).toThrow(/domain should not include new line/)
+    })
+
+    test('complex real-world example', () => {
+      const objName =
+        'org.apache.activemq.artemis:broker="0.0.0.0",component=addresses,address="\\"\'<>",subcomponent=queues,routing-type="anycast",queue="\\"abc/def\\\\ghi.\\*.xxx\\""'
+      const parsed = parseMBeanName(objName)
+      expect(parsed.domain).toBe('org.apache.activemq.artemis')
+      expect(parsed.properties['broker']).toBe('"0.0.0.0"')
+      expect(parsed.properties['address']).toBe('"\\"\'<>"')
+      expect(parsed.paths.find(p => p.key === 'queue')!.value).toBe('"abc/def\\ghi.*.xxx"')
+    })
   })
 
   test('getPaths', () => {

--- a/packages/hawtio/src/plugins/shared/tree/node.ts
+++ b/packages/hawtio/src/plugins/shared/tree/node.ts
@@ -806,8 +806,14 @@ export class PropertyList {
 
   match(properties: Record<string, string>): boolean {
     return Object.entries(properties).every(([key, value]) => {
+      // match by unquoted/unescaped values
       const thisIndex = this.paths.findIndex(e => e.key === key)
-      return thisIndex >= 0 && matchWithWildcard(this.paths[thisIndex]!.value, value)
+      if (thisIndex >= 0 && matchWithWildcard(this.paths[thisIndex]!.value, value)) {
+        return true
+      }
+      // match by quoted/escaped values
+      const thisValue = this.properties[key]
+      return thisValue && matchWithWildcard(thisValue, value)
     })
   }
 

--- a/packages/hawtio/src/plugins/shared/tree/node.ts
+++ b/packages/hawtio/src/plugins/shared/tree/node.ts
@@ -1,6 +1,6 @@
-import { escapeHtmlId, escapeTags } from '@hawtiosrc/util/htmls'
+import { escapeHtmlId } from '@hawtiosrc/util/htmls'
 import { isEmpty } from '@hawtiosrc/util/objects'
-import { matchWithWildcard, stringSorter, trimQuotes } from '@hawtiosrc/util/strings'
+import { matchWithWildcard, stringSorter } from '@hawtiosrc/util/strings'
 import { type TreeViewDataItem } from '@patternfly/react-core'
 import { CubeIcon } from '@patternfly/react-icons/dist/esm/icons/cube-icon'
 import { FolderIcon } from '@patternfly/react-icons/dist/esm/icons/folder-icon'
@@ -598,6 +598,145 @@ export class MBeanNode implements TreeViewDataItem {
   }
 }
 
+export type MBeanName = {
+  domain?: string
+  // unordered map of key-values directly from javax.management.ObjectName#getKeyPropertyList()
+  // the values, when quoted are kept quoted (see javax.management.ObjectName#quote())
+  properties: Record<string, string>
+  // ordered (sometimes reordered by Hawtio) array of key-value pairs, where values are always unquoted
+  // (for display purpose)
+  paths: { key: string; value: string }[]
+}
+
+/**
+ * Parses a full ObjectName according to `javax.management.ObjectName` grammar
+ * @param name
+ */
+export function parseMBeanName(name: string): MBeanName {
+  const colon = name.indexOf(':')
+  if (colon === -1) {
+    throw new Error('Illegal ObjectName')
+  }
+
+  // there's no doubt here
+  const domain = name.substring(0, colon)
+  if (domain.includes('\n')) {
+    throw new Error('Illegal Object name - domain should not include new line characters')
+  }
+  const propsString = name.substring(colon + 1)
+
+  return { ...parseMBeanPropertyList(propsString), domain }
+}
+
+/**
+ * Parses the key=value list of an ObjectName according to `javax.management.ObjectName` grammar
+ * @param propsString
+ */
+export function parseMBeanPropertyList(propsString: string): MBeanName {
+  const res: MBeanName = { properties: {}, paths: [] }
+
+  let i = 0
+  const len = propsString.length
+
+  while (i < len) {
+    let key = ''
+    let value = ''
+    let rawValue = ''
+
+    // key
+    while (i < len && propsString[i] !== '=') {
+      const c = propsString[i]
+      if (',?*:'.includes(c!)) {
+        throw new Error("Illegal ObjectName - '" + c + "' not allowed in the key")
+      }
+      key += c
+      i++
+    }
+    if (i == len || key === '') {
+      throw new Error('Illegal ObjectName - missing key value')
+    }
+    i++
+
+    if (propsString[i] == '"') {
+      i++
+      value += '"'
+      // quoted value
+      while (i < len && propsString[i] !== '"') {
+        const c = propsString[i++]
+        if (c == '\\') {
+          // javax.management.ObjectName#quote() - only 4 escaped values; ", *, ? and <LF>
+          if (i < len) {
+            switch (propsString[i]) {
+              case '"':
+                value += '\\"'
+                rawValue += '"'
+                break
+              case '*':
+                value += '\\*'
+                rawValue += '*'
+                break
+              case '?':
+                value += '\\?'
+                rawValue += '?'
+                break
+              case '\\':
+                value += '\\\\'
+                rawValue += '\\'
+                break
+              case 'n':
+                value += '\\n'
+                rawValue += '\n'
+                break
+              default:
+                throw new Error("Illegal ObjectName - illegal escape character '" + propsString[i] + "'")
+            }
+            i++
+          } else {
+            throw new Error('Illegal ObjectName - illegal escape character at the end')
+          }
+        } else {
+          value += c
+          rawValue += c
+        }
+      }
+      if (i >= len || propsString[i] !== '"') {
+        throw new Error('Illegal ObjectName - missing closing quote for the quoted value')
+      }
+      i++
+      value += '"'
+    } else {
+      // unquoted value
+      while (i < len && propsString[i] !== ',') {
+        const c = propsString[i++]
+        if (',=:"'.includes(c!)) {
+          throw new Error("Illegal ObjectName - unquoted value can't contain '" + c + "' character")
+        }
+        value += c
+      }
+      rawValue = value
+    }
+
+    if (i < len && propsString[i] != ',') {
+      throw new Error('Illegal ObjectName - missing comma after the value')
+    }
+    if (i == len - 1 && propsString[i] == ',') {
+      throw new Error('Illegal ObjectName - trailing comma')
+    }
+    if (i < len) {
+      i++
+    }
+
+    // remember - no trimming!
+    if (key in res.properties) {
+      throw new Error('Illegal ObjectName - duplicate key "' + key + '"')
+    }
+    res.properties[key] = value
+    res.paths.push({ key, value: rawValue })
+  }
+
+  return res
+}
+
 export class PropertyList {
   private properties: Record<string, string> = {}
   private paths: { key: string; value: string }[] = []
@@ -605,11 +744,6 @@ export class PropertyList {
   typeName?: string
   // TODO: serviceName needed?
   serviceName?: string
-
-  private readonly propRegex = new RegExp(
-    '(([^=,]+)=(\\\\"[^"]+\\\\"|\\\\\'[^\']+\\\\\'|"[^"]+"|\'[^\']+\'|[^,]+))|([^=,]+)',
-    'g',
-  )
 
   constructor(
     private domain: MBeanNode,
@@ -619,51 +753,37 @@ export class PropertyList {
   }
 
   private parse(propList: string) {
-    let match
-    while ((match = this.propRegex.exec(propList))) {
-      const [propKey, propValue] = this.parseProperty(match[0])
-      this.properties[propKey] = propValue
+    const parsedName = parseMBeanPropertyList(propList)
+    this.properties = parsedName.properties
+    for (const kv of parsedName.paths) {
       let index = -1
-      const lowerKey = propKey.toLowerCase()
-      const path = { key: lowerKey, value: propValue }
-      switch (lowerKey) {
+      switch (kv.key) {
         case 'type':
-          this.typeName = propValue
-          if (this.domain.findChildren(propValue).length > 0) {
-            // if the type name value already exists in the root node
-            // of the domain then let's move this property around too
-            index = 0
-          } else if (this.properties['name']) {
-            // else if the name key already exists, insert the type key before it
-            index = this.paths.findIndex(p => p.key === 'name')
+          this.typeName = parsedName.properties[kv.key]
+          if (this.typeName) {
+            if (this.domain.findChildren(this.typeName).length > 0) {
+              // if the type name value already exists in the root node
+              // of the domain then let's move this property around too
+              index = 0
+            } else if ('name' in parsedName.properties) {
+              // else if the name key already exists, insert the type key before it
+              index = this.paths.findIndex(p => p.key === 'name')
+            }
           }
           break
         case 'service':
-          this.serviceName = propValue
+          this.serviceName = parsedName.properties[kv.key]
           break
       }
+      const p: { key: string; value: string } = { key: kv.key, value: kv.value }
       if (index >= 0) {
-        this.paths.splice(index, 0, path)
+        this.paths.splice(index, 0, p)
       } else {
-        this.paths.push(path)
+        this.paths.push(p)
       }
     }
 
     this.maybeReorderPaths()
-  }
-
-  private parseProperty(property: string): [string, string] {
-    let key = property
-    let value = property
-    // do not use split('=') as it splits wrong when there is a space in the mbean name
-    const pos = property.indexOf('=')
-    if (pos > 0) {
-      key = property.substring(0, pos)
-      value = property.substring(pos + 1)
-    }
-    // mbean property value is displayed in the tree, so let's escape it here
-    value = escapeTags(trimQuotes(value || key))
-    return [key, value]
   }
 
   /**
@@ -686,8 +806,8 @@ export class PropertyList {
 
   match(properties: Record<string, string>): boolean {
     return Object.entries(properties).every(([key, value]) => {
-      const thisValue = this.properties[key]
-      return thisValue && matchWithWildcard(thisValue, value)
+      const thisIndex = this.paths.findIndex(e => e.key === key)
+      return thisIndex >= 0 && matchWithWildcard(this.paths[thisIndex]!.value, value)
     })
   }
 

--- a/packages/hawtio/src/plugins/shared/tree/tree.ts
+++ b/packages/hawtio/src/plugins/shared/tree/tree.ts
@@ -1,4 +1,3 @@
-import { escapeTags } from '@hawtiosrc/util/htmls'
 import { matchWithWildcard } from '@hawtiosrc/util/strings'
 import { log } from '../globals'
 import { MBeanNode, MBeanNodeFilterFn, OptimisedJmxDomain, OptimisedJmxDomains } from './node'
@@ -61,10 +60,7 @@ export class MBeanTree {
 
   private async populate(domains: OptimisedJmxDomains) {
     Object.entries(domains).forEach(([name, domain]) => {
-      // Domain name is displayed in the tree, so let's escape it here.
-      // Use a custom escaping method here as escaping '"' breaks Camel tree.
-      const escapedName = escapeTags(name)
-      this.populateDomain(escapedName, domain)
+      this.populateDomain(name, domain)
     })
 
     this.sortTree()

--- a/packages/hawtio/src/plugins/shared/workspace.test.ts
+++ b/packages/hawtio/src/plugins/shared/workspace.test.ts
@@ -66,6 +66,22 @@ describe('workspace', () => {
         properties: { context: 'SampleCamel', type: 'endpoints' },
         expected: 4,
       },
+      {
+        // search by unquoted
+        domain: 'org.apache.camel',
+        properties: { context: 'SampleCamel', type: 'endpoints', name: 'quartz://cron?cron=0%2F10+*+*+*+*+%3F' },
+        expected: 1,
+      },
+      {
+        // search by quoted (original)
+        domain: 'org.apache.camel',
+        properties: {
+          context: 'SampleCamel',
+          type: 'endpoints',
+          name: '"quartz://cron\\?cron=0%2F10+\\*+\\*+\\*+\\*+%3F"',
+        },
+        expected: 1,
+      },
     ]
 
     for (const test of tests) {


### PR DESCRIPTION
(cherry picked from commit bde75a5e7651c2588d37bb85019bf6dd67aeca3e)