### PR TITLE
fix(trace): Fixed trace messages not updating

### DIFF
--- a/packages/hawtio/src/plugins/camel/trace/Trace.tsx
+++ b/packages/hawtio/src/plugins/camel/trace/Trace.tsx
@@ -25,13 +25,15 @@ export const Trace: React.FunctionComponent = () => {
     useRouteDiagramContext()
   const [isReading, setIsReading] = useState(true)
   const [isTracing, setIsTracing] = useState(false)
-  const messages = useRef<MessageData[]>([])
+  const previousMessages = useRef<MessageData[]>([])
+  const [parsedMessages, setParsedMessages] = useState<MessageData[]>(previousMessages.current)
   const [message, setMessage] = useState<MessageData>()
 
   const [msgPanelExpanded, setMsgPanelExpanded] = React.useState(false)
 
   const setMessages = (newMessages: MessageData[]) => {
-    messages.current = newMessages
+    previousMessages.current = newMessages
+    setParsedMessages(newMessages)
   }
 
   const populateRouteMessages = useCallback((value: string, routeNode: MBeanNode) => {
@@ -69,7 +71,7 @@ export const Trace: React.FunctionComponent = () => {
     /*
      * Adds new messages to existing stack
      */
-    const msgs = [...newMsgs, ...messages.current]
+    const msgs = [...newMsgs, ...previousMessages.current]
 
     /*
      * Remove messages when the array reaches its limit
@@ -243,46 +245,57 @@ export const Trace: React.FunctionComponent = () => {
                 <Panel id='route-message-table'>
                   <PanelHeader>Messages</PanelHeader>
                   <Divider />
-                  <PanelMain>
-                    <PanelMainBody id='route-message-table-body'>
-                      <Table aria-label='message table' variant='compact' isStriped>
-                        <Thead>
-                          <Tr>
-                            <Th>ID</Th>
-                            <Th>To Node</Th>
-                            <Th>Elapsed</Th>
-                            <Th>Endpoint Uri</Th>
-                            <Th>Is Remote?</Th>
-                            <Th>Service Url</Th>
-                            <Th>Protocol</Th>
-                            <Th>Metadata</Th>
-                          </Tr>
-                        </Thead>
-                        <Tbody isOddStriped>
-                          {messages.current.map(message => (
-                            <Tr
-                              key={message.uid}
-                              onRowClick={() => onRowSelected(message)}
-                              isRowSelected={isRowSelected(message)}
-                            >
-                              <Td dataLabel='ID'>
-                                <Button variant='link' isDisabled={!message} onClick={onMessagePanelToggle}>
-                                  {message.headers.breadcrumbId ? message.headers.breadcrumbId : message.uid}
-                                </Button>
-                              </Td>
-                              <Td dataLabel='ToNode'>{message.toNode}</Td>
-                              <Td dataLabel='Elapsed'>{message.elapsed}ms</Td>
-                              <Td dataLabel='EndpointUri'>{message.endpointUri}</Td>
-                              <Td dataLabel='IsRemote'>{message.isRemoteEndpoint}</Td>
-                              <Td dataLabel='ServiceUrl'>{message.endpointServiceUrl}</Td>
-                              <Td dataLabel='Protocol'>{message.endpointServiceProtocol}</Td>
-                              <Td dataLabel='Metadata'>{message.endpointServiceMetadata}</Td>
+                  {parsedMessages.length === 0 && (
+                    <PanelMain>
+                      <PanelMainBody>
+                        <Content className='tracing-on-no-messages' data-testid='tracing-on-no-messages' component='p'>
+                          Awaiting tracing messages.
+                        </Content>
+                      </PanelMainBody>
+                    </PanelMain>
+                  )}
+                  {parsedMessages.length !== 0 && (
+                    <PanelMain>
+                      <PanelMainBody id='route-message-table-body'>
+                        <Table aria-label='message table' variant='compact' isStriped>
+                          <Thead>
+                            <Tr>
+                              <Th>ID</Th>
+                              <Th>To Node</Th>
+                              <Th>Elapsed</Th>
+                              <Th>Endpoint Uri</Th>
+                              <Th>Is Remote?</Th>
+                              <Th>Service Url</Th>
+                              <Th>Protocol</Th>
+                              <Th>Metadata</Th>
                             </Tr>
-                          ))}
-                        </Tbody>
-                      </Table>
-                    </PanelMainBody>
-                  </PanelMain>
+                          </Thead>
+                          <Tbody isOddStriped>
+                            {parsedMessages.map(message => (
+                              <Tr
+                                key={message.uid}
+                                onRowClick={() => onRowSelected(message)}
+                                isRowSelected={isRowSelected(message)}
+                              >
+                                <Td dataLabel='ID'>
+                                  <Button variant='link' isDisabled={!message} onClick={onMessagePanelToggle}>
+                                    {message.headers.breadcrumbId ? message.headers.breadcrumbId : message.uid}
+                                  </Button>
+                                </Td>
+                                <Td dataLabel='ToNode'>{message.toNode}</Td>
+                                <Td dataLabel='Elapsed'>{message.elapsed}ms</Td>
+                                <Td dataLabel='EndpointUri'>{message.endpointUri}</Td>
+                                <Td dataLabel='IsRemote'>{message.isRemoteEndpoint}</Td>
+                                <Td dataLabel='ServiceUrl'>{message.endpointServiceUrl}</Td>
+                                <Td dataLabel='Protocol'>{message.endpointServiceProtocol}</Td>
+                                <Td dataLabel='Metadata'>{message.endpointServiceMetadata}</Td>
+                              </Tr>
+                            ))}
+                          </Tbody>
+                        </Table>
+                      </PanelMainBody>
+                    </PanelMain>
+                  )}
                 </Panel>
               </div>
             </MessageDrawer>


### PR DESCRIPTION
Ok so PR ready. No major changes needed, it was a state change not being detected by react because we were using an useRef. I also added a new comment so the user knows the Tracing is activated and awaiting for messages

Things that are fixed:

    The tracing will update without user input while tracing is activated.
    
    New note while awaiting to receive the first messages

    When stopping and starting tracing, no user input is required for the tracing to appear

Things that are unknown if are fixed but not reproducible:

    Stopping and starting tracing no longer has wrong messages that belong to other routes

    Stopping and starting tracing no longer has messages from before the tracing was stopped

    Changing tabs no longer has wrong messages that belong to other routes

    Changing tabs no longer has messages from before changing tabs

    Changing routes no longer has wrong messages that belong to other routes

    Changing routes no longer has messages from before changing to another route

Things that I didn’t fix because seems business logic/needs external changes:

    All messages on the trace are removed when changing/stopping tracing - Before the bug I think happened because of some leftover while using useRef, but it’s not happening now. The logic explicitly sets the message log to [] when stopping tracing for example.

    IDs being skipped - Unsolvable. Right now, it brings the tracing messages from all routes. That means that IDs are assigned to any active routes and any time there are multiple routes their IDs will be alternating between the different routes messages.
    
https://github.com/user-attachments/assets/ed3166b1-aa3a-449c-939e-86b5fa4700d2
   