### PR TITLE
fix(ui): Filter MBeanNodes with proper object cloning (fixes #2041)

### DIFF
--- a/packages/hawtio/src/plugins/shared/tree/tree.ts
+++ b/packages/hawtio/src/plugins/shared/tree/tree.ts
@@ -45,7 +45,7 @@ export class MBeanTree {
         const resultsInSubtree = MBeanTree.filter(parentNode.children || [], filter)
 
         if (resultsInSubtree.length !== 0) {
-          const parentNodeCloned = Object.assign({}, parentNode)
+          const parentNodeCloned = Object.assign(Object.create(Object.getPrototypeOf(parentNode)), parentNode)
           parentNodeCloned.children = resultsInSubtree
 
           results = results.concat(parentNodeCloned)


### PR DESCRIPTION
(cherry picked from commit 5e80ae2a6ae9c29b6428f0e4a465c23c34235861)