### PR TITLE
fix(ui): Filter MBeanNodes with proper object cloning (fixes #2041)

### DIFF
--- a/packages/backend-middleware/package.json
+++ b/packages/backend-middleware/package.json
@@ -36,7 +36,7 @@
     "prepack": "yarn build"
   },
   "dependencies": {
-    "axios": "^1.13.5",
+    "axios": "^1.15.0",
     "express": "^5.2.1",
     "js-logger": "^1.6.1"
   },

--- a/packages/hawtio/src/plugins/shared/tree/tree.ts
+++ b/packages/hawtio/src/plugins/shared/tree/tree.ts
@@ -45,7 +45,7 @@ export class MBeanTree {
         const resultsInSubtree = MBeanTree.filter(parentNode.children || [], filter)
 
         if (resultsInSubtree.length !== 0) {
-          const parentNodeCloned = Object.assign({}, parentNode)
+          const parentNodeCloned = Object.assign(Object.create(Object.getPrototypeOf(parentNode)), parentNode)
           parentNodeCloned.children = resultsInSubtree
 
           results = results.concat(parentNodeCloned)

--- a/yarn.lock
+++ b/yarn.lock
@@ -980,7 +980,7 @@ __metadata:
     "@types/express": "npm:^5"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^25.2.2"
-    axios: "npm:^1.13.5"
+    axios: "npm:^1.15.0"
     commit-and-tag-version: "npm:^12.6.1"
     concurrently: "npm:^9.2.1"
     express: "npm:^5.2.1"
@@ -4330,14 +4330,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.13.5":
-  version: 1.13.5
-  resolution: "axios@npm:1.13.5"
+"axios@npm:^1.15.0":
+  version: 1.15.0
+  resolution: "axios@npm:1.15.0"
   dependencies:
     follow-redirects: "npm:^1.15.11"
     form-data: "npm:^4.0.5"
-    proxy-from-env: "npm:^1.1.0"
-  checksum: 10/db726d09902565ef9a0632893530028310e2ec2b95b727114eca1b101450b00014133dfc3871cffc87983fb922bca7e4874d7e2826d1550a377a157cdf3f05b6
+    proxy-from-env: "npm:^2.1.0"
+  checksum: 10/d39a2c0ebc7ff4739401b282e726cc2673377949d6c46d60eb619458f8d7a2f7eadbcada7097f4dbc7d5c59abb4d3bf6fac33d474412bc3415d3f5aa7ed45530
   languageName: node
   linkType: hard
 
@@ -11726,10 +11726,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proxy-from-env@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "proxy-from-env@npm:1.1.0"
-  checksum: 10/f0bb4a87cfd18f77bc2fba23ae49c3b378fb35143af16cc478171c623eebe181678f09439707ad80081d340d1593cd54a33a0113f3ccb3f4bc9451488780ee23
+"proxy-from-env@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "proxy-from-env@npm:2.1.0"
+  checksum: 10/fbbaf4dab2a6231dc9e394903a5f66f20475e36b734335790b46feb9da07c37d6b32e2c02e3e2ea4d4b23774c53d8562e5b7cc73282cb43f4a597b7eacaee2ee
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
(cherry picked from commit c13aa0232fdde060725dc553c8d6d223b4e087f0)