### PR TITLE
fix(chart, route-diagram): Fixed text colors for dark-mode

### DIFF
--- a/packages/hawtio/src/plugins/camel/route-diagram/RouteDiagram.css
+++ b/packages/hawtio/src/plugins/camel/route-diagram/RouteDiagram.css
@@ -147,3 +147,20 @@
 .disabled {
   background-color: var(--pf-t--color--disabled--200) !important;
 }
+
+.pf-v6-theme-dark .camel-route-diagram {
+  color: var(--pf-t--color--black);
+}
+
+.pf-v6-theme-dark .node-tooltip-odd-row td {
+  color: var(--pf-t--global--text--color--100);
+}
+
+.pf-v6-theme-dark .node-tooltip-even-row td {
+  color: var(--pf-t--global--text--color--200);
+}
+
+.pf-v6-theme-dark .camel-route-diagram .route-diagram-side-popover,
+.pf-v6-theme-dark .camel-route-diagram .disabled {
+  color: var(--pf-t--color--white);
+}

--- a/packages/hawtio/src/plugins/camel/route-diagram/RouteDiagram.tsx
+++ b/packages/hawtio/src/plugins/camel/route-diagram/RouteDiagram.tsx
@@ -414,7 +414,9 @@ const CamelNodeActions: React.FunctionComponent<{ data: CamelNodeData }> = ({ da
 
   return (
     <NodeToolbar position={Position.Right}>
-      <Title headingLevel='h4'>Node actions</Title>
+      <Title className='route-diagram-side-popover' headingLevel='h4'>
+        Node actions
+      </Title>
       {data.type === 'from' && (
         <Switch
           id='camel-route-diagram-camel-node-start-stop-route'

--- a/packages/hawtio/src/plugins/shared/chart/Chart.css
+++ b/packages/hawtio/src/plugins/shared/chart/Chart.css
@@ -1,0 +1,4 @@
+.pf-v6-theme-dark .camel-chart tspan {
+  color: var(--pf-t--color--white);
+  fill: var(--pf-t--color--white) !important;
+}

--- a/packages/hawtio/src/plugins/shared/chart/Chart.tsx
+++ b/packages/hawtio/src/plugins/shared/chart/Chart.tsx
@@ -27,6 +27,7 @@ import Jolokia, {
 import React, { useContext, useEffect, useRef, useState } from 'react'
 import { attributeService } from '../attributes/attribute-service'
 import { WatchableAttributesForm } from './WatchableAttributesForm'
+import './Chart.css'
 
 type MBeanChartData = {
   [name: string]: { attributes: AttributeChartEntries }
@@ -324,7 +325,7 @@ export const Chart: React.FunctionComponent = () => {
   return (
     <React.Fragment>
       {watchableAttributesForm}
-      <Grid hasGutter span={12} xl2={6}>
+      <Grid hasGutter span={12} xl2={6} className='camel-chart'>
         <GridItem span={12}>
           <Card isPlain>
             <CardHeader


### PR DESCRIPTION
Fixes #2055

Coauthor @Jinal-Sarvaiya 

Fixes unreadable text in Routes Diagram and in Charts for dark-mode.

<img width="1095" height="718" alt="Captura desde 2026-04-29 12-33-01" src="https://github.com/user-attachments/assets/c02ec6c2-e8ce-4235-99c8-69163e1afeaf" />
<img width="1216" height="454" alt="Captura desde 2026-04-29 12-54-06" src="https://github.com/user-attachments/assets/5a0e507b-de6e-441d-b3ce-21488eaf6ff6" />


