### PR TITLE
feat(ui): Added camel notes

### DIFF
--- a/packages/hawtio/src/plugins/camel/route-diagram/RouteDiagram.css
+++ b/packages/hawtio/src/plugins/camel/route-diagram/RouteDiagram.css
@@ -147,3 +147,24 @@
 .disabled {
   background-color: var(--pf-t--color--disabled--200) !important;
 }
+
+.sticky-note {
+  position: relative;
+  float: left;
+  padding-top: 20px;
+  margin-top: -30px;
+  z-index: 777;
+}
+
+.sticky-note-content {
+  position: relative;
+  background: #ffa;
+  overflow: hidden;
+  margin: 30px auto;
+  padding: 20px;
+  border-radius: 0 0 0 30px/45px;
+  box-shadow:
+    inset 0 -40px 40px rgba(0, 0, 0, 0.2),
+    inset 0 25px 10px rgba(0, 0, 0, 0.2),
+    0 5px 6px 5px rgba(0, 0, 0, 0.2);
+}

--- a/packages/hawtio/src/plugins/camel/route-diagram/RouteDiagram.tsx
+++ b/packages/hawtio/src/plugins/camel/route-diagram/RouteDiagram.tsx
@@ -1,8 +1,8 @@
 import { eventService } from '@hawtiosrc/core'
 import { MBeanNode } from '@hawtiosrc/plugins/shared'
-import { Switch, Title, EmptyState, EmptyStateBody } from '@patternfly/react-core'
+import { Switch, Title, EmptyState, EmptyStateBody, Icon, Popover } from '@patternfly/react-core'
 import { Table, Tbody, Td, Tr } from '@patternfly/react-table'
-import { ExclamationCircleIcon } from '@patternfly/react-icons'
+import { ExclamationCircleIcon, StickyNoteIcon } from '@patternfly/react-icons'
 import React, { RefObject, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import {
   Connection,
@@ -295,6 +295,17 @@ const CamelNode: React.FunctionComponent<NodeProps<CamelNodeData>> = ({
       {showStatistics && (
         <NodeToolbar isVisible={isVisible} position={Position.Bottom} style={{ marginTop: '-30px' }}>
           <div className='node-tooltip'>
+            {data.note && (
+              <Popover
+                triggerAction='hover'
+                showClose={false}
+                bodyContent={<div className='sticky-note-content'>{data.note}</div>}
+              >
+                <Icon size='sm' className='sticky-note'>
+                  <StickyNoteIcon />
+                </Icon>
+              </Popover>
+            )}
             {!data.stats && data.label}
             {data.stats && !showFull && (
               <Table variant='compact'>

--- a/packages/hawtio/src/plugins/camel/route-diagram/visualization-service.ts
+++ b/packages/hawtio/src/plugins/camel/route-diagram/visualization-service.ts
@@ -16,7 +16,7 @@ export type CamelNodeData = {
   group: 1
   disabled: boolean
   routeStopped: boolean
-
+  note: string
   elementId: string | null
   imageUrl: ReactNode
   cid: string
@@ -226,6 +226,7 @@ class VisualizationService {
         }
 
         let cid = routeElement.getAttribute('_cid') || routeElement.getAttribute('id')
+        const note = routeElement.getAttribute('note') || ''
         const parallelProcessing: boolean = routeElement.getAttribute('parallelProcessing')?.toLowerCase() === 'true'
         nodeData = {
           id,
@@ -240,6 +241,7 @@ class VisualizationService {
           imageUrl,
           cid: cid ?? id,
           tooltip,
+          note,
           type: nodeId,
           uri: uri ?? '',
           routeId,


### PR DESCRIPTION
Fixes https://github.com/hawtio/hawtio/issues/4106

Adds the new note field to be shown on Routes Diagram. It's shown as a popover on top of the table with the other details

<img width="639" height="536" alt="Captura desde 2026-04-28 11-33-52" src="https://github.com/user-attachments/assets/86b19865-191c-46e2-bf28-1d4a7f323842" />
