### PR TITLE
fix(route-diagram): Fixed coloring of borders and backgrounds

### DIFF
--- a/packages/hawtio/src/plugins/camel/route-diagram/RouteDiagram.css
+++ b/packages/hawtio/src/plugins/camel/route-diagram/RouteDiagram.css
@@ -141,9 +141,14 @@
 }
 
 .highlighted {
+  border-color: var(--pf-t--color--black) !important;
+  box-shadow: 5px 5px var(--pf-t--global--border--color--nonstatus--gray--clicked);
+}
+
+.pf-v6-theme-dark .highlighted {
   border-color: var(--pf-t--global--background--color--100) !important;
 }
 
 .disabled {
-  background-color: var(--pf-t--color--disabled--200) !important;
+  background-color: var(--pf-t--global--color--nonstatus--gray--clicked) !important;
 }


### PR DESCRIPTION
Fix #2071, #2072

Put them together because they are small changes related to the same component

<img width="914" height="242" alt="Captura desde 2026-04-29 15-16-05" src="https://github.com/user-attachments/assets/9b2b890f-7c57-429e-b148-b3d83bceed7a" />

<img width="914" height="242" alt="Captura desde 2026-04-29 15-16-10" src="https://github.com/user-attachments/assets/6cb00d6a-9d87-4040-b66b-7f775dc63696" />


<img width="914" height="242" alt="Captura desde 2026-04-29 15-14-35" src="https://github.com/user-attachments/assets/177bb047-9766-4dfb-a703-71e615eff151" />

<img width="914" height="242" alt="Captura desde 2026-04-29 15-14-26" src="https://github.com/user-attachments/assets/54c8771c-8e35-4fc9-b464-54680b70d468" />
