### PR TITLE
fix(camel): displayed number for ExchangesTotal is wrong

### DIFF
--- a/packages/hawtio/src/plugins/camel/route-diagram/RouteDiagram.tsx
+++ b/packages/hawtio/src/plugins/camel/route-diagram/RouteDiagram.tsx
@@ -269,9 +269,6 @@ const CamelNode: React.FunctionComponent<NodeProps<CamelNodeData>> = ({
     return newLabel.substring(0, 17) + '...'
   }
 
-  const totalExchanges =
-    parseInt(data.stats?.exchangesCompleted ?? '0') + parseInt(data.stats?.exchangesInflight ?? '0')
-
   return (
     <div
       className={
@@ -289,7 +286,7 @@ const CamelNode: React.FunctionComponent<NodeProps<CamelNodeData>> = ({
       <div className='annotation'>{annotation?.element}</div>
       <div className='icon'>{data.imageUrl}</div>
       <div className='inflights'>{showInflightCounter && data.stats?.exchangesInflight}</div>
-      <div className='number'>{totalExchanges}</div>
+      <div className='number'>{data.stats?.exchangesTotal}</div>
       <div className='camel-node-label'>{truncate(data.label)}</div>
       {data.cid && <div className='camel-node-id'> (ID: {data.cid})</div>}
       {showStatistics && (
@@ -316,7 +313,7 @@ const CamelNode: React.FunctionComponent<NodeProps<CamelNodeData>> = ({
                   </Tr>
                   <Tr className='node-tooltip-even-row'>
                     <Td>Total</Td>
-                    <Td className='node-tooltip-value'>{totalExchanges}</Td>
+                    <Td className='node-tooltip-value'>{data.stats?.exchangesTotal}</Td>
                   </Tr>
                   <Tr className='node-tooltip-odd-row'>
                     <Td>Completed</Td>

--- a/packages/hawtio/src/plugins/camel/route-stats-service.ts
+++ b/packages/hawtio/src/plugins/camel/route-stats-service.ts
@@ -12,6 +12,7 @@ export type Statistics = {
   state: string
   exchangesInflight?: string
   exchangesCompleted?: string
+  exchangesTotal?: string
   failuresHandled?: string
   redeliveries?: string
   externalRedeliveries?: string


### PR DESCRIPTION
Fix hawtio/hawtio#4391

The number of total exchanges was calculated as the sum of completed and inflight exchanges. However, judging with `git log`, this calculation does not appear to have been particularly well thought out.

Like the other numbers, this figure should be taken directly from the route statistics.